### PR TITLE
fix(lattice): graceful fallback when tree-sitter fails

### DIFF
--- a/src/engine/handle-session.ts
+++ b/src/engine/handle-session.ts
@@ -151,11 +151,18 @@ export class HandleSession {
     // Clear any existing symbols before loading new content
     this.db.clearSymbols();
 
-    // Extract symbols for code files
+    // Extract symbols for code files (graceful fallback if tree-sitter fails)
     const ext = extname(path);
     if (ext && isExtensionSupported(ext)) {
-      await this.init();
-      await this.extractAndStoreSymbols(content, ext);
+      try {
+        await this.init();
+        await this.extractAndStoreSymbols(content, ext);
+      } catch (err) {
+        // tree-sitter may throw "Invalid argument" on some platforms/bindings
+        // Fall back to content-only mode (grep, text_stats still work)
+        console.error(`[HandleSession] Symbol extraction failed for ${ext}, continuing without symbols:`,
+          err instanceof Error ? err.message : String(err));
+      }
     }
 
     // Set SessionDB binding for solver access


### PR DESCRIPTION
## Summary

- `loadContentWithSymbols()` in `handle-session.ts` crashes on Windows when `tree-sitter` native bindings throw "Invalid argument" during `Parser.parse()`
- This prevents **any** file from loading in Lattice, even though grep, text_stats, and line queries don't need tree-sitter at all
- Wrapped `extractAndStoreSymbols` in a try-catch so the session degrades gracefully — all non-symbol queries continue to work, only `list_symbols` returns empty

## Reproduction

On Windows (Git Bash + Node.js), calling `lattice_load` on any `.ts`/`.js` file returns:
```
Error: Invalid argument
    at Parser.parse (node_modules/tree-sitter/index.js:361:13)
    at ParserRegistry.parseDocument (...)
    at HandleSession.loadContentWithSymbols (...)
```

## Fix

```typescript
// Before: crash kills the entire loadFile
await this.init();
await this.extractAndStoreSymbols(content, ext);

// After: graceful fallback
try {
  await this.init();
  await this.extractAndStoreSymbols(content, ext);
} catch (err) {
  console.error(`[HandleSession] Symbol extraction failed for ${ext}, continuing without symbols:`,
    err instanceof Error ? err.message : String(err));
}
```

## Test plan

- [x] Verified `loadFile()` succeeds on Windows with the fix
- [x] `(grep "pattern")`, `(text_stats)`, `(lines N M)` all return correct results
- [x] `(list_symbols)` returns empty array (graceful, no crash)
- [x] No behavior change on platforms where tree-sitter works correctly