### PR TITLE
Add token metadata to query and expand results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matryoshka-rlm",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matryoshka-rlm",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matryoshka-rlm",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "Recursive Language Model - Process documents larger than LLM context windows",
   "main": "dist/lib.js",

--- a/src/engine/handle-session.ts
+++ b/src/engine/handle-session.ts
@@ -16,6 +16,36 @@ import { SymbolExtractor } from "../treesitter/symbol-extractor.js";
 import { isExtensionSupported } from "../treesitter/language-map.js";
 
 const MAX_DOCUMENT_SIZE = 50 * 1024 * 1024; // 50MB
+const CHARS_PER_TOKEN = 4; // Approximate token estimation heuristic
+
+/**
+ * Estimate token count from a string or data size using ~4 chars/token heuristic
+ */
+function estimateTokens(charCount: number): number {
+  return Math.ceil(charCount / CHARS_PER_TOKEN);
+}
+
+/**
+ * Token cost metadata for a result
+ */
+export interface TokenMetadata {
+  /** Estimated tokens if full data were returned */
+  estimatedFullTokens: number;
+  /** Tokens used by the stub */
+  stubTokens: number;
+  /** Percentage savings from using handle */
+  savingsPercent: number;
+}
+
+/**
+ * Token cost metadata for an expanded result
+ */
+export interface ExpandTokenMetadata {
+  /** Tokens in the returned (possibly limited) data */
+  returnedTokens: number;
+  /** Estimated tokens for the full dataset */
+  totalTokens: number;
+}
 
 /**
  * Result of a handle-based query execution
@@ -34,6 +64,8 @@ export interface HandleResult {
   error?: string;
   /** Inferred type */
   type?: string;
+  /** Token cost metadata (present for array results) */
+  tokenMetadata?: TokenMetadata;
 }
 
 /**
@@ -58,6 +90,8 @@ export interface ExpandResult {
   offset?: number;
   limit?: number;
   error?: string;
+  /** Token cost metadata for the expanded data */
+  tokenMetadata?: ExpandTokenMetadata;
 }
 
 /**
@@ -279,12 +313,26 @@ export class HandleSession {
       // Get the stub for LLM context
       const stub = this.registry.getStub(handle);
 
+      // Compute token metadata
+      const fullDataSize = JSON.stringify(result.value).length;
+      const stubSize = stub.length;
+      const estimatedFullTokens = estimateTokens(fullDataSize);
+      const stubTokens = estimateTokens(stubSize);
+      const savingsPercent = estimatedFullTokens > 0
+        ? Math.round(((estimatedFullTokens - stubTokens) / estimatedFullTokens) * 100)
+        : 0;
+
       return {
         success: true,
         handle,
         stub,
         logs: result.logs,
         type: result.type,
+        tokenMetadata: {
+          estimatedFullTokens,
+          stubTokens,
+          savingsPercent,
+        },
       };
     }
 
@@ -343,12 +391,24 @@ export class HandleSession {
       });
     }
 
+    // Compute token metadata for expanded data
+    const returnedSize = JSON.stringify(sliced).length;
+    const returnedTokens = estimateTokens(returnedSize);
+    // Estimate total tokens proportionally
+    const totalTokens = total > 0 && sliced.length > 0
+      ? Math.ceil((returnedTokens / sliced.length) * total)
+      : returnedTokens;
+
     return {
       success: true,
       data: sliced,
       total,
       offset,
       limit,
+      tokenMetadata: {
+        returnedTokens,
+        totalTokens,
+      },
     };
   }
 

--- a/src/lattice-mcp-server.ts
+++ b/src/lattice-mcp-server.ts
@@ -305,6 +305,7 @@ function formatHandleResult(result: {
   value?: unknown;
   logs: string[];
   error?: string;
+  tokenMetadata?: { estimatedFullTokens: number; stubTokens: number; savingsPercent: number };
 }): string {
   if (!result.success) {
     return `Error: ${result.error}`;
@@ -313,6 +314,9 @@ function formatHandleResult(result: {
   // If we have a handle (array result), return the stub
   if (result.handle && result.stub) {
     let text = result.stub;
+    if (result.tokenMetadata) {
+      text += `\n\nToken savings: ~${result.tokenMetadata.savingsPercent}% (${result.tokenMetadata.stubTokens} vs ~${result.tokenMetadata.estimatedFullTokens} tokens)`;
+    }
     text += "\n\nChain with (count RESULTS), (filter RESULTS ...), (map RESULTS ...), etc.";
     text += "\nUse lattice_expand to see full data when needed.";
     return text;

--- a/tests/token-metadata.test.ts
+++ b/tests/token-metadata.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for token metadata on query results.
+ *
+ * Validates that handle results include token cost estimates
+ * to help LLM agents make smart decisions about expansion.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { HandleSession } from "../src/engine/handle-session.js";
+
+describe("Token metadata on results", () => {
+  let session: HandleSession;
+  let tempDir: string;
+  let testFile: string;
+
+  const testContent = Array.from({ length: 100 }, (_, i) =>
+    `2024-01-15 ${String(i).padStart(6, "0")} LOG: Entry number ${i} with data value=${i * 100}`
+  ).join("\n");
+
+  beforeEach(() => {
+    session = new HandleSession();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "token-test-"));
+    testFile = path.join(tempDir, "test.log");
+    fs.writeFileSync(testFile, testContent);
+  });
+
+  afterEach(() => {
+    session.close();
+    fs.rmSync(tempDir, { recursive: true });
+  });
+
+  describe("HandleResult token metadata", () => {
+    beforeEach(async () => {
+      await session.loadFile(testFile);
+    });
+
+    it("should include estimatedTokens on array results", () => {
+      const result = session.execute('(grep "LOG")');
+
+      expect(result.success).toBe(true);
+      expect(result.tokenMetadata).toBeDefined();
+      expect(result.tokenMetadata!.estimatedFullTokens).toBeGreaterThan(0);
+      expect(result.tokenMetadata!.stubTokens).toBeGreaterThan(0);
+    });
+
+    it("should show significant savings ratio for large results", () => {
+      const result = session.execute('(grep "LOG")');
+
+      const meta = result.tokenMetadata!;
+      expect(meta.estimatedFullTokens).toBeGreaterThan(meta.stubTokens);
+      expect(meta.savingsPercent).toBeGreaterThan(90);
+    });
+
+    it("should not include tokenMetadata for scalar results", () => {
+      session.execute('(grep "LOG")');
+      const result = session.execute("(count RESULTS)");
+
+      expect(result.success).toBe(true);
+      expect(result.tokenMetadata).toBeUndefined();
+    });
+
+    it("should estimate tokens using ~4 chars per token heuristic", () => {
+      const result = session.execute('(grep "LOG")');
+
+      const meta = result.tokenMetadata!;
+      // Stub is small, full data is much larger
+      expect(meta.stubTokens).toBeLessThan(50);
+      expect(meta.estimatedFullTokens).toBeGreaterThan(500);
+    });
+  });
+
+  describe("ExpandResult token metadata", () => {
+    beforeEach(async () => {
+      await session.loadFile(testFile);
+    });
+
+    it("should include token cost on expanded results", () => {
+      const query = session.execute('(grep "LOG")');
+      const expanded = session.expand(query.handle!, { limit: 10 });
+
+      expect(expanded.success).toBe(true);
+      expect(expanded.tokenMetadata).toBeDefined();
+      expect(expanded.tokenMetadata!.returnedTokens).toBeGreaterThan(0);
+      expect(expanded.tokenMetadata!.totalTokens).toBeGreaterThan(0);
+    });
+
+    it("should show partial vs total tokens when using limit", () => {
+      const query = session.execute('(grep "LOG")');
+      const expanded = session.expand(query.handle!, { limit: 5 });
+
+      const meta = expanded.tokenMetadata!;
+      expect(meta.returnedTokens).toBeLessThan(meta.totalTokens);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `HandleResult` now includes `tokenMetadata` with `estimatedFullTokens`, `stubTokens`, and `savingsPercent` for array results
- `ExpandResult` now includes `tokenMetadata` with `returnedTokens` and `totalTokens`
- MCP server output shows token savings percentage inline (e.g., "Token savings: ~98% (12 vs ~600 tokens)")
- Helps LLM agents make informed decisions about when to expand vs continue narrowing
- Inspired by Context7's token-aware pagination headers

## Test plan
- [x] Test validates tokenMetadata present on array results with correct fields
- [x] Test validates savings ratio > 90% for large result sets
- [x] Test validates no tokenMetadata on scalar results
- [x] Test validates token estimation using ~4 chars/token heuristic
- [x] Test validates expand results include returnedTokens and totalTokens
- [x] Test validates partial vs total tokens when using limit
- [x] Existing lattice-mcp-handles and rlm tests pass without regression