### PR TITLE
Improve Elixir symbol discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ Thumbs.db
 # TypeScript cache
 *.tsbuildinfo
 blog.md
+
+# config
+config.json

--- a/docs/opencode-setup.md
+++ b/docs/opencode-setup.md
@@ -1,0 +1,58 @@
+# Lattice MCP with OpenCode
+
+This project uses Lattice as a local MCP server so OpenCode can inspect large files with handle-based queries instead of dumping full file contents into the model context.
+
+## Install
+
+Install the package that provides the `lattice-mcp` binary:
+
+```bash
+npm install -g matryoshka-rlm
+```
+
+Sanity check:
+
+```bash
+lattice-mcp --help
+```
+
+If it is installed correctly, the command starts the server and prints startup info such as `MCP server started (handle-based mode)`.
+
+## Configure OpenCode
+
+Add Lattice to your OpenCode config in `~/.config/opencode/config.json` or a project-level `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "lattice": {
+      "type": "local",
+      "command": ["lattice-mcp"],
+      "enabled": true
+    }
+  }
+}
+```
+
+You can also add it interactively:
+
+```bash
+opencode mcp add
+```
+
+Then verify OpenCode sees it:
+
+```bash
+opencode mcp list
+```
+
+## How it appears in OpenCode
+
+Once enabled, the Lattice tools are exposed with the `lattice_` prefix, for example:
+
+- `lattice_lattice_load`
+- `lattice_lattice_query`
+- `lattice_lattice_expand`
+- `lattice_lattice_bindings`
+- `lattice_lattice_close`

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "ramo": "^0.1.2",
         "tree-sitter": "^0.21.1",
         "tree-sitter-css": "^0.21.1",
+        "tree-sitter-elixir": "^0.3.5",
         "tree-sitter-go": "^0.23.4",
         "tree-sitter-html": "^0.23.2",
         "tree-sitter-javascript": "^0.23.1",
@@ -3145,6 +3146,26 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tree-sitter-elixir": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/tree-sitter-elixir/-/tree-sitter-elixir-0.3.5.tgz",
+      "integrity": "sha512-xozQMvYK0aSolcQZAx2d84Xe/YMWFuRPYFlLVxO01bM2GITh5jyiIp0TqPCQa8754UzRAI7A83hZmfiYub5TZQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-addon-api": "^7.1.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      }
+    },
+    "node_modules/tree-sitter-elixir/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/tree-sitter-go": {
       "version": "0.23.4",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "ramo": "^0.1.2",
     "tree-sitter": "^0.21.1",
     "tree-sitter-css": "^0.21.1",
+    "tree-sitter-elixir": "^0.3.5",
     "tree-sitter-go": "^0.23.4",
     "tree-sitter-html": "^0.23.2",
     "tree-sitter-javascript": "^0.23.1",

--- a/src/repl/lattice-repl.ts
+++ b/src/repl/lattice-repl.ts
@@ -13,7 +13,7 @@
 import * as readline from "node:readline";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
-import { NucleusEngine } from "../engine/nucleus-engine.js";
+import { HandleSession } from "../engine/handle-session.js";
 
 const VERSION = "0.1.0";
 
@@ -138,7 +138,7 @@ EXAMPLES
  * Show command reference
  */
 function showReference(output: NodeJS.WritableStream): void {
-  output.write(NucleusEngine.getCommandReference() + "\n");
+  output.write(HandleSession.getCommandReference() + "\n");
 }
 
 /**
@@ -153,7 +153,7 @@ export async function startREPL(options: REPLOptions = {}): Promise<void> {
     input = process.stdin,
   } = options;
 
-  const engine = new NucleusEngine({ verbose });
+  const session = new HandleSession();
 
   // Print banner
   output.write(`Lattice REPL v${VERSION}\n`);
@@ -166,11 +166,10 @@ export async function startREPL(options: REPLOptions = {}): Promise<void> {
       output.write(`Error: File not found: ${resolved}\n`);
     } else {
       try {
-        await engine.loadFile(resolved);
-        const stats = engine.getStats();
+        const stats = await session.loadFile(resolved);
         if (stats) {
           output.write(`Loaded: ${resolved}\n`);
-          output.write(`  ${stats.length.toLocaleString()} chars, ${stats.lineCount.toLocaleString()} lines\n\n`);
+          output.write(`  ${stats.size.toLocaleString()} chars, ${stats.lineCount.toLocaleString()} lines\n\n`);
         }
       } catch (err) {
         output.write(`Error loading file: ${err instanceof Error ? err.message : err}\n`);
@@ -227,11 +226,10 @@ export async function startREPL(options: REPLOptions = {}): Promise<void> {
               output.write(`Error: File not found: ${resolved}\n`);
             } else {
               try {
-                await engine.loadFile(resolved);
-                const stats = engine.getStats();
+                const stats = await session.loadFile(resolved);
                 if (stats) {
                   output.write(`Loaded: ${resolved}\n`);
-                  output.write(`  ${stats.length.toLocaleString()} chars, ${stats.lineCount.toLocaleString()} lines\n`);
+                  output.write(`  ${stats.size.toLocaleString()} chars, ${stats.lineCount.toLocaleString()} lines\n`);
                 }
               } catch (err) {
                 output.write(`Error: ${err instanceof Error ? err.message : err}\n`);
@@ -241,13 +239,13 @@ export async function startREPL(options: REPLOptions = {}): Promise<void> {
           break;
 
         case "stats":
-          if (!engine.isLoaded()) {
+          if (!session.isLoaded()) {
             output.write("No document loaded. Use :load <file>\n");
           } else {
-            const stats = engine.getStats();
+            const stats = session.getStats();
             if (stats) {
               output.write(`Document statistics:\n`);
-              output.write(`  Length: ${stats.length.toLocaleString()} chars\n`);
+              output.write(`  Length: ${stats.size.toLocaleString()} chars\n`);
               output.write(`  Lines: ${stats.lineCount.toLocaleString()}\n`);
             }
           }
@@ -255,7 +253,7 @@ export async function startREPL(options: REPLOptions = {}): Promise<void> {
 
         case "bindings":
         case "vars":
-          const bindings = engine.getBindings();
+          const bindings = session.getBindings();
           const keys = Object.keys(bindings);
           if (keys.length === 0) {
             output.write("No bindings\n");
@@ -271,7 +269,7 @@ export async function startREPL(options: REPLOptions = {}): Promise<void> {
           if (!arg) {
             output.write("Usage: :get <varname>\n");
           } else {
-            const value = engine.getBinding(arg);
+            const value = session.getBindings()[arg];
             if (value === undefined) {
               output.write(`Binding not found: ${arg}\n`);
             } else {
@@ -281,7 +279,7 @@ export async function startREPL(options: REPLOptions = {}): Promise<void> {
           break;
 
         case "reset":
-          engine.reset();
+          session.reset();
           output.write("State reset\n");
           break;
 
@@ -294,12 +292,12 @@ export async function startREPL(options: REPLOptions = {}): Promise<void> {
     }
 
     // Nucleus query (S-expression)
-    if (!engine.isLoaded()) {
+    if (!session.isLoaded()) {
       output.write("No document loaded. Use :load <file>\n");
       return true;
     }
 
-    const result = engine.execute(trimmed);
+    const result = session.execute(trimmed);
 
     if (!result.success) {
       output.write(`Error: ${result.error}\n`);
@@ -312,7 +310,15 @@ export async function startREPL(options: REPLOptions = {}): Promise<void> {
       }
 
       // Show result
-      output.write(`${formatValue(result.value)}\n`);
+      if (result.handle && result.stub) {
+        output.write(`${result.stub}\n`);
+        const expanded = session.expand(result.handle, { limit: 10 });
+        if (expanded.success && expanded.data) {
+          output.write(`${formatValue(expanded.data)}\n`);
+        }
+      } else {
+        output.write(`${formatValue(result.value)}\n`);
+      }
 
       // Show type if inferred
       if (result.type && verbose) {
@@ -336,6 +342,7 @@ export async function startREPL(options: REPLOptions = {}): Promise<void> {
   });
 
   rl.on("close", () => {
+    session.close();
     process.exit(0);
   });
 

--- a/src/treesitter/symbol-extractor.ts
+++ b/src/treesitter/symbol-extractor.ts
@@ -75,6 +75,16 @@ const CONTAINER_TYPES = new Set([
   "namespace_definition",
 ]);
 
+const ELIXIR_FUNCTION_MACROS = new Set(["def", "defp", "defmacro", "defmacrop"]);
+const SIGNATURE_FUNCTION_TYPES = [
+  "function_declaration",
+  "method_definition",
+  "function_definition",
+  "method_declaration",
+  "function_item",
+];
+const MAX_SIGNATURE_TEXT_LENGTH = 50_000;
+
 /**
  * SymbolExtractor extracts symbols from source code
  */
@@ -157,6 +167,14 @@ export class SymbolExtractor {
       if (symbol) {
         symbols.push(symbol);
       }
+    } else if (language === "elixir" && node.type === "call") {
+      const elixirSymbol = this.extractElixirCallSymbol(node, parentId);
+      if (elixirSymbol) {
+        symbols.push(elixirSymbol.symbol);
+        if (elixirSymbol.isContainer) {
+          currentParentId = elixirSymbol.symbol.id!;
+        }
+      }
     } else {
       // Check if this node is a symbol definition using the mappings
       const kind = symbolMappings[node.type];
@@ -195,6 +213,21 @@ export class SymbolExtractor {
     const name = this.getNodeName(node);
     if (!name) return null;
 
+    // buildSymbol clamps line bounds so endLine is never below startLine.
+    return this.buildSymbol(name, node, kind, parentId, language);
+  }
+
+  private buildSymbol(
+    name: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    node: any,
+    kind: SymbolKind,
+    parentId: number | null,
+    language: SupportedLanguage
+  ): Symbol | null {
+    const normalizedName = typeof name === "string" ? name.trim() : "";
+    if (!normalizedName) return null;
+
     if (this.symbolIdCounter >= Number.MAX_SAFE_INTEGER - 1) return null;
     this.symbolIdCounter++;
 
@@ -209,7 +242,7 @@ export class SymbolExtractor {
 
     return {
       id: this.symbolIdCounter,
-      name,
+      name: normalizedName,
       kind,
       startLine,
       endLine,
@@ -218,6 +251,41 @@ export class SymbolExtractor {
       signature: this.getSignature(node, language),
       parentSymbolId: parentId,
     };
+  }
+
+  private extractElixirCallSymbol(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    node: any,
+    parentId: number | null
+  ): { symbol: Symbol; isContainer: boolean } | null {
+    const macroName = this.getElixirCallTargetName(node);
+    if (!macroName) return null;
+
+    if (ELIXIR_FUNCTION_MACROS.has(macroName)) {
+      const name = this.getElixirDefinitionName(node);
+      const symbol = name ? this.buildSymbol(name, node, "function", parentId, "elixir") : null;
+      return symbol ? { symbol, isContainer: false } : null;
+    }
+
+    if (macroName === "defmodule") {
+      const name = this.getElixirFirstAliasArgument(node);
+      const symbol = name ? this.buildSymbol(name, node, "module", parentId, "elixir") : null;
+      return symbol ? { symbol, isContainer: true } : null;
+    }
+
+    if (macroName === "defprotocol") {
+      const name = this.getElixirFirstAliasArgument(node);
+      const symbol = name ? this.buildSymbol(name, node, "interface", parentId, "elixir") : null;
+      return symbol ? { symbol, isContainer: true } : null;
+    }
+
+    if (macroName === "defimpl") {
+      const name = this.getElixirImplementationName(node);
+      const symbol = name ? this.buildSymbol(name, node, "module", parentId, "elixir") : null;
+      return symbol ? { symbol, isContainer: true } : null;
+    }
+
+    return null;
   }
 
   /**
@@ -314,42 +382,183 @@ export class SymbolExtractor {
     return null;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private getElixirCallTargetName(node: any): string | null {
+    if (!node || node.type !== "call") return null;
+    const targetNode = node.childForFieldName?.("target");
+    return this.getElixirNameFromNode(targetNode);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private getElixirArgumentsNode(node: any): any | null {
+    if (!node) return null;
+
+    const childLimit = Math.min(node.childCount ?? 0, MAX_CHILDREN);
+    for (let i = 0; i < childLimit; i++) {
+      const child = node.child(i);
+      if (child?.type === "arguments") {
+        return child;
+      }
+    }
+
+    return null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private getElixirDefinitionName(node: any): string | null {
+    const argsNode = this.getElixirArgumentsNode(node);
+    if (!argsNode) return null;
+
+    const firstArg = this.getFirstNamedChild(argsNode);
+    return this.getElixirDefinedNameFromArgument(firstArg);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private getElixirFirstAliasArgument(node: any): string | null {
+    const argsNode = this.getElixirArgumentsNode(node);
+    if (!argsNode) return null;
+
+    const childLimit = Math.min(argsNode.childCount ?? 0, MAX_CHILDREN);
+    for (let i = 0; i < childLimit; i++) {
+      const child = argsNode.child(i);
+      if (child?.type === "alias" && child.text) {
+        return child.text.trim();
+      }
+    }
+
+    return null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private getElixirImplementationName(node: any): string | null {
+    const protocolName = this.getElixirFirstAliasArgument(node);
+    const implTarget = this.getElixirImplementationTarget(node);
+
+    if (protocolName && implTarget) return `${protocolName} for ${implTarget}`;
+    return protocolName ?? implTarget;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private getElixirImplementationTarget(node: any): string | null {
+    const argsNode = this.getElixirArgumentsNode(node);
+    if (!argsNode) return null;
+
+    const childLimit = Math.min(argsNode.childCount ?? 0, MAX_CHILDREN);
+    for (let i = 0; i < childLimit; i++) {
+      const child = argsNode.child(i);
+      if (child?.type !== "keywords") continue;
+
+      const pairLimit = Math.min(child.childCount ?? 0, MAX_CHILDREN);
+      for (let j = 0; j < pairLimit; j++) {
+        const pair = child.child(j);
+        if (pair?.type !== "pair") continue;
+
+        const keyNode = pair.childForFieldName?.("key");
+        const valueNode = pair.childForFieldName?.("value");
+        const keyText = typeof keyNode?.text === "string" ? keyNode.text.trim() : "";
+        if (!keyText.startsWith("for:")) continue;
+
+        const valueText = this.getElixirNameFromNode(valueNode) ?? this.getNormalizedNodeText(valueNode);
+        if (valueText) return valueText;
+      }
+    }
+
+    return null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private getElixirDefinedNameFromArgument(node: any): string | null {
+    if (!node) return null;
+
+    if (node.type === "binary_operator") {
+      const operatorNode = node.childForFieldName?.("operator");
+      if (operatorNode?.text === "when") {
+        return this.getElixirDefinedNameFromArgument(node.childForFieldName?.("left"));
+      }
+    }
+
+    if (node.type === "call") {
+      return this.getElixirNameFromNode(node.childForFieldName?.("target"));
+    }
+
+    return this.getElixirNameFromNode(node);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private getElixirNameFromNode(node: any): string | null {
+    if (!node || typeof node.text !== "string") return null;
+
+    if (
+      node.type === "identifier" ||
+      node.type === "alias" ||
+      node.type === "operator_identifier" ||
+      node.type === "atom" ||
+      node.type === "quoted_atom"
+    ) {
+      return node.text.trim();
+    }
+
+    if (node.type === "dot") {
+      const right = node.childForFieldName?.("right");
+      return this.getElixirNameFromNode(right) ?? this.getNormalizedNodeText(node);
+    }
+
+    return this.getNormalizedNodeText(node);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private getNormalizedNodeText(node: any): string | null {
+    if (!node || typeof node.text !== "string") return null;
+    const text = node.text.replace(/\s+/g, " ").trim();
+    return text || null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private getFirstNamedChild(node: any): any | null {
+    if (!node) return null;
+
+    const childLimit = Math.min(node.childCount ?? 0, MAX_CHILDREN);
+    for (let i = 0; i < childLimit; i++) {
+      const child = node.child(i);
+      if (child?.isNamed) {
+        return child;
+      }
+    }
+
+    return null;
+  }
+
   /**
    * Get a signature string for a symbol
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private getSignature(node: any, language: SupportedLanguage): string | undefined {
-    // For functions/methods, try to get the signature from the first line
-    const functionTypes = [
-      "function_declaration",
-      "method_definition",
-      "function_definition",
-      "method_declaration",
-      "function_item",
-    ];
+    if (!node?.text || typeof node.text !== "string") return undefined;
+    if (node.text.length > MAX_SIGNATURE_TEXT_LENGTH) return undefined;
 
-    if (functionTypes.includes(node.type)) {
-      if (!node.text || typeof node.text !== "string") return undefined;
-      if (node.text.length > 50_000) return undefined;
-      const text = node.text;
-      const lines = text.split("\n", 50);
-      if (lines.length > 0) {
-        let firstLine = lines[0];
-        // Clean up the signature
-        if (language === "python") {
-          const colonIndex = firstLine.indexOf(":");
-          if (colonIndex !== -1) {
-            firstLine = firstLine.substring(0, colonIndex + 1);
-          }
-        } else {
-          const braceIndex = firstLine.indexOf("{");
-          if (braceIndex !== -1) {
-            firstLine = firstLine.substring(0, braceIndex).trim();
-          }
+    const isElixirDefinition =
+      language === "elixir" && node.type === "call" && ELIXIR_FUNCTION_MACROS.has(this.getElixirCallTargetName(node) ?? "");
+    if (!SIGNATURE_FUNCTION_TYPES.includes(node.type) && !isElixirDefinition) return undefined;
+
+    const text = node.text;
+    const lines = text.split("\n", 50);
+    if (lines.length > 0) {
+      let firstLine = lines[0];
+      // Clean up the signature
+      if (language === "python") {
+        const colonIndex = firstLine.indexOf(":");
+        if (colonIndex !== -1) {
+          firstLine = firstLine.substring(0, colonIndex + 1);
         }
-        return firstLine.trim();
+      } else {
+        const braceIndex = firstLine.indexOf("{");
+        if (braceIndex !== -1) {
+          firstLine = firstLine.substring(0, braceIndex).trim();
+        }
       }
+      return firstLine.trim();
     }
+
     return undefined;
   }
 }

--- a/test-fixtures/sample-code.ex
+++ b/test-fixtures/sample-code.ex
@@ -1,0 +1,41 @@
+# implementation
+defmodule RowParser do
+  def parse(input) do
+    input
+    |> String.split("\n", trim: true)
+    |> Stream.map(&String.trim_leading/1)
+    |> Stream.map(fn str ->
+      [left, right] = String.split(str, ~r/\s{3}/)
+      [String.to_integer(left), String.to_integer(right)]
+    end)
+    |> Enum.to_list()
+    |> Enum.reduce(%{left: [], right: []}, fn [left, right], acc ->
+      acc
+      |> Map.put(:left, [ left | acc[:left]])
+      |> Map.put(:right, [ right | acc[:right]])
+    end)
+  end
+end
+
+# test
+ExUnit.start(autorun: false)
+
+defmodule RowParserTest do
+  use ExUnit.Case, async: true
+
+  @test_input """
+  3   4
+  4   3
+  2   5
+  1   3
+  3   9
+  3   3
+  """
+
+  test "row parse test" do
+    assert RowParser.parse(@test_input) ==
+             %{left: [3, 3, 1, 2, 4, 3], right: [3, 9, 3, 5, 3, 4]}
+  end
+end
+
+ExUnit.run()

--- a/tests/repl/lattice-repl.test.ts
+++ b/tests/repl/lattice-repl.test.ts
@@ -2,18 +2,21 @@ import { describe, it, expect } from "vitest";
 
 // Test the REPL by importing the engine it uses
 // Full REPL interactive testing is complex, so we test the underlying engine
-import { NucleusEngine } from "../../src/engine/nucleus-engine.js";
+import { HandleSession } from "../../src/engine/handle-session.js";
 
 describe("REPL underlying engine", () => {
   it("should process commands sequentially", () => {
-    const engine = new NucleusEngine();
+    const engine = new HandleSession();
     // Use unique pattern that won't match INFO, etc
     engine.loadContent("FATAL: test error\nINFO: test info\nFATAL: another error");
 
     // Simulate REPL session
     const r1 = engine.execute('(grep "FATAL")');
     expect(r1.success).toBe(true);
-    expect((r1.value as unknown[]).length).toBe(2);
+    expect(r1.handle).toBeDefined();
+    const expanded = engine.expand(r1.handle!);
+    expect(expanded.success).toBe(true);
+    expect(expanded.data?.length).toBe(2);
 
     const r2 = engine.execute('(count RESULTS)');
     expect(r2.success).toBe(true);
@@ -21,18 +24,18 @@ describe("REPL underlying engine", () => {
   });
 
   it("should maintain state across commands", () => {
-    const engine = new NucleusEngine();
+    const engine = new HandleSession();
     engine.loadContent("line1\nline2\nline3");
 
     engine.execute('(grep "line")');
     const bindings = engine.getBindings();
 
-    expect(bindings.RESULTS).toBe("Array[3]");
-    expect(bindings._1).toBe("Array[3]");
+    expect(bindings.RESULTS).toBe("-> $res1");
+    expect(bindings.$res1).toContain("Array(3)");
   });
 
   it("should reset state on command", () => {
-    const engine = new NucleusEngine();
+    const engine = new HandleSession();
     engine.loadContent("test");
 
     engine.execute('(grep "test")');
@@ -43,7 +46,7 @@ describe("REPL underlying engine", () => {
   });
 
   it("should provide command reference", () => {
-    const ref = NucleusEngine.getCommandReference();
+    const ref = HandleSession.getCommandReference();
 
     expect(ref).toContain("grep");
     expect(ref).toContain("filter");
@@ -51,11 +54,29 @@ describe("REPL underlying engine", () => {
     expect(ref).toContain("sum");
     expect(ref).toContain("RESULTS");
   });
+
+  it("should support symbol queries after loading Elixir code", async () => {
+    const engine = new HandleSession();
+    await engine.loadContentWithSymbols(`
+defmodule Greeter do
+  def hello(name) do
+    "Hello, #{name}"
+  end
+end
+`, "test.ex");
+
+    const result = engine.execute('(list_symbols)');
+    expect(result.success).toBe(true);
+    expect(result.handle).toBeDefined();
+    const expanded = engine.expand(result.handle!);
+    expect(expanded.success).toBe(true);
+    expect(JSON.stringify(expanded.data)).toContain("Greeter");
+  });
 });
 
 describe("REPL command patterns", () => {
   it("should handle typical grep -> count workflow", () => {
-    const engine = new NucleusEngine();
+    const engine = new HandleSession();
     engine.loadContent(`
 [2024-01-15 10:30:00] FATAL: Connection timeout
 [2024-01-15 10:30:01] INFO: Retrying...
@@ -67,7 +88,9 @@ describe("REPL command patterns", () => {
     // Step 1: Find all fatal errors
     const grep = engine.execute('(grep "FATAL")');
     expect(grep.success).toBe(true);
-    expect((grep.value as unknown[]).length).toBe(3);
+    const expanded = engine.expand(grep.handle!);
+    expect(expanded.success).toBe(true);
+    expect(expanded.data?.length).toBe(3);
 
     // Step 2: Count
     const count = engine.execute('(count RESULTS)');
@@ -76,7 +99,7 @@ describe("REPL command patterns", () => {
   });
 
   it("should handle grep -> sum workflow for numeric data", () => {
-    const engine = new NucleusEngine();
+    const engine = new HandleSession();
     // Use $ prefix so sum can identify currency values
     engine.loadContent(`
 Sales: $100,000
@@ -88,7 +111,9 @@ Sales: $175,000
     // Find sales lines
     const grep = engine.execute('(grep "Sales")');
     expect(grep.success).toBe(true);
-    expect((grep.value as unknown[]).length).toBe(4);
+    const expanded = engine.expand(grep.handle!);
+    expect(expanded.success).toBe(true);
+    expect(expanded.data?.length).toBe(4);
 
     // Sum them - sum extracts $ amounts from line content
     const sum = engine.execute('(sum RESULTS)');

--- a/tests/treesitter/integration.test.ts
+++ b/tests/treesitter/integration.test.ts
@@ -45,6 +45,18 @@ class Greeter:
         return hello(self.name)
 `.trim();
 
+  const sampleElixir = `
+defmodule Greeter do
+  def hello(name) do
+    "Hello, #{name}"
+  end
+end
+
+defprotocol String.Chars do
+  def to_string(data)
+end
+`.trim();
+
   beforeEach(() => {
     session = new HandleSession();
   });
@@ -83,6 +95,20 @@ class Greeter:
       const names = symbols.map(s => s.name);
       expect(names).toContain("hello");
       expect(names).toContain("Greeter");
+    });
+
+    it("should auto-index symbols on Elixir file load", async () => {
+      await session.loadContentWithSymbols(sampleElixir, "test.ex");
+
+      const result = session.execute('(list_symbols)');
+      expect(result.success).toBe(true);
+
+      const expanded = session.expand(result.handle!);
+      const symbols = expanded.data as Array<{ name: string; kind: string }>;
+      const names = symbols.map(s => s.name);
+      expect(names).toContain("Greeter");
+      expect(names).toContain("hello");
+      expect(names).toContain("String.Chars");
     });
 
     it("should handle non-code files gracefully", async () => {
@@ -176,6 +202,30 @@ function baz() { return 3; }
 
       const expanded = session.expand(result.handle!);
       expect(expanded.data?.length).toBeGreaterThanOrEqual(2); // Declaration + usage
+    });
+  });
+
+  describe("Elixir symbol query operations", () => {
+    beforeEach(async () => {
+      await session.loadContentWithSymbols(sampleElixir, "test.ex");
+    });
+
+    it("should return protocol symbols with interface kind", () => {
+      const result = session.execute('(list_symbols "interface")');
+      expect(result.success).toBe(true);
+
+      const expanded = session.expand(result.handle!);
+      const symbols = expanded.data as Array<{ name: string; kind: string }>;
+      expect(symbols.some(s => s.kind === "interface" && s.name === "String.Chars")).toBe(true);
+    });
+
+    it("should support get_symbol_body for Elixir functions", () => {
+      const result = session.execute('(get_symbol_body "hello")');
+      expect(result.success).toBe(true);
+
+      const body = result.value as string;
+      expect(body).toContain("def hello(name) do");
+      expect(body).toContain('"Hello, #{name}"');
     });
   });
 

--- a/tests/treesitter/parser-registry.test.ts
+++ b/tests/treesitter/parser-registry.test.ts
@@ -42,6 +42,7 @@ describe("Language Map", () => {
     expect(getLanguageForExtension(".java")).toBe("java");
     expect(getLanguageForExtension(".html")).toBe("html");
     expect(getLanguageForExtension(".json")).toBe("json");
+    expect(getLanguageForExtension(".ex")).toBe("elixir");
   });
 
   it("should be case-insensitive for extensions", () => {
@@ -72,6 +73,7 @@ describe("Language Map", () => {
     expect(isLanguageAvailable("python")).toBe(true);
     expect(isLanguageAvailable("go")).toBe(true);
     expect(isLanguageAvailable("javascript")).toBe(true);
+    expect(isLanguageAvailable("elixir")).toBe(true);
     // These have configs but packages aren't installed
     expect(isLanguageAvailable("rust")).toBe(false);
     expect(isLanguageAvailable("java")).toBe(false);
@@ -226,6 +228,21 @@ func (p *Person) Greet() string {
       const tree = await registry.parseDocument(code, ".go");
       expect(tree).not.toBeNull();
       expect(tree!.rootNode.type).toBe("source_file");
+    });
+  });
+
+  describe("Elixir parsing", () => {
+    it("should parse Elixir and return tree", async () => {
+      const code = `
+defmodule Greeter do
+  def hello(name) do
+    "Hello, #{name}"
+  end
+end
+`;
+      const tree = await registry.parseDocument(code, ".ex");
+      expect(tree).not.toBeNull();
+      expect(tree!.rootNode.type).toBe("source");
     });
   });
 

--- a/tests/treesitter/symbol-extractor.test.ts
+++ b/tests/treesitter/symbol-extractor.test.ts
@@ -261,6 +261,94 @@ func (p *Person) Greet() string {
     });
   });
 
+  describe("Elixir", () => {
+    it("should extract module, functions, and macros", async () => {
+      const code = `
+defmodule Greeter do
+  def hello(name) do
+    "Hello, #{name}"
+  end
+
+  defp secret do
+    :ok
+  end
+
+  defmacro announce(value) do
+    value
+  end
+end
+`;
+      const symbols = await extractor.extractSymbols(code, ".ex");
+
+      const moduleSymbol = symbols.find((s) => s.kind === "module" && s.name === "Greeter");
+      expect(moduleSymbol).toBeDefined();
+
+      const functionNames = symbols.filter((s) => s.kind === "function").map((s) => s.name);
+      expect(functionNames).toContain("hello");
+      expect(functionNames).toContain("secret");
+      expect(functionNames).toContain("announce");
+    });
+
+    it("should extract guarded function definitions", async () => {
+      const code = `
+defmodule Guarded do
+  def greet(name) when is_binary(name) do
+    name
+  end
+end
+`;
+      const symbols = await extractor.extractSymbols(code, ".ex");
+
+      const greet = symbols.find((s) => s.kind === "function" && s.name === "greet");
+      expect(greet).toBeDefined();
+    });
+
+    it("should extract protocols and implementations", async () => {
+      const code = `
+defprotocol String.Chars do
+  def to_string(data)
+end
+
+defimpl String.Chars, for: Integer do
+  def to_string(data) do
+    Integer.to_string(data)
+  end
+end
+`;
+      const symbols = await extractor.extractSymbols(code, ".ex");
+
+      const protocolSymbol = symbols.find((s) => s.kind === "interface" && s.name === "String.Chars");
+      expect(protocolSymbol).toBeDefined();
+
+      const implSymbol = symbols.find((s) => s.kind === "module" && s.name === "String.Chars for Integer");
+      expect(implSymbol).toBeDefined();
+
+      const toStringSymbols = symbols.filter((s) => s.kind === "function" && s.name === "to_string");
+      expect(toStringSymbols.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("should capture parent-child relationships for nested Elixir definitions", async () => {
+      const code = `
+defmodule Parent do
+  def child(value) do
+    value
+  end
+end
+`;
+      const symbols = await extractor.extractSymbols(code, ".ex");
+
+      const parentModule = symbols.find((s) => s.kind === "module" && s.name === "Parent");
+      const childFunction = symbols.find((s) => s.kind === "function" && s.name === "child");
+
+      expect(parentModule).toBeDefined();
+      expect(childFunction).toBeDefined();
+
+      if (parentModule && childFunction) {
+        expect(childFunction.parentSymbolId).toBe(parentModule.id);
+      }
+    });
+  });
+
   describe("error handling", () => {
     it("should return empty array for parse errors", async () => {
       const code = `


### PR DESCRIPTION
## Summary of changes
- add Elixir-aware symbol extraction for modules, protocols, implementations, functions, and macros
- update the REPL to load code files through the symbol-aware session so `list_symbols` and `get_symbol_body` work interactively
- add Elixir parser, extractor, integration, and REPL coverage, 
- OpenCode setup doc 

## Testing
- npm test
- npm run typecheck

## Verification

```lisp

> :load test-fixtures/sample-code.ex
Loaded: /Users/davm/local/oss/Matryoshka/test-fixtures/sample-code.ex
  844 chars, 42 lines
> (list_symbols)
$res1: Array(3) [id, name, kind]
...
```

During my REPL test, `load-symbols` correctly identified Elixir symbols
<img width="1464" height="632" alt="Screenshot 2026-03-22 at 9 10 13 PM" src="https://github.com/user-attachments/assets/d0f3da49-1550-4080-a03f-0b568fe87d05" />


