### PR TITLE
feat: add RRF fusion for multi-signal search

### DIFF
--- a/src/adapters/nucleus.ts
+++ b/src/adapters/nucleus.ts
@@ -197,7 +197,7 @@ function extractCode(response: string): string | null {
 
   // Check for plain S-expression in raw text
   // Find opening paren and balance to closing
-  const KNOWN_COMMANDS = ["grep", "filter", "map", "reduce", "count", "sum", "lines", "fuzzy_search", "text_stats", "match", "replace", "split", "parseInt", "parseFloat", "parseDate", "parseCurrency", "parseNumber", "coerce", "extract", "synthesize", "lambda", "if", "classify", "predicate", "define-fn", "apply-fn", "list_symbols", "get_symbol_body", "find_references"];
+  const KNOWN_COMMANDS = ["grep", "filter", "map", "reduce", "count", "sum", "lines", "fuzzy_search", "bm25", "fuse", "text_stats", "match", "replace", "split", "parseInt", "parseFloat", "parseDate", "parseCurrency", "parseNumber", "coerce", "extract", "synthesize", "lambda", "if", "classify", "predicate", "define-fn", "apply-fn", "list_symbols", "get_symbol_body", "find_references"];
 
   const MAX_SEXP_ITERATIONS = 200;
   let sexpIterations = 0;

--- a/src/engine/nucleus-engine.ts
+++ b/src/engine/nucleus-engine.ts
@@ -417,6 +417,7 @@ Nucleus Command Reference
 SEARCH OPERATIONS (impure - access document):
   (grep "pattern")              Search for regex pattern, returns matches
   (fuzzy_search "query" limit)  Fuzzy search, returns top matches by relevance
+  (bm25 "query" limit)          BM25 ranked keyword search, returns by relevance
   (text_stats)                  Get document statistics
   (lines start end)             Get lines in range (1-indexed)
 
@@ -426,6 +427,10 @@ SYMBOL OPERATIONS (requires tree-sitter - .ts, .js, .py, .go, .md, etc.):
   (get_symbol_body "name")      Get source code body for a symbol by name
   (get_symbol_body RESULTS)     Get source code body for symbol from previous query
   (find_references "name")      Find all references to an identifier
+
+FUSION:
+  (fuse expr1 expr2 ...)        Fuse results from multiple searches using RRF
+                                Example: (fuse (grep "ERROR") (bm25 "error handling"))
 
 COLLECTION OPERATIONS (pure - work on RESULTS):
   (filter RESULTS pred)         Keep items matching predicate

--- a/src/logic/lc-parser.ts
+++ b/src/logic/lc-parser.ts
@@ -480,6 +480,19 @@ function parseList(state: ParserState): LCTerm | null {
       return { tag: "bm25", query: query.value, limit };
     }
 
+    case "fuse": {
+      // (fuse <coll1> <coll2> [<coll3> ...]) — requires at least 2
+      const MAX_FUSE_ARGS = 10;
+      const collections: LCTerm[] = [];
+      while (peek(state) && peek(state)?.type !== "rparen" && collections.length < MAX_FUSE_ARGS) {
+        const coll = parseTerm(state);
+        if (!coll) break;
+        collections.push(coll);
+      }
+      if (collections.length < 2) return null;
+      return { tag: "fuse", collections };
+    }
+
     case "text_stats": {
       return { tag: "text_stats" };
     }
@@ -949,6 +962,8 @@ export function prettyPrint(term: LCTerm): string {
       return term.limit
         ? `(bm25 "${escapeForPrint(term.query)}" ${term.limit})`
         : `(bm25 "${escapeForPrint(term.query)}")`;
+    case "fuse":
+      return `(fuse ${term.collections.map(c => prettyPrint(c)).join(" ")})`;
     case "text_stats":
       return "(text_stats)";
     case "lines":

--- a/src/logic/lc-solver.ts
+++ b/src/logic/lc-solver.ts
@@ -13,6 +13,7 @@
  */
 
 import type { LCTerm, CoercionType, SynthesisExample } from "./types.js";
+import { fuseRRF, type LineResult } from "./rrf.js";
 import { resolveConstraints } from "./constraint-resolver.js";
 import { run, Rel, eq, conde, exist, failo, type Var, type Substitution } from "../minikanren/index.js";
 import { synthesizeExtractor, compileToFunction, prettyPrint, type Example } from "../synthesis/evalo/index.js";
@@ -209,6 +210,33 @@ function evaluate(
         });
       }
       return results;
+    }
+
+    case "fuse": {
+      // Evaluate all collection sub-expressions
+      const signals: LineResult[][] = [];
+      for (const coll of term.collections) {
+        const result = evaluate(coll, tools, bindings, log, depth + 1);
+        if (!Array.isArray(result)) {
+          throw new Error(`fuse: expected array argument, got ${typeof result}`);
+        }
+        // Normalize to LineResult format — grep results have {match, line, lineNum, index, groups}
+        // bm25/fuzzy have {line, lineNum, score} — ensure all have score
+        const normalized: LineResult[] = (result as unknown[]).map((item: unknown) => {
+          const obj = item as Record<string, unknown>;
+          return {
+            ...(obj as object),             // base fields first (preserves extra fields like match, groups)
+            line: String(obj.line ?? ""),    // sanitized overrides after spread
+            lineNum: Number(obj.lineNum ?? 0),
+            score: Number(obj.score ?? 1),  // grep results lack score — default 1
+          };
+        });
+        signals.push(normalized);
+      }
+      log(`[Solver] Fusing ${signals.length} signals (${signals.map(s => s.length).join(" + ")} results)`);
+      const fused = fuseRRF(signals);
+      log(`[Solver] Fused into ${fused.length} results`);
+      return fused;
     }
 
     case "text_stats": {

--- a/src/logic/rrf.ts
+++ b/src/logic/rrf.ts
@@ -1,0 +1,144 @@
+/**
+ * Reciprocal Rank Fusion for Nucleus
+ *
+ * Ported from Ori-Mnemos (src/core/fusion.ts) and adapted for
+ * line-based document search. Fuses result arrays keyed by lineNum.
+ *
+ * Formula (score-weighted RRF):
+ *   score = Σ_s( weight_s × raw_score_s / (k + rank_s + 1) )
+ *
+ * Where:
+ *   k = smoothing parameter (default 60)
+ *   rank_s = 0-based position in signal's ranked list
+ *   raw_score_s = original score from that signal
+ */
+
+// ── Types ────────────────────────────────────────────────────────────
+
+/** A single search result with line content and score */
+export interface LineResult {
+  line: string;
+  lineNum: number;
+  score: number;
+  [key: string]: unknown; // allow extra fields (match, index, groups from grep)
+}
+
+/** RRF configuration */
+export interface RRFConfig {
+  k: number;
+  weights: number[];  // one weight per input signal
+}
+
+/** Fused result with per-signal score breakdown */
+export interface FusedResult {
+  line: string;
+  lineNum: number;
+  score: number;
+  signals: number[];  // raw score from each input signal (0 if absent)
+}
+
+// ── Default config ──────────────────────────────────────────────────
+
+const DEFAULT_K = 60;
+
+// ── Helpers (from Ori-Mnemos) ───────────────────────────────────────
+
+interface RankEntry {
+  rank: number;
+  score: number;
+  line: string;
+}
+
+/** Build a lineNum → { rank, score, line } lookup for a single signal. */
+function buildIndex(results: LineResult[]): Map<number, RankEntry> {
+  const map = new Map<number, RankEntry>();
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    // Keep first occurrence (highest rank) if duplicates exist
+    if (!map.has(r.lineNum)) {
+      map.set(r.lineNum, { rank: i, score: r.score, line: r.line });
+    }
+  }
+  return map;
+}
+
+/** Normalize weights to sum to 1.0. Clamp negatives to 0. */
+export function normalizeWeights(weights: number[]): number[] {
+  const clamped = weights.map(w => Math.max(0, w));
+  const total = clamped.reduce((a, b) => a + b, 0);
+  if (total <= 0) {
+    // Equal weights fallback
+    const eq = 1 / weights.length;
+    return weights.map(() => eq);
+  }
+  return clamped.map(w => w / total);
+}
+
+// ── Score-weighted RRF (from Ori-Mnemos fuseScoreWeightedRRF) ───────
+
+/**
+ * Fuse multiple result arrays using score-weighted RRF.
+ *
+ * @param signals - Array of result arrays from different search operations
+ * @param config - Optional RRF configuration (k parameter, weights)
+ * @returns Fused results sorted by combined score descending
+ */
+export function fuseRRF(
+  signals: LineResult[][],
+  config?: Partial<RRFConfig>,
+): FusedResult[] {
+  if (signals.length === 0) return [];
+  if (signals.length === 1) {
+    // Single signal — just pass through with score normalization
+    return signals[0].map(r => ({
+      line: r.line,
+      lineNum: r.lineNum,
+      score: r.score,
+      signals: [r.score],
+    }));
+  }
+
+  const k = config?.k ?? DEFAULT_K;
+  const rawWeights = config?.weights ?? signals.map(() => 1);
+
+  // Pad or trim weights to match signal count
+  const paddedWeights = signals.map((_, i) => rawWeights[i] ?? 1);
+  const weights = normalizeWeights(paddedWeights);
+
+  // Build per-signal indexes
+  const indexes = signals.map(s => buildIndex(s));
+
+  // Collect unique lineNums across all signals
+  const lineNums = new Set<number>();
+  for (const signal of signals) {
+    for (const r of signal) {
+      lineNums.add(r.lineNum);
+    }
+  }
+
+  // Fuse
+  const results: FusedResult[] = [];
+
+  for (const lineNum of lineNums) {
+    let fusedScore = 0;
+    const signalScores: number[] = [];
+    let line = "";
+
+    for (let s = 0; s < signals.length; s++) {
+      const entry = indexes[s].get(lineNum);
+      if (entry) {
+        const contribution = (weights[s] * entry.score) / (k + entry.rank + 1);
+        fusedScore += contribution;
+        signalScores.push(entry.score);
+        if (!line) line = entry.line;
+      } else {
+        signalScores.push(0);
+      }
+    }
+
+    results.push({ line, lineNum, score: fusedScore, signals: signalScores });
+  }
+
+  results.sort((a, b) => b.score - a.score);
+  return results;
+}

--- a/src/logic/type-inference.ts
+++ b/src/logic/type-inference.ts
@@ -56,6 +56,10 @@ function infer(term: LCTerm, env: TypeEnv): LCType {
       // bm25 returns array of {line, lineNum, score}
       return { tag: "array", element: { tag: "any" } };
 
+    case "fuse":
+      // fuse returns array of {line, lineNum, score, signals}
+      return { tag: "array", element: { tag: "any" } };
+
     case "text_stats":
       // text_stats returns {length, lineCount, sample}
       return { tag: "any" };

--- a/src/logic/types.ts
+++ b/src/logic/types.ts
@@ -21,6 +21,7 @@ export type LCTerm =
   | LCGrep
   | LCFuzzySearch
   | LCBm25
+  | LCFuse
   | LCTextStats
   | LCLines
   | LCFilter
@@ -93,6 +94,16 @@ export interface LCBm25 {
   tag: "bm25";
   query: string;
   limit?: number;
+}
+
+/**
+ * (fuse <coll1> <coll2> [<coll3> ...]) - fuse multiple result arrays using RRF
+ * Combines results from different search operations (grep, bm25, fuzzy_search)
+ * using score-weighted Reciprocal Rank Fusion
+ */
+export interface LCFuse {
+  tag: "fuse";
+  collections: LCTerm[];
 }
 
 /**

--- a/tests/logic/fuse-nucleus.test.ts
+++ b/tests/logic/fuse-nucleus.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for (fuse ...) Nucleus integration
+ * Covers: parser, solver, type inference, prettyPrint
+ */
+
+import { describe, it, expect } from "vitest";
+import { parse, prettyPrint } from "../../src/logic/lc-parser.js";
+import { solve, type SolverTools, type Bindings } from "../../src/logic/lc-solver.js";
+import { inferType } from "../../src/logic/type-inference.js";
+
+function createMockTools(context: string): SolverTools {
+  const lines = context.split("\n");
+  return {
+    context,
+    grep: (pattern: string) => {
+      const regex = new RegExp(pattern, "gi");
+      const results: Array<{ match: string; line: string; lineNum: number; index: number; groups: string[] }> = [];
+      let match;
+      while ((match = regex.exec(context)) !== null) {
+        const beforeMatch = context.slice(0, match.index);
+        const lineNum = (beforeMatch.match(/\n/g) || []).length + 1;
+        results.push({
+          match: match[0],
+          line: lines[lineNum - 1] || "",
+          lineNum,
+          index: match.index,
+          groups: match.slice(1),
+        });
+      }
+      return results;
+    },
+    fuzzy_search: (query: string, limit = 10) => {
+      return lines
+        .map((line, idx) => ({
+          line,
+          lineNum: idx + 1,
+          score: line.toLowerCase().includes(query.toLowerCase()) ? 100 : 0,
+        }))
+        .filter(r => r.score > 0)
+        .slice(0, limit);
+    },
+    bm25: (query: string, limit = 10) => {
+      const queryTerms = query.toLowerCase().split(/\s+/);
+      return lines
+        .map((line, idx) => {
+          const lower = line.toLowerCase();
+          const score = queryTerms.reduce((s, t) => s + (lower.includes(t) ? 10 : 0), 0);
+          return { line, lineNum: idx + 1, score };
+        })
+        .filter(r => r.score > 0)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, limit);
+    },
+    text_stats: () => ({
+      length: context.length,
+      lineCount: lines.length,
+      sample: { start: "", middle: "", end: "" },
+    }),
+  };
+}
+
+const testContext = `[10:00] INFO: System started
+[10:01] ERROR: Failed to connect to database
+[10:02] INFO: Retry scheduled
+[10:03] ERROR: Connection timeout
+[10:04] INFO: Connection established`;
+
+describe("fuse Parser", () => {
+  it("should parse fuse with two sub-expressions", () => {
+    const result = parse('(fuse (grep "ERROR") (bm25 "error"))');
+    expect(result.success).toBe(true);
+    expect(result.term?.tag).toBe("fuse");
+    if (result.term?.tag === "fuse") {
+      expect(result.term.collections.length).toBe(2);
+      expect(result.term.collections[0].tag).toBe("grep");
+      expect(result.term.collections[1].tag).toBe("bm25");
+    }
+  });
+
+  it("should parse fuse with three sub-expressions", () => {
+    const result = parse('(fuse (grep "ERROR") (bm25 "error") (fuzzy_search "error"))');
+    expect(result.success).toBe(true);
+    if (result.term?.tag === "fuse") {
+      expect(result.term.collections.length).toBe(3);
+    }
+  });
+
+  it("should parse fuse with variable references", () => {
+    const result = parse("(fuse RESULTS _1)");
+    expect(result.success).toBe(true);
+    if (result.term?.tag === "fuse") {
+      expect(result.term.collections.length).toBe(2);
+      expect(result.term.collections[0].tag).toBe("var");
+      expect(result.term.collections[1].tag).toBe("var");
+    }
+  });
+
+  it("should fail on fuse with fewer than 2 arguments", () => {
+    const result = parse('(fuse (grep "ERROR"))');
+    expect(result.success).toBe(false);
+  });
+
+  it("should fail on empty fuse", () => {
+    const result = parse("(fuse)");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("fuse prettyPrint", () => {
+  it("should round-trip fuse with two sub-expressions", () => {
+    const result = parse('(fuse (grep "ERROR") (bm25 "error"))');
+    expect(result.success).toBe(true);
+    const printed = prettyPrint(result.term!);
+    expect(printed).toBe('(fuse (grep "ERROR") (bm25 "error"))');
+  });
+});
+
+describe("fuse Type Inference", () => {
+  it("should infer array type for fuse", () => {
+    const result = parse('(fuse (grep "ERROR") (bm25 "error"))');
+    expect(result.success).toBe(true);
+    const typeResult = inferType(result.term!);
+    expect(typeResult.valid).toBe(true);
+    expect(typeResult.type?.tag).toBe("array");
+  });
+});
+
+describe("fuse Solver", () => {
+  it("should fuse grep and bm25 results", () => {
+    const tools = createMockTools(testContext);
+    const result = parse('(fuse (grep "ERROR") (bm25 "error"))');
+    expect(result.success).toBe(true);
+
+    const solveResult = solve(result.term!, tools);
+    expect(solveResult.success).toBe(true);
+    expect(Array.isArray(solveResult.value)).toBe(true);
+    const results = solveResult.value as Array<{ line: string; lineNum: number; score: number }>;
+    expect(results.length).toBeGreaterThan(0);
+    // Fused results should be sorted by score
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score);
+    }
+  });
+
+  it("should fuse bindings with fresh results", () => {
+    const tools = createMockTools(testContext);
+    const bindings: Bindings = new Map();
+
+    // Simulate a previous grep result stored in _1
+    const grepParse = parse('(grep "ERROR")');
+    const grepResult = solve(grepParse.term!, tools);
+    bindings.set("_1", grepResult.value);
+
+    // Fuse _1 with fresh bm25
+    const fuseParse = parse('(fuse _1 (bm25 "connection"))');
+    expect(fuseParse.success).toBe(true);
+    const fuseResult = solve(fuseParse.term!, tools, bindings);
+    expect(fuseResult.success).toBe(true);
+    expect(Array.isArray(fuseResult.value)).toBe(true);
+  });
+
+  it("should work with filter on fused results", () => {
+    const tools = createMockTools(testContext);
+    const bindings: Bindings = new Map();
+
+    // Fuse and store
+    const fuseParse = parse('(fuse (grep "ERROR") (bm25 "connection"))');
+    const fuseResult = solve(fuseParse.term!, tools);
+    expect(fuseResult.success).toBe(true);
+    bindings.set("RESULTS", fuseResult.value);
+
+    // Filter fused results
+    const filterParse = parse('(filter RESULTS (lambda x (match x "timeout" 0)))');
+    expect(filterParse.success).toBe(true);
+    const filterResult = solve(filterParse.term!, tools, bindings);
+    expect(filterResult.success).toBe(true);
+  });
+
+  it("should normalize grep results that lack score field", () => {
+    const tools = createMockTools(testContext);
+    // grep results have {match, line, lineNum, index, groups} but NO score
+    // fuse must assign default score=1 to them
+    const result = parse('(fuse (grep "ERROR") (bm25 "error"))');
+    expect(result.success).toBe(true);
+
+    const solveResult = solve(result.term!, tools);
+    expect(solveResult.success).toBe(true);
+    const results = solveResult.value as Array<{ line: string; lineNum: number; score: number }>;
+    // All fused results must have numeric scores
+    for (const r of results) {
+      expect(typeof r.score).toBe("number");
+      expect(Number.isFinite(r.score)).toBe(true);
+      expect(r.score).toBeGreaterThan(0);
+    }
+  });
+
+  it("should fuse three signals", () => {
+    const tools = createMockTools(testContext);
+    const result = parse('(fuse (grep "ERROR") (bm25 "error") (fuzzy_search "error"))');
+    expect(result.success).toBe(true);
+
+    const solveResult = solve(result.term!, tools);
+    expect(solveResult.success).toBe(true);
+    expect(Array.isArray(solveResult.value)).toBe(true);
+  });
+});

--- a/tests/logic/rrf.test.ts
+++ b/tests/logic/rrf.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for RRF (Reciprocal Rank Fusion)
+ * Ported from Ori-Mnemos and adapted for line-based search
+ */
+
+import { describe, it, expect } from "vitest";
+import { fuseRRF, normalizeWeights, type LineResult } from "../../src/logic/rrf.js";
+
+describe("normalizeWeights", () => {
+  it("should normalize weights to sum to 1", () => {
+    const result = normalizeWeights([2, 3, 5]);
+    const sum = result.reduce((a, b) => a + b, 0);
+    expect(sum).toBeCloseTo(1.0);
+    expect(result[0]).toBeCloseTo(0.2);
+    expect(result[1]).toBeCloseTo(0.3);
+    expect(result[2]).toBeCloseTo(0.5);
+  });
+
+  it("should clamp negative weights to 0", () => {
+    const result = normalizeWeights([-1, 2, 3]);
+    expect(result[0]).toBe(0);
+    expect(result[1]).toBeCloseTo(0.4);
+    expect(result[2]).toBeCloseTo(0.6);
+  });
+
+  it("should fall back to equal weights when all zero", () => {
+    const result = normalizeWeights([0, 0, 0]);
+    expect(result[0]).toBeCloseTo(1 / 3);
+    expect(result[1]).toBeCloseTo(1 / 3);
+    expect(result[2]).toBeCloseTo(1 / 3);
+  });
+});
+
+describe("fuseRRF", () => {
+  const signal1: LineResult[] = [
+    { line: "ERROR: db failed", lineNum: 1, score: 0.95 },
+    { line: "ERROR: timeout", lineNum: 3, score: 0.80 },
+    { line: "INFO: retry", lineNum: 2, score: 0.50 },
+  ];
+
+  const signal2: LineResult[] = [
+    { line: "INFO: retry", lineNum: 2, score: 0.90 },
+    { line: "ERROR: db failed", lineNum: 1, score: 0.70 },
+    { line: "DEBUG: trace", lineNum: 5, score: 0.30 },
+  ];
+
+  it("should return all unique lines from all signals", () => {
+    const results = fuseRRF([signal1, signal2]);
+    const lineNums = results.map(r => r.lineNum);
+    expect(lineNums).toContain(1); // in both
+    expect(lineNums).toContain(2); // in both
+    expect(lineNums).toContain(3); // only signal1
+    expect(lineNums).toContain(5); // only signal2
+    expect(results.length).toBe(4);
+  });
+
+  it("should rank multi-signal lines higher than single-signal", () => {
+    const results = fuseRRF([signal1, signal2]);
+    // Lines 1 and 2 appear in both signals, should rank higher
+    const multiSignalLines = results.filter(r => r.signals.every(s => s > 0));
+    const singleSignalLines = results.filter(r => r.signals.some(s => s === 0));
+
+    const maxMulti = Math.max(...multiSignalLines.map(r => r.score));
+    const maxSingle = Math.max(...singleSignalLines.map(r => r.score));
+    expect(maxMulti).toBeGreaterThan(maxSingle);
+  });
+
+  it("should preserve per-signal scores", () => {
+    const results = fuseRRF([signal1, signal2]);
+    const line1 = results.find(r => r.lineNum === 1)!;
+    expect(line1.signals[0]).toBe(0.95); // signal1 score
+    expect(line1.signals[1]).toBe(0.70); // signal2 score
+
+    const line5 = results.find(r => r.lineNum === 5)!;
+    expect(line5.signals[0]).toBe(0);    // not in signal1
+    expect(line5.signals[1]).toBe(0.30); // signal2 score
+  });
+
+  it("should sort by fused score descending", () => {
+    const results = fuseRRF([signal1, signal2]);
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score);
+    }
+  });
+
+  it("should handle empty signals", () => {
+    expect(fuseRRF([])).toEqual([]);
+    expect(fuseRRF([[], []])).toEqual([]);
+  });
+
+  it("should pass through single signal", () => {
+    const results = fuseRRF([signal1]);
+    expect(results.length).toBe(3);
+    expect(results[0].lineNum).toBe(1); // highest score
+    expect(results[0].signals).toEqual([0.95]);
+  });
+
+  it("should apply custom weights", () => {
+    // Heavily weight signal2
+    const weighted = fuseRRF([signal1, signal2], { weights: [0.1, 0.9] });
+    // Line 2 is rank 0 in signal2 (score 0.90) — should benefit from high weight
+    const line2 = weighted.find(r => r.lineNum === 2)!;
+    const line1 = weighted.find(r => r.lineNum === 1)!;
+    // With 90% weight on signal2, line 2 (rank 0 in signal2) should score well
+    expect(line2.score).toBeGreaterThan(0);
+    expect(line1.score).toBeGreaterThan(0);
+  });
+
+  it("should apply custom k parameter", () => {
+    const lowK = fuseRRF([signal1, signal2], { k: 1 });
+    const highK = fuseRRF([signal1, signal2], { k: 1000 });
+    // Lower k = higher scores (less smoothing)
+    expect(lowK[0].score).toBeGreaterThan(highK[0].score);
+  });
+
+  it("should handle duplicate lineNums within a signal", () => {
+    const dupSignal: LineResult[] = [
+      { line: "first", lineNum: 1, score: 0.9 },
+      { line: "first again", lineNum: 1, score: 0.5 }, // duplicate
+    ];
+    const results = fuseRRF([dupSignal]);
+    // Should keep first occurrence (higher rank)
+    const line1 = results.find(r => r.lineNum === 1)!;
+    expect(line1.score).toBe(0.9);
+  });
+
+  it("should verify RRF formula manually", () => {
+    const s1: LineResult[] = [{ line: "A", lineNum: 1, score: 1.0 }];
+    const s2: LineResult[] = [{ line: "A", lineNum: 1, score: 0.5 }];
+
+    const k = 60;
+    const results = fuseRRF([s1, s2], { k });
+    const line1 = results.find(r => r.lineNum === 1)!;
+
+    // With equal weights (0.5 each):
+    // signal1: 0.5 * 1.0 / (60 + 0 + 1) = 0.5 / 61
+    // signal2: 0.5 * 0.5 / (60 + 0 + 1) = 0.25 / 61
+    const expected = (0.5 * 1.0) / (k + 0 + 1) + (0.5 * 0.5) / (k + 0 + 1);
+    expect(line1.score).toBeCloseTo(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- Port score-weighted Reciprocal Rank Fusion from Ori-Mnemos
- Add `(fuse expr1 expr2 ...)` Nucleus operation
- Add `bm25`/`fuse` to KNOWN_COMMANDS and command reference
- Fix spread-order bug in solver normalization

See #21 for full details.