### PR TITLE
Add markdown file support with heading symbol extraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "tree-sitter-html": "^0.23.2",
         "tree-sitter-javascript": "^0.23.1",
         "tree-sitter-json": "^0.24.8",
+        "tree-sitter-markdown": "^0.7.1",
         "tree-sitter-python": "^0.21.0",
         "tree-sitter-typescript": "^0.23.2",
         "web-tree-sitter": "^0.26.3"
@@ -1717,6 +1718,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1995,6 +1997,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2322,6 +2325,12 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2489,6 +2498,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3123,6 +3133,7 @@
       "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0"
@@ -3243,6 +3254,16 @@
         }
       }
     },
+    "node_modules/tree-sitter-markdown": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-markdown/-/tree-sitter-markdown-0.7.1.tgz",
+      "integrity": "sha512-hB3sEm1JtfoRUzGvknL9RQrS/LJvbrdI9WfGbU8gE6xMjbbAKHfHrNzh4Oo9JxksfUf6UEMxy91acRajEIOnGQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "nan": "^2.14.0"
+      }
+    },
     "node_modules/tree-sitter-python": {
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/tree-sitter-python/-/tree-sitter-python-0.21.0.tgz",
@@ -3294,6 +3315,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3384,6 +3406,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3459,6 +3482,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -3580,6 +3604,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
+        "@tree-sitter-grammars/tree-sitter-markdown": "^0.3.2",
         "@types/better-sqlite3": "^7.6.13",
         "@vscode/tree-sitter-wasm": "^0.3.0",
         "better-sqlite3": "^12.6.2",
@@ -22,7 +23,6 @@
         "tree-sitter-html": "^0.23.2",
         "tree-sitter-javascript": "^0.23.1",
         "tree-sitter-json": "^0.24.8",
-        "tree-sitter-markdown": "^0.7.1",
         "tree-sitter-python": "^0.21.0",
         "tree-sitter-typescript": "^0.23.2",
         "web-tree-sitter": "^0.26.3"
@@ -985,6 +985,25 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tree-sitter-grammars/tree-sitter-markdown": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-markdown/-/tree-sitter-markdown-0.3.2.tgz",
+      "integrity": "sha512-hQXCcDVvg2t4E8cn7zz6jjIBerzk9E9ZlHxJp5IrUOpY4s1YVpXJbMeWZks2/V7lmkPRnnkM8IrTbQ5ltwEOnA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.1.0",
+        "node-gyp-build": "^4.8.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
@@ -2325,12 +2344,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/nan": {
-      "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
-      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
-      "license": "MIT"
-    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -3252,16 +3265,6 @@
         "tree-sitter": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tree-sitter-markdown": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter-markdown/-/tree-sitter-markdown-0.7.1.tgz",
-      "integrity": "sha512-hB3sEm1JtfoRUzGvknL9RQrS/LJvbrdI9WfGbU8gE6xMjbbAKHfHrNzh4Oo9JxksfUf6UEMxy91acRajEIOnGQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "nan": "^2.14.0"
       }
     },
     "node_modules/tree-sitter-python": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "tree-sitter-html": "^0.23.2",
     "tree-sitter-javascript": "^0.23.1",
     "tree-sitter-json": "^0.24.8",
+    "tree-sitter-markdown": "^0.7.1",
     "tree-sitter-python": "^0.21.0",
     "tree-sitter-typescript": "^0.23.2",
     "web-tree-sitter": "^0.26.3"

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   "author": "yogthos",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "@tree-sitter-grammars/tree-sitter-markdown": "^0.3.2",
     "@types/better-sqlite3": "^7.6.13",
     "@vscode/tree-sitter-wasm": "^0.3.0",
     "better-sqlite3": "^12.6.2",
@@ -92,7 +93,6 @@
     "tree-sitter-html": "^0.23.2",
     "tree-sitter-javascript": "^0.23.1",
     "tree-sitter-json": "^0.24.8",
-    "tree-sitter-markdown": "^0.7.1",
     "tree-sitter-python": "^0.21.0",
     "tree-sitter-typescript": "^0.23.2",
     "web-tree-sitter": "^0.26.3"

--- a/skills/lattice/SKILL.md
+++ b/skills/lattice/SKILL.md
@@ -57,9 +57,9 @@ The standard workflow is: **load → query → expand → close**
 (match str "pattern" 1)       ; Extract regex capture group from a string
 ```
 
-### Code Symbols (for .ts, .js, .py, .go, .rs, etc.)
+### Code & Document Symbols (for .ts, .js, .py, .go, .rs, .md, etc.)
 ```scheme
-(list_symbols)                ; List all functions, classes, methods, etc.
+(list_symbols)                ; List all functions, classes, methods, headings, etc.
 (list_symbols "function")     ; Filter by kind: "function", "class", "method", "interface", "type"
 (get_symbol_body "funcName")  ; Get full source code of a symbol
 (find_references "identifier"); Find all usages of an identifier

--- a/src/engine/handle-session.ts
+++ b/src/engine/handle-session.ts
@@ -13,7 +13,11 @@ import { HandleRegistry } from "../persistence/handle-registry.js";
 import { HandleOps } from "../persistence/handle-ops.js";
 import { ParserRegistry } from "../treesitter/parser-registry.js";
 import { SymbolExtractor } from "../treesitter/symbol-extractor.js";
-import { isExtensionSupported } from "../treesitter/language-map.js";
+import {
+  getLanguageForExtension,
+  getSymbolMappings,
+  isLanguageAvailable,
+} from "../treesitter/language-map.js";
 
 const MAX_DOCUMENT_SIZE = 50 * 1024 * 1024; // 50MB
 const CHARS_PER_TOKEN = 4; // Approximate token estimation heuristic
@@ -117,6 +121,13 @@ export class HandleSession {
   private lastAccessedAt: Date | null = null;
   private queryCount: number = 0;
 
+  private canExtractSymbols(ext: string): boolean {
+    const language = getLanguageForExtension(ext);
+    if (!language) return false;
+    if (!isLanguageAvailable(language)) return false;
+    return getSymbolMappings(language) !== null;
+  }
+
   constructor(options: HandleSessionOptions = {}) {
     this.engine = new NucleusEngine({ verbose: options.verbose });
     this.db = new SessionDB();
@@ -174,7 +185,7 @@ export class HandleSession {
 
     // Extract symbols for code files (async, but we fire and forget for sync API)
     const ext = extname(path);
-    if (ext && isExtensionSupported(ext)) {
+    if (ext && this.canExtractSymbols(ext)) {
       this.extractSymbolsAsync(content, ext);
     }
 
@@ -206,9 +217,13 @@ export class HandleSession {
 
     // Extract symbols for code files
     const ext = extname(path);
-    if (ext && isExtensionSupported(ext)) {
+    if (ext && this.canExtractSymbols(ext)) {
       await this.init();
-      await this.extractAndStoreSymbols(content, ext);
+      try {
+        await this.extractAndStoreSymbols(content, ext);
+      } catch (err) {
+        console.error("[HandleSession] Symbol extraction failed:", err instanceof Error ? err.message : String(err));
+      }
     }
 
     // Set SessionDB binding for solver access

--- a/src/engine/nucleus-engine.ts
+++ b/src/engine/nucleus-engine.ts
@@ -409,8 +409,8 @@ SEARCH OPERATIONS (impure - access document):
   (text_stats)                  Get document statistics
   (lines start end)             Get lines in range (1-indexed)
 
-SYMBOL OPERATIONS (code files only - requires tree-sitter):
-  (list_symbols)                List all symbols (functions, classes, methods, etc.)
+SYMBOL OPERATIONS (requires tree-sitter - .ts, .js, .py, .go, .md, etc.):
+  (list_symbols)                List all symbols (functions, classes, methods, headings, etc.)
   (list_symbols "kind")         Filter by kind: "function", "class", "method", "interface", "type", "struct"
   (get_symbol_body "name")      Get source code body for a symbol by name
   (get_symbol_body RESULTS)     Get source code body for symbol from previous query

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ Examples:
   rlm "Extract errors" ./logs.txt --constraints '{"type":"array","items":{"type":"string"}}'
   rlm "Find all mentions of 'whale'" ./moby-dick.txt --max-turns 15
   rlm "Count the words" ./file.txt --model llama3 --verbose
+  rlm "List all section headings" ./README.md
 `);
 }
 

--- a/src/lattice-mcp-server.ts
+++ b/src/lattice-mcp-server.ts
@@ -152,8 +152,8 @@ SEARCH (returns handle to matches):
   (fuzzy_search "query" 10)     Fuzzy search - top N matches by relevance
   (lines 10 20)                 Get specific line range
 
-SYMBOL OPERATIONS (code files: .ts, .js, .py, .go):
-  (list_symbols)                List all symbols (functions, classes, methods, etc.)
+SYMBOL OPERATIONS (.ts, .js, .py, .go, .md, and more):
+  (list_symbols)                List all symbols (functions, classes, methods, headings, etc.)
   (list_symbols "function")     Filter by kind: "function", "class", "method", "interface", "type"
   (get_symbol_body "funcName")  Get source code for a symbol
   (find_references "identifier") Find all references to an identifier
@@ -179,6 +179,10 @@ SYMBOL WORKFLOW:
 1. (list_symbols "function")         → Returns: $res1: Array(15) [preview]
 2. (get_symbol_body "myFunction")    → Returns source code directly
 3. (find_references "myFunction")    → Returns: $res2: Array(8) [references]
+
+MARKDOWN WORKFLOW:
+1. (list_symbols)                       → Returns: $res1: Array(12) [# Intro, ## Setup, ...]
+2. (grep "## Installation")             → Find specific section content
 
 VARIABLE BINDING:
 - RESULTS: Always points to the last array result (use in queries)

--- a/src/treesitter/builtin-grammars.ts
+++ b/src/treesitter/builtin-grammars.ts
@@ -326,7 +326,7 @@ export const BUILTIN_GRAMMARS: Record<string, BuiltinGrammar> = {
   },
 
   markdown: {
-    package: "tree-sitter-markdown",
+    package: "@tree-sitter-grammars/tree-sitter-markdown",
     extensions: [".md", ".markdown"],
     symbols: {
       atx_heading: "type",

--- a/src/treesitter/symbol-extractor.ts
+++ b/src/treesitter/symbol-extractor.ts
@@ -167,6 +167,11 @@ export class SymbolExtractor {
       if (symbol) {
         symbols.push(symbol);
       }
+    } else if (language === "markdown" && (node.type === "atx_heading" || node.type === "setext_heading")) {
+      const symbol = this.extractMarkdownHeading(node, parentId);
+      if (symbol) {
+        symbols.push(symbol);
+      }
     } else if (language === "elixir" && node.type === "call") {
       const elixirSymbol = this.extractElixirCallSymbol(node, parentId);
       if (elixirSymbol) {
@@ -342,6 +347,39 @@ export class SymbolExtractor {
       endCol: typeof goEndCol === "number" && Number.isFinite(goEndCol) ? Math.max(0, goEndCol) : 0,
       parentSymbolId: parentId,
     };
+  }
+
+  /**
+   * Extract a markdown heading as a symbol
+   * atx_heading has children: atx_h{N}_marker + inline (the heading text)
+   * setext_heading has children: inline (heading text) + setext_h{N}_underline
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private extractMarkdownHeading(node: any, parentId: number | null): Symbol | null {
+    // Find the inline child which contains the heading text
+    const childLimit = Math.min(node.childCount, MAX_CHILDREN);
+    let headingText: string | null = null;
+    for (let i = 0; i < childLimit; i++) {
+      const child = node.child(i);
+      if (child && child.type === "inline" && child.text) {
+        headingText = child.text.trim();
+        break;
+      }
+    }
+
+    if (!headingText) return null;
+
+    // Determine heading level from marker (e.g., atx_h2_marker → "## Heading")
+    let prefix = "";
+    for (let i = 0; i < childLimit; i++) {
+      const child = node.child(i);
+      if (child && child.type.startsWith("atx_h") && child.type.endsWith("_marker")) {
+        prefix = child.text + " ";
+        break;
+      }
+    }
+
+    return this.buildSymbol(prefix + headingText, node, "type", parentId, "markdown");
   }
 
   /**

--- a/test-fixtures/short-article.md
+++ b/test-fixtures/short-article.md
@@ -1,0 +1,63 @@
+# The Science of Sleep
+
+Sleep is a fundamental biological process essential for human health and well-being.
+Scientists have identified several stages of sleep, each serving different functions.
+
+## Stage 1: Light Sleep
+
+During this initial stage, you transition from wakefulness to sleep. Your heartbeat,
+breathing, and eye movements slow down. Your muscles relax with occasional twitches.
+This stage typically lasts only a few minutes.
+
+## Stage 2: Deeper Light Sleep
+
+Your heartbeat and breathing slow further. Body temperature drops. Eye movements stop.
+Brain wave activity slows but has brief bursts of electrical activity. You spend more
+time in this stage than any other.
+
+## Stage 3: Deep Sleep
+
+This is the period of deep sleep that you need to feel refreshed in the morning.
+Heartbeat and breathing slow to their lowest levels. Muscles are relaxed, and it
+may be difficult to awaken you. This stage is crucial for physical recovery.
+
+## REM Sleep
+
+REM stands for Rapid Eye Movement. During this stage, your eyes move rapidly behind
+closed eyelids. Brain wave activity becomes closer to that of wakefulness. Breathing
+becomes faster and irregular. Heart rate and blood pressure increase to near waking
+levels. Most dreaming occurs during REM sleep.
+
+## The Importance of Sleep
+
+Adequate sleep is crucial for memory consolidation, immune function, hormone regulation,
+and emotional well-being. Adults typically need 7-9 hours of sleep per night. Children
+and teenagers need even more. Chronic sleep deprivation can lead to serious health
+problems including heart disease, diabetes, and depression.
+
+## Tips for Better Sleep
+
+1. Maintain a consistent sleep schedule
+2. Create a restful environment
+3. Limit screen time before bed
+4. Avoid caffeine and alcohol close to bedtime
+5. Exercise regularly, but not too close to bedtime
+6. Manage stress and worries
+
+### Quick Checklist
+
+- Keep your room dark and cool
+- Avoid heavy meals before bedtime
+- Track your sleep routine
+
+| Metric | Recommendation |
+| --- | --- |
+| Adult sleep target | 7-9 hours |
+| Common stages | 4 |
+
+```text
+SLEEP_TOKEN: markdown_fixture
+CATEGORY: health
+```
+
+Understanding and prioritizing sleep can significantly improve quality of life.

--- a/tests/engine/handle-session.test.ts
+++ b/tests/engine/handle-session.test.ts
@@ -287,6 +287,35 @@ DEBUG: Cache hit ratio: 95%`;
       session.loadContent("plain text", "test.txt");
       await expect(session.waitForSymbols()).resolves.toBeUndefined();
     });
+
+    it("should load markdown and allow grep queries", async () => {
+      await expect(session.loadFile("test-fixtures/short-article.md")).resolves.toMatchObject({
+        lineCount: expect.any(Number),
+        size: expect.any(Number),
+      });
+
+      const grepResult = session.execute('(grep "SLEEP_TOKEN")');
+      expect(grepResult.success).toBe(true);
+      expect(grepResult.handle).toBeDefined();
+
+      const expanded = session.expand(grepResult.handle!);
+      expect(expanded.success).toBe(true);
+      expect(expanded.data).toHaveLength(1);
+    });
+
+    it("should extract markdown headings as symbols", async () => {
+      await session.loadFile("test-fixtures/short-article.md");
+      await session.waitForSymbols();
+
+      const symbolResult = session.execute("(list_symbols)");
+      expect(symbolResult.success).toBe(true);
+      expect(symbolResult.handle).toBeDefined();
+
+      const expanded = session.expand(symbolResult.handle!);
+      expect(expanded.success).toBe(true);
+      // short-article.md has 8 headings: 1 h1, 6 h2, 1 h3
+      expect(expanded.data!.length).toBe(8);
+    });
   });
 
   describe("getSessionInfo", () => {

--- a/tests/tool/ai-tools.test.ts
+++ b/tests/tool/ai-tools.test.ts
@@ -75,6 +75,17 @@ describe("AI SDK tool definitions", () => {
       expect(result.stub).toContain("Array(50)");
     });
 
+    it("should load markdown files and query their content", async () => {
+      const markdownFile = path.join(process.cwd(), "test-fixtures/short-article.md");
+
+      const loadResult = await tools.load.execute({ filePath: markdownFile });
+      expect(loadResult.success).toBe(true);
+
+      const queryResult = await tools.query.execute({ command: '(grep "SLEEP_TOKEN")' });
+      expect(queryResult.success).toBe(true);
+      expect(queryResult.handle).toBeDefined();
+    });
+
     it("should expand a handle", async () => {
       await tools.load.execute({ filePath: testFile });
       const queryResult = await tools.query.execute({ command: '(grep "LOG")' });


### PR DESCRIPTION
## Summary
- Replace incompatible `tree-sitter-markdown` (nan-based) with `@tree-sitter-grammars/tree-sitter-markdown` (node-addon-api) so markdown parsing actually works
- Add `extractMarkdownHeading()` to symbol extractor — `list_symbols` now returns headings (e.g., `## Section`) for `.md` files
- Replace `isExtensionSupported` with stricter `canExtractSymbols()` in HandleSession, plus try/catch resilience for symbol extraction failures
- Update tool descriptions in lattice-mcp-server, nucleus-engine, CLI help, and SKILL.md to surface `.md` support to users and LLM agents

## Test plan
- [x] New test: markdown load → grep → expand pipeline (`handle-session.test.ts`)
- [x] New test: markdown heading symbol extraction asserts exactly 8 headings (`handle-session.test.ts`)
- [x] New test: AI SDK tool interface loads and queries markdown (`ai-tools.test.ts`)
- [x] Full suite: 169 test files, 2668 tests pass

## REPL verification
<img width="2329" height="1428" alt="CleanShot 2026-03-23 at 19 10 07@2x" src="https://github.com/user-attachments/assets/ddac2b59-ba8a-4c0d-8503-66435e875f83" />


