### PR TITLE
feat: add --dangerously-skip-cwd-checking flag to skip cwd checkin

### DIFF
--- a/src/lattice-mcp-server.ts
+++ b/src/lattice-mcp-server.ts
@@ -392,13 +392,15 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
         }
 
         // Validate path - reject traversal and paths outside CWD
-        if (filePath.includes("..")) {
-          return { content: [{ type: "text", text: "Error: Path traversal (..) is not allowed" }] };
-        }
-        const resolvedPath = resolve(filePath);
-        const cwd = process.cwd();
-        if (!resolvedPath.startsWith(cwd + sep) && resolvedPath !== cwd) {
-          return { content: [{ type: "text", text: "Error: Path outside working directory is not allowed" }] };
+        if (!skipCwdChecking) {
+          if (filePath.includes("..")) {
+            return { content: [{ type: "text", text: "Error: Path traversal (..) is not allowed" }] };
+          }
+          const resolvedPath = resolve(filePath);
+          const cwd = process.cwd();
+          if (!resolvedPath.startsWith(cwd + sep) && resolvedPath !== cwd) {
+            return { content: [{ type: "text", text: "Error: Path outside working directory is not allowed" }] };
+          }
         }
 
         // Check file size before loading to avoid wasting memory
@@ -583,6 +585,9 @@ process.on("SIGTERM", () => {
   process.exit(0);
 });
 
+// CLI flags
+const skipCwdChecking = process.argv.includes("--dangerously-skip-cwd-checking");
+
 async function main() {
   // Handle version flag
   if (process.argv.includes("-v") || process.argv.includes("--version")) {
@@ -617,6 +622,9 @@ async function main() {
   console.error("[Lattice] MCP server started (handle-based mode)");
   console.error(`[Lattice] Session timeout: ${SESSION_TIMEOUT_MS / 1000}s`);
   console.error(`[Lattice] Max document size: ${MAX_DOCUMENT_SIZE / 1024 / 1024}MB`);
+  if (skipCwdChecking) {
+    console.error("[Lattice] WARNING: CWD path checking is DISABLED (--dangerously-skip-cwd-checking)");
+  }
   console.error("[Lattice] Query results return handle stubs for 97%+ token savings");
 }
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -42,7 +42,13 @@ export interface MCPServerOptions {
   onRunRLM?: (opts: { maxTurns?: number }) => void;
 }
 
+// CLI flags
+const skipCwdChecking = process.argv.includes("--dangerously-skip-cwd-checking");
+
 function validateFilePath(filePath: string): string | null {
+  if (skipCwdChecking) {
+    return null;
+  }
   // Reject path traversal
   if (filePath.includes("..")) {
     return "Path traversal (..) is not allowed";

--- a/src/tool/lattice-tool.ts
+++ b/src/tool/lattice-tool.ts
@@ -44,9 +44,11 @@ export class LatticeTool {
   private engine: NucleusEngine;
   private documentPath: string | null = null;
   private documentName: string | null = null;
+  private skipCwdChecking: boolean;
 
-  constructor() {
+  constructor(options?: { skipCwdChecking?: boolean }) {
     this.engine = new NucleusEngine();
+    this.skipCwdChecking = options?.skipCwdChecking ?? false;
   }
 
   /**
@@ -101,31 +103,42 @@ export class LatticeTool {
         error: "Invalid path: null bytes are not allowed",
       };
     }
-    // Resolve first, then dereference symlinks with realpathSync to prevent bypass
-    const resolved = path.resolve(filePath);
-    const cwd = process.cwd();
-    // Pre-check resolved path before stat/realpath (catches obvious traversal)
-    if (!resolved.startsWith(cwd + path.sep) && resolved !== cwd) {
-      return {
-        success: false,
-        error: `Invalid path: paths outside working directory not allowed`,
-      };
-    }
-    // Dereference symlinks to prevent symlink-based directory escape
     let realResolved: string;
-    try {
-      realResolved = fs.realpathSync(resolved);
-    } catch {
-      return {
-        success: false,
-        error: `Invalid path: cannot resolve file`,
-      };
-    }
-    if (!realResolved.startsWith(cwd + path.sep) && realResolved !== cwd) {
-      return {
-        success: false,
-        error: `Invalid path: paths outside working directory not allowed`,
-      };
+    if (!this.skipCwdChecking) {
+      // Resolve first, then dereference symlinks with realpathSync to prevent bypass
+      const resolved = path.resolve(filePath);
+      const cwd = process.cwd();
+      // Pre-check resolved path before stat/realpath (catches obvious traversal)
+      if (!resolved.startsWith(cwd + path.sep) && resolved !== cwd) {
+        return {
+          success: false,
+          error: `Invalid path: paths outside working directory not allowed`,
+        };
+      }
+      // Dereference symlinks to prevent symlink-based directory escape
+      try {
+        realResolved = fs.realpathSync(resolved);
+      } catch {
+        return {
+          success: false,
+          error: `Invalid path: cannot resolve file`,
+        };
+      }
+      if (!realResolved.startsWith(cwd + path.sep) && realResolved !== cwd) {
+        return {
+          success: false,
+          error: `Invalid path: paths outside working directory not allowed`,
+        };
+      }
+    } else {
+      try {
+        realResolved = fs.realpathSync(path.resolve(filePath));
+      } catch {
+        return {
+          success: false,
+          error: `Invalid path: cannot resolve file`,
+        };
+      }
     }
     try {
       await this.engine.loadFile(realResolved);

--- a/tests/skip-cwd-checking.test.ts
+++ b/tests/skip-cwd-checking.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for --dangerously-skip-cwd-checking flag
+ *
+ * Verifies that:
+ * 1. LatticeTool constructor option bypasses CWD path restriction
+ * 2. Default behavior (no flag) still rejects paths outside CWD
+ * 3. Security baselines survive even when CWD checking is skipped
+ * 4. mcp-server.ts validateFilePath respects the flag via process.argv
+ * 5. lattice-mcp-server.ts guards are properly conditional
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+import { LatticeTool } from "../src/tool/lattice-tool.js";
+
+describe("--dangerously-skip-cwd-checking", () => {
+  let tempDir: string;
+  let outsideFile: string;
+
+  beforeEach(() => {
+    // Create a temp file outside CWD (in /tmp)
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lattice-cwd-test-"));
+    outsideFile = path.join(tempDir, "outside.txt");
+    fs.writeFileSync(outsideFile, "line1\nline2\nline3\nERROR: something broke\nline5");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true });
+  });
+
+  // =========================================================================
+  // LatticeTool — constructor option
+  // =========================================================================
+  describe("LatticeTool({ skipCwdChecking })", () => {
+    describe("default (skipCwdChecking: false)", () => {
+      it("should reject absolute paths outside CWD", async () => {
+        const tool = new LatticeTool();
+        const result = await tool.loadAsync(outsideFile);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/path|outside|not allowed/i);
+      });
+
+      it("should still accept files inside CWD", async () => {
+        const tool = new LatticeTool();
+        // test-fixtures/small.txt is known to exist inside the repo
+        const result = await tool.loadAsync("./test-fixtures/small.txt");
+
+        expect(result.success).toBe(true);
+      });
+    });
+
+    describe("skipCwdChecking: true", () => {
+      it("should allow absolute paths outside CWD", async () => {
+        const tool = new LatticeTool({ skipCwdChecking: true });
+        const result = await tool.loadAsync(outsideFile);
+
+        expect(result.success).toBe(true);
+        expect(result.message).toContain("5 lines");
+      });
+
+      it("should still allow files inside CWD", async () => {
+        const tool = new LatticeTool({ skipCwdChecking: true });
+        const result = await tool.loadAsync("./test-fixtures/small.txt");
+
+        expect(result.success).toBe(true);
+      });
+
+      it("should still reject null bytes (security baseline)", async () => {
+        const tool = new LatticeTool({ skipCwdChecking: true });
+        const result = await tool.loadAsync("/tmp/safe\0/evil");
+
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/null/i);
+      });
+
+      it("should still reject non-existent files", async () => {
+        const tool = new LatticeTool({ skipCwdChecking: true });
+        const result = await tool.loadAsync("/tmp/this-file-definitely-does-not-exist-12345.txt");
+
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/cannot resolve|not found|no such/i);
+      });
+
+      it("should allow querying after loading outside-CWD file", async () => {
+        const tool = new LatticeTool({ skipCwdChecking: true });
+        await tool.loadAsync(outsideFile);
+
+        const result = tool.execute({ type: "query", command: '(grep "ERROR")' });
+
+        expect(result.success).toBe(true);
+        expect(result.message).toContain("Found 1 result");
+      });
+    });
+
+    describe("constructor default matches false", () => {
+      it("should default to skipCwdChecking=false when no options given", async () => {
+        const toolDefault = new LatticeTool();
+        const toolExplicitFalse = new LatticeTool({ skipCwdChecking: false });
+
+        const resultDefault = await toolDefault.loadAsync(outsideFile);
+        const resultExplicit = await toolExplicitFalse.loadAsync(outsideFile);
+
+        // Both should reject
+        expect(resultDefault.success).toBe(false);
+        expect(resultExplicit.success).toBe(false);
+      });
+    });
+  });
+
+  // =========================================================================
+  // mcp-server.ts — validateFilePath via process.argv
+  // =========================================================================
+  describe("mcp-server validateFilePath (process.argv integration)", () => {
+    afterEach(() => {
+      vi.resetModules();
+      // Clean up argv if we added the flag
+      const idx = process.argv.indexOf("--dangerously-skip-cwd-checking");
+      if (idx !== -1) {
+        process.argv.splice(idx, 1);
+      }
+    });
+
+    it("should reject outside-CWD path for nucleus_execute by default", async () => {
+      vi.resetModules();
+      const { createMCPServer } = await import("../src/mcp-server.js");
+      const server = createMCPServer();
+
+      const result = await server.callTool("nucleus_execute", {
+        command: '(grep "test")',
+        filePath: outsideFile,
+      });
+
+      expect(result.content[0].text).toMatch(/error.*path|not allowed/i);
+    });
+
+    it("should reject outside-CWD path for analyze_document by default", async () => {
+      vi.resetModules();
+      const { createMCPServer } = await import("../src/mcp-server.js");
+      const server = createMCPServer();
+
+      const result = await server.callTool("analyze_document", {
+        query: "test",
+        filePath: outsideFile,
+      });
+
+      expect(result.content[0].text).toMatch(/error.*path|not allowed/i);
+    });
+
+    it("should allow outside-CWD path when --dangerously-skip-cwd-checking is in argv", async () => {
+      process.argv.push("--dangerously-skip-cwd-checking");
+      vi.resetModules();
+      const { createMCPServer } = await import("../src/mcp-server.js");
+      const server = createMCPServer();
+
+      const result = await server.callTool("nucleus_execute", {
+        command: '(grep "line")',
+        filePath: outsideFile,
+      });
+
+      // Should NOT contain path error — should succeed or fail for other reasons
+      expect(result.content[0].text).not.toMatch(/path outside|not allowed/i);
+      expect(result.content[0].text).toContain("results");
+    });
+
+    it("should still reject path traversal (..) when flag is NOT set", async () => {
+      vi.resetModules();
+      const { createMCPServer } = await import("../src/mcp-server.js");
+      const server = createMCPServer();
+
+      const result = await server.callTool("nucleus_execute", {
+        command: '(grep "test")',
+        filePath: "../../etc/passwd",
+      });
+
+      expect(result.content[0].text).toMatch(/error.*traversal|not allowed/i);
+    });
+
+    it("should allow path traversal (..) when flag IS set", async () => {
+      process.argv.push("--dangerously-skip-cwd-checking");
+      vi.resetModules();
+      const { createMCPServer } = await import("../src/mcp-server.js");
+      const server = createMCPServer();
+
+      // ../../etc/passwd won't exist or will fail to load, but it should NOT
+      // be rejected by the path validation itself
+      const result = await server.callTool("nucleus_execute", {
+        command: '(grep "test")',
+        filePath: "../../etc/passwd",
+      });
+
+      // Should not be a path-validation error — it'll be a file-not-found or similar
+      expect(result.content[0].text).not.toMatch(/traversal.*not allowed/i);
+    });
+  });
+
+  // =========================================================================
+  // lattice-mcp-server.ts — source-level verification
+  // The handleToolCall function is not exported, so we verify the source
+  // structure ensures the guard is properly conditional on skipCwdChecking.
+  // =========================================================================
+  describe("lattice-mcp-server source structure", () => {
+    const serverSource = fs.readFileSync(
+      path.resolve(__dirname, "../src/lattice-mcp-server.ts"),
+      "utf-8"
+    );
+
+    it("should parse --dangerously-skip-cwd-checking from process.argv", () => {
+      expect(serverSource).toContain('process.argv.includes("--dangerously-skip-cwd-checking")');
+    });
+
+    it("should wrap CWD check in skipCwdChecking conditional", () => {
+      // The path validation block should be inside an if (!skipCwdChecking) guard
+      expect(serverSource).toMatch(/if\s*\(\s*!skipCwdChecking\s*\)/);
+    });
+
+    it("should still contain the original path-outside-CWD error message", () => {
+      // The error message should still exist (just conditionally reached)
+      expect(serverSource).toContain("Path outside working directory is not allowed");
+    });
+
+    it("should still contain the path traversal error message", () => {
+      expect(serverSource).toContain("Path traversal (..) is not allowed");
+    });
+
+    it("should log a warning when CWD checking is disabled", () => {
+      expect(serverSource).toMatch(/WARNING.*CWD.*checking.*DISABLED|CWD.*path.*checking.*DISABLED/i);
+    });
+  });
+});


### PR DESCRIPTION
Thanks for the tool, @yogthos 

I went through my log and found that most lattice tool call from claude code got blocked by cwd checking.
Claude code automatically write tool call result to disk and the agent know where to check for long tool result.
But agent got cwd checking error when using lattice for these kind of files

This PR add `--dangerously-skip-cwd-checking` to skip that

```json
  "tool_use_result": {
    "persistedOutputSize": 344005,
    "isImage": false,
    "persistedOutputPath": "\/Users\/yqrashawn\/.claude\/projects\/-private-var-folders-0x-8sm4swwd66l3lsw3ydk3-sww0000gn-T-cchp-multi-12574037508702015635\/0b6d2d85-f801-4e85-a816-24211fe6de86\/tool-results\/b0yulh89l.txt",
    "noOutputExpected": false,
    "interrupted": false,
    "stderr": "",
    "stdout": "<full tool output>"
```



<img width="3072" height="1066" alt="CleanShot 2026-04-01 at 13 09 52@2x" src="https://github.com/user-attachments/assets/8540c91a-9155-4ece-bb43-96e004b145f2" />
