### PR TITLE
feat: add BM25 ranked text search

### DIFF
--- a/src/engine/nucleus-engine.ts
+++ b/src/engine/nucleus-engine.ts
@@ -12,6 +12,7 @@ import { readFile } from "node:fs/promises";
 import { parse as parseLC } from "../logic/lc-parser.js";
 import { inferType, typeToString } from "../logic/type-inference.js";
 import { solve as solveTerm, validateRegex, type SolverTools, type Bindings } from "../logic/lc-solver.js";
+import { buildBM25Index, searchBM25, type BM25Index } from "../logic/bm25.js";
 
 /**
  * Result of executing a Nucleus command
@@ -149,6 +150,16 @@ function createSolverTools(context: string): SolverTools {
       });
       return results.slice(0, clampedLimit);
     },
+
+    bm25: (() => {
+      let index: BM25Index | null = null;
+      return (query: string, limit: number = 10) => {
+        if (!index) {
+          index = buildBM25Index(lines);
+        }
+        return searchBM25(query, lines, index, undefined, limit);
+      };
+    })(),
 
     text_stats: () => ({ ...textStats }),
   };

--- a/src/logic/bm25.ts
+++ b/src/logic/bm25.ts
@@ -1,0 +1,137 @@
+/**
+ * BM25 search for Nucleus
+ *
+ * Ported from Ori-Mnemos (src/core/bm25.ts) and adapted for
+ * line-based document search instead of vault-based note search.
+ *
+ * BM25 (Best Matching 25) is a ranking function used by search engines
+ * to estimate relevance of documents to a given search query.
+ */
+
+// ── Stopwords (from Ori-Mnemos) ─────────────────────────────────────
+const STOPWORDS = new Set([
+  "a", "an", "and", "are", "as", "at", "be", "by", "for", "from",
+  "has", "he", "in", "is", "it", "its", "of", "on", "or", "that",
+  "the", "to", "was", "were", "will", "with",
+]);
+
+// ── Types ────────────────────────────────────────────────────────────
+export interface BM25Index {
+  termFreqs: Map<string, Map<number, number>>; // term → { lineNum → count }
+  docLengths: Map<number, number>;             // lineNum → token count
+  avgDocLength: number;
+  docCount: number;
+}
+
+export interface BM25Config {
+  k1: number;
+  b: number;
+}
+
+export interface BM25Result {
+  line: string;
+  lineNum: number;
+  score: number;
+}
+
+// ── Default config (from Ori-Mnemos) ────────────────────────────────
+const DEFAULT_BM25: BM25Config = {
+  k1: 1.2,
+  b: 0.75,
+};
+
+// ── Tokenizer (from Ori-Mnemos) ─────────────────────────────────────
+export function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length >= 2 && !STOPWORDS.has(t));
+}
+
+// ── Build index from document lines ─────────────────────────────────
+export function buildBM25Index(
+  lines: string[],
+): BM25Index {
+  const termFreqs = new Map<string, Map<number, number>>();
+  const docLengths = new Map<number, number>();
+
+  for (let i = 0; i < lines.length; i++) {
+    const lineNum = i + 1; // 1-indexed
+    const tokens = tokenize(lines[i]);
+
+    // Count term frequencies for this line
+    const bag = new Map<string, number>();
+    for (const t of tokens) {
+      bag.set(t, (bag.get(t) ?? 0) + 1);
+    }
+
+    docLengths.set(lineNum, tokens.length);
+
+    // Populate inverted index
+    for (const [term, count] of bag) {
+      let lineMap = termFreqs.get(term);
+      if (!lineMap) {
+        lineMap = new Map<number, number>();
+        termFreqs.set(term, lineMap);
+      }
+      lineMap.set(lineNum, count);
+    }
+  }
+
+  const totalLength = Array.from(docLengths.values()).reduce((a, b) => a + b, 0);
+  const avgDocLength = lines.length > 0 ? totalLength / lines.length : 0;
+
+  return {
+    termFreqs,
+    docLengths,
+    avgDocLength,
+    docCount: lines.length,
+  };
+}
+
+// ── BM25 search (scoring from Ori-Mnemos) ───────────────────────────
+export function searchBM25(
+  query: string,
+  lines: string[],
+  index: BM25Index,
+  config: BM25Config = DEFAULT_BM25,
+  limit: number = 10,
+): BM25Result[] {
+  const queryTokens = tokenize(query);
+  if (queryTokens.length === 0) return [];
+
+  const { termFreqs, docLengths, avgDocLength, docCount } = index;
+  const { k1, b } = config;
+  const N = docCount;
+
+  // Collect scores per line
+  const scores = new Map<number, number>();
+
+  for (const term of queryTokens) {
+    const lineMap = termFreqs.get(term);
+    if (!lineMap) continue;
+
+    const n = lineMap.size; // lines containing term
+    const idf = Math.log((N - n + 0.5) / (n + 0.5) + 1);
+
+    for (const [lineNum, tf] of lineMap) {
+      const dl = docLengths.get(lineNum) ?? 0;
+      const tfNorm = (tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (dl / avgDocLength)));
+      const termScore = idf * tfNorm;
+      scores.set(lineNum, (scores.get(lineNum) ?? 0) + termScore);
+    }
+  }
+
+  // Build result array, sort by score, limit
+  const results: BM25Result[] = [];
+  for (const [lineNum, score] of scores) {
+    results.push({
+      line: lines[lineNum - 1] ?? "",
+      lineNum,
+      score,
+    });
+  }
+
+  results.sort((a, b) => b.score - a.score);
+  return results.slice(0, limit);
+}

--- a/src/logic/lc-parser.ts
+++ b/src/logic/lc-parser.ts
@@ -466,6 +466,20 @@ function parseList(state: ParserState): LCTerm | null {
       return { tag: "fuzzy_search", query: query.value, limit };
     }
 
+    case "bm25": {
+      const query = parseTerm(state);
+      if (!query || query.tag !== "lit" || typeof query.value !== "string")
+        return null;
+      // Optional limit
+      const limitTerm = peek(state);
+      let limit: number | undefined;
+      if (limitTerm && limitTerm.type === "number") {
+        consume(state);
+        limit = limitTerm.value;
+      }
+      return { tag: "bm25", query: query.value, limit };
+    }
+
     case "text_stats": {
       return { tag: "text_stats" };
     }
@@ -931,6 +945,10 @@ export function prettyPrint(term: LCTerm): string {
       return term.limit
         ? `(fuzzy_search "${escapeForPrint(term.query)}" ${term.limit})`
         : `(fuzzy_search "${escapeForPrint(term.query)}")`;
+    case "bm25":
+      return term.limit
+        ? `(bm25 "${escapeForPrint(term.query)}" ${term.limit})`
+        : `(bm25 "${escapeForPrint(term.query)}")`;
     case "text_stats":
       return "(text_stats)";
     case "lines":

--- a/src/logic/lc-solver.ts
+++ b/src/logic/lc-solver.ts
@@ -23,6 +23,7 @@ import { SynthesisIntegrator } from "./synthesis-integrator.js";
 export interface SolverTools {
   grep: (pattern: string) => Array<{ match: string; line: string; lineNum: number; index: number; groups: string[] }>;
   fuzzy_search: (query: string, limit?: number) => Array<{ line: string; lineNum: number; score: number }>;
+  bm25: (query: string, limit?: number) => Array<{ line: string; lineNum: number; score: number }>;
   text_stats: () => { length: number; lineCount: number; sample: { start: string; middle: string; end: string } };
   context: string;
 }
@@ -193,6 +194,20 @@ function evaluate(
       log(`[Solver] Executing fuzzy_search("${term.query}", ${fuzzyLimit})`);
       const results = tools.fuzzy_search(term.query, fuzzyLimit);
       log(`[Solver] Found ${results.length} fuzzy matches`);
+      return results;
+    }
+
+    case "bm25": {
+      const bm25Limit = Math.min(Math.max(1, term.limit ?? 10), 1000);
+      log(`[Solver] Executing bm25("${term.query}", ${bm25Limit})`);
+      const results = tools.bm25(term.query, bm25Limit);
+      log(`[Solver] Found ${results.length} BM25 matches`);
+      if (results.length > 0) {
+        log(`[Solver] Top BM25 results:`);
+        results.slice(0, 5).forEach((r, i) => {
+          log(`  ${i + 1}. [line ${r.lineNum}, score ${r.score.toFixed(2)}] ${r.line.slice(0, 80)}`);
+        });
+      }
       return results;
     }
 

--- a/src/logic/type-inference.ts
+++ b/src/logic/type-inference.ts
@@ -52,6 +52,10 @@ function infer(term: LCTerm, env: TypeEnv): LCType {
       // fuzzy_search returns array of {line, lineNum, score}
       return { tag: "array", element: { tag: "any" } };
 
+    case "bm25":
+      // bm25 returns array of {line, lineNum, score}
+      return { tag: "array", element: { tag: "any" } };
+
     case "text_stats":
       // text_stats returns {length, lineCount, sample}
       return { tag: "any" };

--- a/src/logic/types.ts
+++ b/src/logic/types.ts
@@ -20,6 +20,7 @@ export type LCTerm =
   | LCLit
   | LCGrep
   | LCFuzzySearch
+  | LCBm25
   | LCTextStats
   | LCLines
   | LCFilter
@@ -80,6 +81,16 @@ export interface LCGrep {
  */
 export interface LCFuzzySearch {
   tag: "fuzzy_search";
+  query: string;
+  limit?: number;
+}
+
+/**
+ * (bm25 <query> [<limit>]) - BM25 ranked text search
+ * Returns array of {line, lineNum, score} ranked by BM25 relevance
+ */
+export interface LCBm25 {
+  tag: "bm25";
   query: string;
   limit?: number;
 }

--- a/src/rlm.ts
+++ b/src/rlm.ts
@@ -21,6 +21,7 @@ import { parse as parseLC } from "./logic/lc-parser.js";
 import { isClassifyTerm, validateClassifyExamples } from "./logic/lc-compiler.js";
 import { inferType, typeToString } from "./logic/type-inference.js";
 import { solve as solveTerm, validateRegex, type SolverTools, type Bindings } from "./logic/lc-solver.js";
+import * as bm25Module from "./logic/bm25.js";
 
 /**
  * Create SolverTools from document content
@@ -138,6 +139,17 @@ function createSolverTools(context: string): SolverTools {
       results.sort((a, b) => b.score - a.score);
       return results.slice(0, limit);
     },
+
+    bm25: (() => {
+      // Lazy-init BM25 index on first use
+      let index: import("./logic/bm25.js").BM25Index | null = null;
+      return (query: string, limit: number = 10) => {
+        if (!index) {
+          index = bm25Module.buildBM25Index(lines);
+        }
+        return bm25Module.searchBM25(query, lines, index, undefined, limit);
+      };
+    })(),
 
     text_stats: () => ({ ...textStats }),
   };

--- a/tests/audit13.test.ts
+++ b/tests/audit13.test.ts
@@ -36,6 +36,7 @@ function createMockTools(context: string): SolverTools {
       } catch { return []; }
     },
     fuzzy_search: () => [],
+    bm25: () => [],
     text_stats: () => ({ length: context.length, lineCount: lines.length, sample: { start: "", middle: "", end: "" } }),
   };
 }

--- a/tests/integration/diverse-scenarios.test.ts
+++ b/tests/integration/diverse-scenarios.test.ts
@@ -50,6 +50,7 @@ function createMockTools(context: string): SolverTools {
         .filter(r => r.score > 0)
         .slice(0, limit);
     },
+    bm25: (_query: string, _limit = 10) => [],
     text_stats: () => ({
       length: context.length,
       lineCount: lines.length,

--- a/tests/logic/bm25-nucleus.test.ts
+++ b/tests/logic/bm25-nucleus.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for BM25 Nucleus integration
+ * Covers: parser, solver, type inference, prettyPrint
+ */
+
+import { describe, it, expect } from "vitest";
+import { parse, prettyPrint } from "../../src/logic/lc-parser.js";
+import { solve, type SolverTools, type Bindings } from "../../src/logic/lc-solver.js";
+import { inferType } from "../../src/logic/type-inference.js";
+
+// Mock tools that include bm25
+function createMockTools(context: string): SolverTools {
+  const lines = context.split("\n");
+  return {
+    context,
+    grep: (pattern: string) => {
+      const regex = new RegExp(pattern, "gi");
+      const results: Array<{ match: string; line: string; lineNum: number; index: number; groups: string[] }> = [];
+      let match;
+      while ((match = regex.exec(context)) !== null) {
+        const beforeMatch = context.slice(0, match.index);
+        const lineNum = (beforeMatch.match(/\n/g) || []).length + 1;
+        results.push({
+          match: match[0],
+          line: lines[lineNum - 1] || "",
+          lineNum,
+          index: match.index,
+          groups: match.slice(1),
+        });
+      }
+      return results;
+    },
+    fuzzy_search: (query: string, limit = 10) => {
+      return lines
+        .map((line, idx) => ({
+          line,
+          lineNum: idx + 1,
+          score: line.toLowerCase().includes(query.toLowerCase()) ? 100 : 0,
+        }))
+        .filter(r => r.score > 0)
+        .slice(0, limit);
+    },
+    bm25: (query: string, limit = 10) => {
+      // Simple mock: lines containing query terms get scored
+      const queryTerms = query.toLowerCase().split(/\s+/);
+      return lines
+        .map((line, idx) => {
+          const lower = line.toLowerCase();
+          const score = queryTerms.reduce((s, t) => s + (lower.includes(t) ? 10 : 0), 0);
+          return { line, lineNum: idx + 1, score };
+        })
+        .filter(r => r.score > 0)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, limit);
+    },
+    text_stats: () => ({
+      length: context.length,
+      lineCount: lines.length,
+      sample: { start: "", middle: "", end: "" },
+    }),
+  };
+}
+
+const testContext = `[10:00] INFO: System started
+[10:01] ERROR: Failed to connect to database
+[10:02] INFO: Retry scheduled
+[10:03] ERROR: Connection timeout
+[10:04] INFO: Connection established`;
+
+describe("BM25 Parser", () => {
+  it("should parse bm25 with query", () => {
+    const result = parse('(bm25 "database error")');
+    expect(result.success).toBe(true);
+    expect(result.term?.tag).toBe("bm25");
+    if (result.term?.tag === "bm25") {
+      expect(result.term.query).toBe("database error");
+      expect(result.term.limit).toBeUndefined();
+    }
+  });
+
+  it("should parse bm25 with query and limit", () => {
+    const result = parse('(bm25 "database error" 20)');
+    expect(result.success).toBe(true);
+    expect(result.term?.tag).toBe("bm25");
+    if (result.term?.tag === "bm25") {
+      expect(result.term.query).toBe("database error");
+      expect(result.term.limit).toBe(20);
+    }
+  });
+
+  it("should fail on non-string query", () => {
+    const result = parse("(bm25 42)");
+    expect(result.success).toBe(false);
+  });
+
+  it("should fail on empty bm25", () => {
+    const result = parse("(bm25)");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("BM25 prettyPrint", () => {
+  it("should round-trip bm25 without limit", () => {
+    const result = parse('(bm25 "database error")');
+    expect(result.success).toBe(true);
+    const printed = prettyPrint(result.term!);
+    expect(printed).toBe('(bm25 "database error")');
+  });
+
+  it("should round-trip bm25 with limit", () => {
+    const result = parse('(bm25 "database error" 20)');
+    expect(result.success).toBe(true);
+    const printed = prettyPrint(result.term!);
+    expect(printed).toBe('(bm25 "database error" 20)');
+  });
+});
+
+describe("BM25 Type Inference", () => {
+  it("should infer array type for bm25", () => {
+    const result = parse('(bm25 "query")');
+    expect(result.success).toBe(true);
+    const typeResult = inferType(result.term!);
+    expect(typeResult.valid).toBe(true);
+    expect(typeResult.type?.tag).toBe("array");
+  });
+});
+
+describe("BM25 Solver", () => {
+  it("should execute bm25 search and return results", () => {
+    const tools = createMockTools(testContext);
+    const result = parse('(bm25 "error database")');
+    expect(result.success).toBe(true);
+
+    const solveResult = solve(result.term!, tools);
+    expect(solveResult.success).toBe(true);
+    expect(Array.isArray(solveResult.value)).toBe(true);
+    const results = solveResult.value as Array<{ line: string; lineNum: number; score: number }>;
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it("should respect limit in bm25 search", () => {
+    const tools = createMockTools(testContext);
+    const result = parse('(bm25 "error" 1)');
+    expect(result.success).toBe(true);
+
+    const solveResult = solve(result.term!, tools);
+    expect(solveResult.success).toBe(true);
+    const results = solveResult.value as Array<{ line: string }>;
+    expect(results.length).toBeLessThanOrEqual(1);
+  });
+
+  it("should work with filter on bm25 results", () => {
+    const tools = createMockTools(testContext);
+    const bindings: Bindings = new Map();
+
+    // First: run bm25
+    const bm25Result = parse('(bm25 "error connection")');
+    expect(bm25Result.success).toBe(true);
+    const bm25SolveResult = solve(bm25Result.term!, tools);
+    expect(bm25SolveResult.success).toBe(true);
+    bindings.set("RESULTS", bm25SolveResult.value);
+
+    // Then: filter RESULTS
+    const filterResult = parse('(filter RESULTS (lambda line (match line "timeout" 0)))');
+    expect(filterResult.success).toBe(true);
+    const filterSolveResult = solve(filterResult.term!, tools, bindings);
+    expect(filterSolveResult.success).toBe(true);
+  });
+
+  it("should use default limit when none provided", () => {
+    const tools = createMockTools(testContext);
+    const result = parse('(bm25 "error")');
+    expect(result.success).toBe(true);
+    const solveResult = solve(result.term!, tools);
+    expect(solveResult.success).toBe(true);
+    // Default limit is 10, so all matching lines should appear
+    const results = solveResult.value as Array<{ line: string }>;
+    expect(results.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/logic/bm25.test.ts
+++ b/tests/logic/bm25.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for BM25 search (ported from Ori-Mnemos)
+ */
+
+import { describe, it, expect } from "vitest";
+import { tokenize, buildBM25Index, searchBM25 } from "../../src/logic/bm25.js";
+
+describe("BM25 tokenizer", () => {
+  it("should lowercase and split on non-alphanumeric", () => {
+    const tokens = tokenize("Hello World! Testing 123");
+    expect(tokens).toContain("hello");
+    expect(tokens).toContain("world");
+    expect(tokens).toContain("testing");
+    expect(tokens).toContain("123");
+  });
+
+  it("should filter stopwords", () => {
+    const tokens = tokenize("the quick brown fox and the lazy dog");
+    expect(tokens).not.toContain("the");
+    expect(tokens).not.toContain("and");
+    expect(tokens).toContain("quick");
+    expect(tokens).toContain("brown");
+    expect(tokens).toContain("fox");
+    expect(tokens).toContain("lazy");
+    expect(tokens).toContain("dog");
+  });
+
+  it("should filter single-character tokens", () => {
+    const tokens = tokenize("I a b cd ef");
+    expect(tokens).not.toContain("i");
+    expect(tokens).not.toContain("b");
+    expect(tokens).toContain("cd");
+    expect(tokens).toContain("ef");
+  });
+
+  it("should return empty array for empty input", () => {
+    expect(tokenize("")).toEqual([]);
+    expect(tokenize("   ")).toEqual([]);
+  });
+
+  it("should handle all-stopword input", () => {
+    expect(tokenize("the and is are")).toEqual([]);
+  });
+});
+
+describe("BM25 index", () => {
+  const lines = [
+    "ERROR: database connection failed",
+    "INFO: retry scheduled for database",
+    "ERROR: timeout waiting for response",
+    "INFO: connection established successfully",
+    "DEBUG: query executed in 5ms",
+  ];
+
+  it("should build index with correct doc count", () => {
+    const index = buildBM25Index(lines);
+    expect(index.docCount).toBe(5);
+  });
+
+  it("should track term frequencies per line", () => {
+    const index = buildBM25Index(lines);
+    // "database" appears in lines 1 and 2
+    const dbMap = index.termFreqs.get("database");
+    expect(dbMap).toBeDefined();
+    expect(dbMap!.size).toBe(2);
+    expect(dbMap!.has(1)).toBe(true); // line 1
+    expect(dbMap!.has(2)).toBe(true); // line 2
+  });
+
+  it("should compute average document length", () => {
+    const index = buildBM25Index(lines);
+    expect(index.avgDocLength).toBeGreaterThan(0);
+  });
+
+  it("should handle empty lines array", () => {
+    const index = buildBM25Index([]);
+    expect(index.docCount).toBe(0);
+    expect(index.avgDocLength).toBe(0);
+  });
+});
+
+describe("BM25 search", () => {
+  const lines = [
+    "ERROR: database connection failed",
+    "INFO: retry scheduled for database",
+    "ERROR: timeout waiting for response",
+    "INFO: connection established successfully",
+    "DEBUG: query executed in 5ms",
+  ];
+
+  it("should return results ranked by relevance", () => {
+    const index = buildBM25Index(lines);
+    const results = searchBM25("database connection", lines, index);
+
+    expect(results.length).toBeGreaterThan(0);
+    // Line 1 has both "database" and "connection" — should rank highest
+    expect(results[0].lineNum).toBe(1);
+    expect(results[0].score).toBeGreaterThan(0);
+  });
+
+  it("should include line content in results", () => {
+    const index = buildBM25Index(lines);
+    const results = searchBM25("error", lines, index);
+
+    expect(results.length).toBe(2);
+    for (const r of results) {
+      expect(r.line.toLowerCase()).toContain("error");
+      expect(r.lineNum).toBeGreaterThan(0);
+    }
+  });
+
+  it("should respect limit parameter", () => {
+    const index = buildBM25Index(lines);
+    const results = searchBM25("database connection error", lines, index, undefined, 2);
+    expect(results.length).toBeLessThanOrEqual(2);
+  });
+
+  it("should return empty for no matches", () => {
+    const index = buildBM25Index(lines);
+    const results = searchBM25("xyznonexistent", lines, index);
+    expect(results).toEqual([]);
+  });
+
+  it("should return empty for stopword-only query", () => {
+    const index = buildBM25Index(lines);
+    const results = searchBM25("the and is", lines, index);
+    expect(results).toEqual([]);
+  });
+
+  it("should score multi-term matches higher than single-term", () => {
+    const index = buildBM25Index(lines);
+    const results = searchBM25("database connection", lines, index);
+
+    // Line 1 has both terms, line 2 only has "database"
+    if (results.length >= 2) {
+      const line1Score = results.find(r => r.lineNum === 1)?.score ?? 0;
+      const line2Score = results.find(r => r.lineNum === 2)?.score ?? 0;
+      expect(line1Score).toBeGreaterThan(line2Score);
+    }
+  });
+
+  it("should handle repeated terms in query", () => {
+    const index = buildBM25Index(lines);
+    const results = searchBM25("error error error", lines, index);
+    // Should still work, just boosting "error" term
+    expect(results.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/logic/lc-solver-bindings.test.ts
+++ b/tests/logic/lc-solver-bindings.test.ts
@@ -38,6 +38,7 @@ function createMockTools(context: string): SolverTools {
         .filter(r => r.score > 0)
         .slice(0, limit);
     },
+    bm25: (_query: string, _limit = 10) => [],
     text_stats: () => ({
       length: context.length,
       lineCount: lines.length,

--- a/tests/logic/lc-solver-coercion.test.ts
+++ b/tests/logic/lc-solver-coercion.test.ts
@@ -38,6 +38,7 @@ function createMockTools(context: string): SolverTools {
         .filter(r => r.score > 0)
         .slice(0, limit);
     },
+    bm25: (_query: string, _limit = 10) => [],
     text_stats: () => ({
       length: context.length,
       lineCount: lines.length,

--- a/tests/logic/lc-solver-symbols.test.ts
+++ b/tests/logic/lc-solver-symbols.test.ts
@@ -123,6 +123,7 @@ type ID = string | number;
         return results;
       },
       fuzzy_search: () => [],
+      bm25: () => [],
       text_stats: () => ({
         length: sampleCode.length,
         lineCount: sampleCode.split("\n").length,

--- a/tests/logic/lc-solver-synthesis.test.ts
+++ b/tests/logic/lc-solver-synthesis.test.ts
@@ -55,6 +55,7 @@ function createMockTools(content: string): SolverTools {
         .filter((r) => r.score > 0)
         .slice(0, limit);
     },
+    bm25: (_query: string, _limit = 10) => [],
     text_stats: () => ({
       length: content.length,
       lineCount: lines.length,


### PR DESCRIPTION
## Summary
- Port BM25 tokenizer, index builder, and scorer from Ori-Mnemos (`src/core/bm25.ts`), adapted for line-based document search
- Add `(bm25 "query" [limit])` as a new Nucleus operation with full pipeline support: parser, solver, type inference, prettyPrint
- Lazy-initialize BM25 index on first use in both `rlm.ts` and `nucleus-engine.ts`
- Update `SolverTools` interface and all consumers (6 test files + 2 engine files)

## What is BM25?
BM25 (Best Matching 25) is a standard ranking function for keyword search, complementing the existing `grep` (regex) and `fuzzy_search` operations. It provides proper term frequency / inverse document frequency scoring with length normalization — better relevance ranking than simple pattern matching.

## Usage
```scheme
(bm25 "database connection error")        ; top 10 by relevance
(bm25 "database connection error" 5)      ; top 5
(filter (bm25 "error") (lambda x ...))    ; compose with other ops
```

## Test plan
- [x] 16 BM25 core tests (tokenizer, index, search, edge cases)
- [x] 11 Nucleus integration tests (parser, prettyPrint, type inference, solver, composition)
- [x] Full test suite: 172 files, 2714 tests passing
- [x] `tsc --noEmit` clean