### PR TITLE
Add programmatic AI SDK tool definitions for Lattice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matryoshka-rlm",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matryoshka-rlm",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matryoshka-rlm",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "Recursive Language Model - Process documents larger than LLM context windows",
   "main": "dist/lib.js",

--- a/src/tool/ai-tools.ts
+++ b/src/tool/ai-tools.ts
@@ -1,0 +1,310 @@
+/**
+ * AI SDK Tool Definitions for Lattice
+ *
+ * Provides typed tool definitions that can be used programmatically
+ * with any AI SDK (Vercel AI SDK, LangChain, custom agents, etc.).
+ *
+ * Each tool has:
+ * - name: Tool identifier
+ * - description: What the tool does (for LLM)
+ * - parameters: JSON Schema for input validation
+ * - execute: Async function to run the tool
+ *
+ * Usage:
+ *   import { createLatticeTools } from "matryoshka-rlm/tool";
+ *   const tools = createLatticeTools();
+ *   await tools.load.execute({ filePath: "./data.log" });
+ *   const result = await tools.query.execute({ command: '(grep "ERROR")' });
+ */
+
+import { HandleSession } from "../engine/handle-session.js";
+import type {
+  HandleResult,
+  ExpandResult,
+  ExpandOptions,
+} from "../engine/handle-session.js";
+
+// ── Tool parameter types ────────────────────────────────────────
+
+interface LoadParams {
+  filePath: string;
+}
+
+interface QueryParams {
+  command: string;
+}
+
+interface ExpandParams {
+  handle: string;
+  limit?: number;
+  offset?: number;
+  format?: "full" | "lines";
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface EmptyParams {}
+
+// ── Tool result types ───────────────────────────────────────────
+
+interface LoadResult {
+  success: boolean;
+  message?: string;
+  error?: string;
+  lineCount?: number;
+  size?: number;
+}
+
+interface StatusResult {
+  success: boolean;
+  data?: {
+    documentPath: string;
+    documentSize: number;
+    queryCount: number;
+    handleCount: number;
+  };
+  error?: string;
+}
+
+interface BindingsResult {
+  success: boolean;
+  data?: Record<string, string>;
+  error?: string;
+}
+
+// ── Tool definition type ────────────────────────────────────────
+
+interface ToolDefinition<TParams, TResult> {
+  name: string;
+  description: string;
+  parameters: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required: string[];
+  };
+  execute: (params: TParams) => Promise<TResult>;
+}
+
+// ── Generic tool definition for getToolDefinitions ──────────────
+
+export interface GenericToolDefinition {
+  name: string;
+  description: string;
+  parameters: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required: string[];
+  };
+  execute: (params: Record<string, unknown>) => Promise<unknown>;
+}
+
+// ── Tool set type ───────────────────────────────────────────────
+
+export interface LatticeToolSet {
+  load: ToolDefinition<LoadParams, LoadResult>;
+  query: ToolDefinition<QueryParams, HandleResult>;
+  expand: ToolDefinition<ExpandParams, ExpandResult>;
+  close: ToolDefinition<EmptyParams, { success: boolean }>;
+  status: ToolDefinition<EmptyParams, StatusResult>;
+  bindings: ToolDefinition<EmptyParams, BindingsResult>;
+  /** Get all tools as an array for SDK integration */
+  getToolDefinitions: () => GenericToolDefinition[];
+}
+
+/**
+ * Create a set of Lattice tools for programmatic use.
+ *
+ * Returns typed tool definitions that wrap a HandleSession.
+ * Each tool has a name, description, JSON Schema parameters, and execute function.
+ */
+export function createLatticeTools(): LatticeToolSet {
+  let session: HandleSession | null = null;
+
+  function getSession(): HandleSession {
+    if (!session) {
+      session = new HandleSession();
+    }
+    return session;
+  }
+
+  const load: ToolDefinition<LoadParams, LoadResult> = {
+    name: "lattice_load",
+    description:
+      "Load a document for analysis. Use for files >500 lines. " +
+      "Returns line count and size. Session stays open until close.",
+    parameters: {
+      type: "object",
+      properties: {
+        filePath: {
+          type: "string",
+          description: "Path to the document to analyze",
+        },
+      },
+      required: ["filePath"],
+    },
+    async execute(params: LoadParams): Promise<LoadResult> {
+      // Close existing session if any
+      if (session) {
+        session.close();
+        session = null;
+      }
+      const s = getSession();
+      try {
+        const stats = await s.loadFile(params.filePath);
+        return {
+          success: true,
+          message: `Loaded: ${stats.lineCount} lines, ${(stats.size / 1024).toFixed(1)} KB`,
+          lineCount: stats.lineCount,
+          size: stats.size,
+        };
+      } catch (err) {
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    },
+  };
+
+  const query: ToolDefinition<QueryParams, HandleResult> = {
+    name: "lattice_query",
+    description:
+      "Execute a Nucleus S-expression query on the loaded document. " +
+      "Array results return handle stubs; scalars return directly. " +
+      "Chain operations via RESULTS variable.",
+    parameters: {
+      type: "object",
+      properties: {
+        command: {
+          type: "string",
+          description: 'Nucleus S-expression, e.g., (grep "ERROR")',
+        },
+      },
+      required: ["command"],
+    },
+    async execute(params: QueryParams): Promise<HandleResult> {
+      if (!session || !session.isLoaded()) {
+        return {
+          success: false,
+          logs: [],
+          error: "No document loaded. Use load first.",
+        };
+      }
+      return session.execute(params.command);
+    },
+  };
+
+  const expand: ToolDefinition<ExpandParams, ExpandResult> = {
+    name: "lattice_expand",
+    description:
+      "Get full data from a handle stub. Use limit for large results. " +
+      "Supports pagination via offset.",
+    parameters: {
+      type: "object",
+      properties: {
+        handle: {
+          type: "string",
+          description: 'Handle reference, e.g., "$res1"',
+        },
+        limit: {
+          type: "number",
+          description: "Max items to return (default: all)",
+        },
+        offset: {
+          type: "number",
+          description: "Skip first N items",
+        },
+        format: {
+          type: "string",
+          enum: ["full", "lines"],
+          description: "Output format",
+        },
+      },
+      required: ["handle"],
+    },
+    async execute(params: ExpandParams): Promise<ExpandResult> {
+      if (!session) {
+        return { success: false, error: "No active session." };
+      }
+      const opts: ExpandOptions = {};
+      if (params.limit !== undefined) opts.limit = params.limit;
+      if (params.offset !== undefined) opts.offset = params.offset;
+      if (params.format !== undefined) opts.format = params.format;
+      return session.expand(params.handle, opts);
+    },
+  };
+
+  const closeTool: ToolDefinition<EmptyParams, { success: boolean }> = {
+    name: "lattice_close",
+    description: "Close the session and free memory.",
+    parameters: {
+      type: "object",
+      properties: {},
+      required: [],
+    },
+    async execute(): Promise<{ success: boolean }> {
+      if (session) {
+        session.close();
+        session = null;
+      }
+      return { success: true };
+    },
+  };
+
+  const status: ToolDefinition<EmptyParams, StatusResult> = {
+    name: "lattice_status",
+    description: "Get current session status.",
+    parameters: {
+      type: "object",
+      properties: {},
+      required: [],
+    },
+    async execute(): Promise<StatusResult> {
+      if (!session) {
+        return { success: false, error: "No active session." };
+      }
+      const info = session.getSessionInfo();
+      return {
+        success: true,
+        data: {
+          documentPath: info.documentPath,
+          documentSize: info.documentSize,
+          queryCount: info.queryCount,
+          handleCount: info.handleCount,
+        },
+      };
+    },
+  };
+
+  const bindings: ToolDefinition<EmptyParams, BindingsResult> = {
+    name: "lattice_bindings",
+    description: "Show current handle bindings.",
+    parameters: {
+      type: "object",
+      properties: {},
+      required: [],
+    },
+    async execute(): Promise<BindingsResult> {
+      if (!session) {
+        return { success: false, error: "No active session." };
+      }
+      return {
+        success: true,
+        data: session.getBindings(),
+      };
+    },
+  };
+
+  const toolSet: LatticeToolSet = {
+    load,
+    query,
+    expand,
+    close: closeTool,
+    status,
+    bindings,
+    getToolDefinitions(): GenericToolDefinition[] {
+      return [load, query, expand, closeTool, status, bindings] as GenericToolDefinition[];
+    },
+  };
+
+  return toolSet;
+}

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -39,3 +39,10 @@ export {
   startHttpAdapter,
   type HttpAdapterOptions,
 } from "./adapters/http.js";
+
+// AI SDK integration
+export {
+  createLatticeTools,
+  type LatticeToolSet,
+  type GenericToolDefinition,
+} from "./ai-tools.js";

--- a/tests/tool/ai-tools.test.ts
+++ b/tests/tool/ai-tools.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for AI SDK tool definitions.
+ *
+ * Validates that the ai-tools module exports typed tool definitions
+ * that can be used programmatically with any AI SDK.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  createLatticeTools,
+  type LatticeToolSet,
+} from "../../src/tool/ai-tools.js";
+
+describe("AI SDK tool definitions", () => {
+  let tools: LatticeToolSet;
+  let tempDir: string;
+  let testFile: string;
+
+  const testContent = Array.from({ length: 50 }, (_, i) =>
+    `2024-01-15 ${String(i).padStart(4, "0")} LOG: Entry ${i} value=${i * 10}`
+  ).join("\n");
+
+  beforeEach(() => {
+    tools = createLatticeTools();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-tools-test-"));
+    testFile = path.join(tempDir, "test.log");
+    fs.writeFileSync(testFile, testContent);
+  });
+
+  afterEach(async () => {
+    await tools.close.execute({});
+    fs.rmSync(tempDir, { recursive: true });
+  });
+
+  describe("createLatticeTools", () => {
+    it("should return a tool set with all required tools", () => {
+      expect(tools.load).toBeDefined();
+      expect(tools.query).toBeDefined();
+      expect(tools.expand).toBeDefined();
+      expect(tools.close).toBeDefined();
+      expect(tools.status).toBeDefined();
+      expect(tools.bindings).toBeDefined();
+    });
+
+    it("should expose tool definitions with name, description, and parameters", () => {
+      expect(tools.load.name).toBe("lattice_load");
+      expect(tools.load.description).toBeTruthy();
+      expect(tools.load.parameters).toBeDefined();
+      expect(tools.load.parameters.properties.filePath).toBeDefined();
+
+      expect(tools.query.name).toBe("lattice_query");
+      expect(tools.query.parameters.properties.command).toBeDefined();
+
+      expect(tools.expand.name).toBe("lattice_expand");
+      expect(tools.expand.parameters.properties.handle).toBeDefined();
+    });
+  });
+
+  describe("tool execution", () => {
+    it("should load a document via execute", async () => {
+      const result = await tools.load.execute({ filePath: testFile });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("50");
+    });
+
+    it("should query a loaded document", async () => {
+      await tools.load.execute({ filePath: testFile });
+      const result = await tools.query.execute({ command: '(grep "LOG")' });
+
+      expect(result.success).toBe(true);
+      expect(result.handle).toBeDefined();
+      expect(result.stub).toContain("Array(50)");
+    });
+
+    it("should expand a handle", async () => {
+      await tools.load.execute({ filePath: testFile });
+      const queryResult = await tools.query.execute({ command: '(grep "LOG")' });
+      const expandResult = await tools.expand.execute({
+        handle: queryResult.handle!,
+        limit: 5,
+      });
+
+      expect(expandResult.success).toBe(true);
+      expect(expandResult.data).toHaveLength(5);
+      expect(expandResult.total).toBe(50);
+    });
+
+    it("should return bindings", async () => {
+      await tools.load.execute({ filePath: testFile });
+      await tools.query.execute({ command: '(grep "LOG")' });
+      const result = await tools.bindings.execute({});
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.data!["$res1"]).toBeDefined();
+    });
+
+    it("should return status", async () => {
+      await tools.load.execute({ filePath: testFile });
+      const result = await tools.status.execute({});
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.data!.documentPath).toBe(testFile);
+    });
+
+    it("should support full workflow: load -> query -> filter -> count -> expand", async () => {
+      await tools.load.execute({ filePath: testFile });
+
+      // Search
+      const grep = await tools.query.execute({ command: '(grep "LOG")' });
+      expect(grep.success).toBe(true);
+
+      // Filter
+      const filter = await tools.query.execute({
+        command: '(filter RESULTS (lambda x (match x "value=100" 0)))',
+      });
+      expect(filter.success).toBe(true);
+
+      // Count
+      const count = await tools.query.execute({ command: "(count RESULTS)" });
+      expect(count.success).toBe(true);
+      expect(count.value).toBe(1);
+
+      // Expand
+      const expanded = await tools.expand.execute({
+        handle: filter.handle!,
+      });
+      expect(expanded.success).toBe(true);
+      expect(expanded.data!.length).toBe(1);
+    });
+  });
+
+  describe("getToolDefinitions", () => {
+    it("should return an array of tool definitions for SDK integration", () => {
+      const defs = tools.getToolDefinitions();
+
+      expect(Array.isArray(defs)).toBe(true);
+      expect(defs.length).toBeGreaterThanOrEqual(4);
+
+      for (const def of defs) {
+        expect(def.name).toBeTruthy();
+        expect(def.description).toBeTruthy();
+        expect(def.parameters).toBeDefined();
+        expect(typeof def.execute).toBe("function");
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `createLatticeTools()` in `src/tool/ai-tools.ts` that returns typed tool definitions
- Each tool has `name`, `description`, `parameters` (JSON Schema), and `execute` function
- Tools: `load`, `query`, `expand`, `close`, `status`, `bindings`
- `getToolDefinitions()` returns all tools as an array for SDK integration
- Exported from `matryoshka-rlm/tool` alongside existing adapters
- Provides a programmatic alternative to MCP for embedding Lattice in AI applications
- Inspired by Context7's `@upstash/context7-ai` package pattern

## Usage
```typescript
import { createLatticeTools } from "matryoshka-rlm/tool";

const tools = createLatticeTools();
await tools.load.execute({ filePath: "./data.log" });
const result = await tools.query.execute({ command: '(grep "ERROR")' });
const expanded = await tools.expand.execute({ handle: result.handle!, limit: 10 });
await tools.close.execute({});
```

## Test plan
- [x] Test validates tool set has all required tools (load, query, expand, close, status, bindings)
- [x] Test validates tool definitions have name, description, parameters
- [x] Test validates load/query/expand execution workflow
- [x] Test validates bindings and status tools
- [x] Test validates full pipeline: load → query → filter → count → expand
- [x] Test validates getToolDefinitions returns array for SDK integration
- [x] Existing claude-code-adapter tests pass without regression
- [x] `npx vitest run tests/tool/ai-tools.test.ts` passes (9 tests)