### PR TITLE
Add call-limiting guidance to MCP tool descriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matryoshka-rlm",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matryoshka-rlm",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matryoshka-rlm",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "Recursive Language Model - Process documents larger than LLM context windows",
   "main": "dist/lib.js",

--- a/src/lattice-mcp-server.ts
+++ b/src/lattice-mcp-server.ts
@@ -183,7 +183,11 @@ SYMBOL WORKFLOW:
 VARIABLE BINDING:
 - RESULTS: Always points to the last array result (use in queries)
 - _1, _2, _3, ...: Results from turn N (use in queries for older results)
-- $res1, $res2, ...: Handle stubs (use ONLY with lattice_expand, NOT in queries)`,
+- $res1, $res2, ...: Handle stubs (use ONLY with lattice_expand, NOT in queries)
+
+EFFICIENCY: Minimize the number of separate tool calls by chaining queries.
+Build a pipeline (grep → filter → count) rather than making independent calls.
+Aim to answer your question in 3-5 queries, not 10+.`,
     inputSchema: {
       type: "object" as const,
       properties: {

--- a/tests/mcp-call-limiting.test.ts
+++ b/tests/mcp-call-limiting.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for call-limiting guidance in MCP tool descriptions.
+ *
+ * Validates that tool descriptions include guidance to prevent
+ * LLM tool-calling loops and encourage efficient query patterns.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// Read the source file directly to extract TOOLS array descriptions
+const serverPath = path.resolve(__dirname, "../src/lattice-mcp-server.ts");
+const serverSource = fs.readFileSync(serverPath, "utf-8");
+
+describe("MCP tool call-limiting guidance", () => {
+  describe("lattice_query tool", () => {
+    it("should include guidance to chain operations", () => {
+      // The lattice_query description should tell agents to chain queries
+      expect(serverSource).toMatch(
+        /lattice_query[\s\S]*?description[\s\S]*?chain.*quer/i
+      );
+    });
+
+    it("should include a maximum calls guideline", () => {
+      // Should tell agents to limit the number of separate tool calls
+      expect(serverSource).toMatch(
+        /lattice_query[\s\S]*?description[\s\S]*?(minimize|limit|avoid|reduce)\s+(the\s+number\s+of\s+)?(separate\s+)?(tool\s+)?call/i
+      );
+    });
+  });
+
+  describe("lattice_load tool", () => {
+    it("should recommend checking file size before loading", () => {
+      expect(serverSource).toMatch(
+        /lattice_load[\s\S]*?description[\s\S]*?(small|<\s*300|Read\s+directly)/i
+      );
+    });
+  });
+
+  describe("lattice_expand tool", () => {
+    it("should recommend starting with a small limit", () => {
+      expect(serverSource).toMatch(
+        /lattice_expand[\s\S]*?description[\s\S]*?small\s+limit/i
+      );
+    });
+
+    it("should discourage expanding without limit on large results", () => {
+      expect(serverSource).toMatch(
+        /lattice_expand[\s\S]*?description[\s\S]*?(avoid expanding|use.*limit|start with.*limit|preview)/i
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds explicit efficiency guidance to `lattice_query` tool description
- Tells LLM agents to minimize separate tool calls by chaining queries into pipelines (grep → filter → count)
- Recommends 3-5 queries per task instead of 10+
- Inspired by Context7's pattern of embedding usage limits directly in tool descriptions

## Test plan
- [x] Test validates lattice_query description includes chaining guidance
- [x] Test validates lattice_query description includes call-limiting language
- [x] Test validates lattice_load recommends checking file size first
- [x] Test validates lattice_expand recommends starting with small limits
- [x] `npx vitest run tests/mcp-call-limiting.test.ts` passes (5 tests)