### PR TITLE
Fix REPL regressions from HandleSession swap

### DIFF
--- a/src/engine/handle-session.ts
+++ b/src/engine/handle-session.ts
@@ -97,6 +97,11 @@ export interface ExpandResult {
 /**
  * HandleSession - combines NucleusEngine with handle-based storage
  */
+export interface HandleSessionOptions {
+  /** Enable verbose logging on the underlying NucleusEngine */
+  verbose?: boolean;
+}
+
 export class HandleSession {
   private engine: NucleusEngine;
   private db: SessionDB;
@@ -112,8 +117,8 @@ export class HandleSession {
   private lastAccessedAt: Date | null = null;
   private queryCount: number = 0;
 
-  constructor() {
-    this.engine = new NucleusEngine();
+  constructor(options: HandleSessionOptions = {}) {
+    this.engine = new NucleusEngine({ verbose: options.verbose });
     this.db = new SessionDB();
     this.registry = new HandleRegistry(this.db);
     this.ops = new HandleOps(this.db, this.registry);
@@ -454,6 +459,13 @@ export class HandleSession {
     }
 
     return bindings;
+  }
+
+  /**
+   * Get a specific binding value from the underlying engine
+   */
+  getBinding(name: string): unknown {
+    return this.engine.getBinding(name);
   }
 
   /**

--- a/src/repl/lattice-repl.ts
+++ b/src/repl/lattice-repl.ts
@@ -153,7 +153,7 @@ export async function startREPL(options: REPLOptions = {}): Promise<void> {
     input = process.stdin,
   } = options;
 
-  const session = new HandleSession();
+  const session = new HandleSession({ verbose });
 
   // Print banner
   output.write(`Lattice REPL v${VERSION}\n`);
@@ -269,7 +269,7 @@ export async function startREPL(options: REPLOptions = {}): Promise<void> {
           if (!arg) {
             output.write("Usage: :get <varname>\n");
           } else {
-            const value = session.getBindings()[arg];
+            const value = session.getBinding(arg);
             if (value === undefined) {
               output.write(`Binding not found: ${arg}\n`);
             } else {


### PR DESCRIPTION
## Summary
- **:get returns actual data**: Added `getBinding()` to `HandleSession` that delegates to the underlying `NucleusEngine`, so `:get RESULTS` shows the real value instead of a handle stub string
- **verbose flag restored**: Added `HandleSessionOptions` interface with `verbose` option, threaded through to `new NucleusEngine({ verbose })` so `--verbose`/`-v` works again in the REPL

## Test plan
- [x] `npm run typecheck` passes
- [x] All non-Elixir REPL tests pass (Elixir failures are pre-existing from #15, unrelated to this change)