### PR TITLE
feat: add Q-value learning reranker

### DIFF
--- a/src/adapters/nucleus.ts
+++ b/src/adapters/nucleus.ts
@@ -197,7 +197,7 @@ function extractCode(response: string): string | null {
 
   // Check for plain S-expression in raw text
   // Find opening paren and balance to closing
-  const KNOWN_COMMANDS = ["grep", "filter", "map", "reduce", "count", "sum", "lines", "fuzzy_search", "bm25", "fuse", "dampen", "text_stats", "match", "replace", "split", "parseInt", "parseFloat", "parseDate", "parseCurrency", "parseNumber", "coerce", "extract", "synthesize", "lambda", "if", "classify", "predicate", "define-fn", "apply-fn", "list_symbols", "get_symbol_body", "find_references"];
+  const KNOWN_COMMANDS = ["grep", "filter", "map", "reduce", "count", "sum", "lines", "fuzzy_search", "bm25", "fuse", "dampen", "rerank", "text_stats", "match", "replace", "split", "parseInt", "parseFloat", "parseDate", "parseCurrency", "parseNumber", "coerce", "extract", "synthesize", "lambda", "if", "classify", "predicate", "define-fn", "apply-fn", "list_symbols", "get_symbol_body", "find_references"];
 
   const MAX_SEXP_ITERATIONS = 200;
   let sexpIterations = 0;

--- a/src/engine/nucleus-engine.ts
+++ b/src/engine/nucleus-engine.ts
@@ -433,6 +433,8 @@ FUSION:
                                 Example: (fuse (grep "ERROR") (bm25 "error handling"))
   (dampen results "query")      Remove false positives by checking term overlap
                                 Example: (dampen (bm25 "error") "database error")
+  (rerank results)              Rerank using Q-value learning (learns across turns)
+                                Example: (rerank (fuse (grep "ERROR") (bm25 "error")))
 
 COLLECTION OPERATIONS (pure - work on RESULTS):
   (filter RESULTS pred)         Keep items matching predicate

--- a/src/logic/lc-parser.ts
+++ b/src/logic/lc-parser.ts
@@ -502,6 +502,12 @@ function parseList(state: ParserState): LCTerm | null {
       return { tag: "dampen", collection, query: query.value };
     }
 
+    case "rerank": {
+      const collection = parseTerm(state);
+      if (!collection) return null;
+      return { tag: "rerank", collection };
+    }
+
     case "text_stats": {
       return { tag: "text_stats" };
     }
@@ -975,6 +981,8 @@ export function prettyPrint(term: LCTerm): string {
       return `(fuse ${term.collections.map(c => prettyPrint(c)).join(" ")})`;
     case "dampen":
       return `(dampen ${prettyPrint(term.collection)} "${escapeForPrint(term.query)}")`;
+    case "rerank":
+      return `(rerank ${prettyPrint(term.collection)})`;
     case "text_stats":
       return "(text_stats)";
     case "lines":

--- a/src/logic/lc-solver.ts
+++ b/src/logic/lc-solver.ts
@@ -15,6 +15,7 @@
 import type { LCTerm, CoercionType, SynthesisExample } from "./types.js";
 import { fuseRRF, type LineResult } from "./rrf.js";
 import { applyGravityDampening, type DampenableResult } from "./dampening.js";
+import { QValueStore, rerank as rerankFn } from "./qvalue.js";
 import { resolveConstraints } from "./constraint-resolver.js";
 import { run, Rel, eq, conde, exist, failo, type Var, type Substitution } from "../minikanren/index.js";
 import { synthesizeExtractor, compileToFunction, prettyPrint, type Example } from "../synthesis/evalo/index.js";
@@ -260,6 +261,45 @@ function evaluate(
       const dampenedCount = results.filter((r, i) => r.score !== dampened[i].score).length;
       log(`[Solver] Dampened ${dampenedCount} of ${results.length} results`);
       return dampened;
+    }
+
+    case "rerank": {
+      const collection = evaluate(term.collection, tools, bindings, log, depth + 1);
+      if (!Array.isArray(collection)) {
+        throw new Error(`rerank: expected array, got ${typeof collection}`);
+      }
+      // Normalize to LineResult format
+      const normalized = (collection as unknown[]).map((item: unknown) => {
+        const obj = item as Record<string, unknown>;
+        return {
+          ...(obj as object),
+          line: String(obj.line ?? ""),
+          lineNum: Number(obj.lineNum ?? 0),
+          score: Number(obj.score ?? 1),
+        };
+      });
+      // Get or create Q-value store from bindings
+      let store = bindings.get("_qstore") as QValueStore | undefined;
+      if (!store) {
+        store = new QValueStore();
+        bindings.set("_qstore", store);
+      }
+      // Auto-reward: if previous RESULTS exist, reward those lines (they were useful enough to query again)
+      const prevResults = bindings.get("RESULTS");
+      if (Array.isArray(prevResults) && prevResults.length > 0) {
+        const prevLineNums = prevResults
+          .filter((r: unknown) => typeof r === "object" && r !== null && "lineNum" in (r as Record<string, unknown>))
+          .map((r: unknown) => Number((r as Record<string, unknown>).lineNum));
+        if (prevLineNums.length > 0) {
+          store.rewardReusedLines(prevLineNums, 0.4);
+          log(`[Solver] Auto-rewarded ${prevLineNums.length} lines from previous RESULTS`);
+        }
+      }
+
+      log(`[Solver] Reranking ${normalized.length} results (Q-store: ${store.getTotalUpdates()} updates)`);
+      const reranked = rerankFn(normalized, store);
+      log(`[Solver] Reranked ${reranked.length} results`);
+      return reranked;
     }
 
     case "text_stats": {

--- a/src/logic/qvalue.ts
+++ b/src/logic/qvalue.ts
@@ -1,0 +1,190 @@
+/**
+ * Q-value learning for Nucleus
+ *
+ * Ported from Ori-Mnemos (src/core/qvalue.ts + src/core/rerank.ts).
+ * Adapted for line-based document search with in-memory storage.
+ *
+ * Learns which lines are useful via exponential moving average Q-updates,
+ * then reranks results using lambda blend + UCB exploration bonus.
+ */
+
+import type { LineResult } from "./rrf.js";
+
+// ── Constants (from Ori-Mnemos) ─────────────────────────────────────
+
+export const ALPHA = 0.1;           // EMA learning rate
+export const DEFAULT_Q = 0.5;       // Initial Q-value
+const LAMBDA_MIN = 0.15;            // Min blend weight for Q-value
+const LAMBDA_MAX = 0.50;            // Max blend weight for Q-value
+const LAMBDA_MATURITY = 200;         // Updates to reach max lambda
+const UCB_C = 0.2;                   // UCB exploration coefficient
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface QEntry {
+  qValue: number;
+  updateCount: number;
+  exposureCount: number;
+  rewardSum: number;
+  rewardSqSum: number;
+}
+
+export interface RerankedResult extends LineResult {
+  qScore: number;
+}
+
+// ── Q-Value Store (in-memory, session-scoped) ───────────────────────
+
+export class QValueStore {
+  private entries = new Map<number, QEntry>(); // lineNum → QEntry
+  private totalUpdates = 0;
+  private totalQueries = 0;
+
+  /** Get Q-value for a line (default 0.5 for unseen lines) */
+  getQ(lineNum: number): number {
+    return this.entries.get(lineNum)?.qValue ?? DEFAULT_Q;
+  }
+
+  /** Get reward statistics for UCB exploration bonus */
+  getRewardStats(lineNum: number): { mean: number; variance: number; count: number } {
+    const entry = this.entries.get(lineNum);
+    if (!entry || entry.updateCount === 0) {
+      return { mean: 0, variance: 0.25, count: 0 };
+    }
+    const mean = entry.rewardSum / entry.updateCount;
+    const variance = entry.rewardSqSum / entry.updateCount - mean * mean;
+    return { mean, variance: Math.max(0, variance), count: entry.updateCount };
+  }
+
+  /** Update Q-value with reward using EMA (from Ori-Mnemos updateQ) */
+  update(lineNum: number, reward: number): void {
+    const entry = this.entries.get(lineNum);
+    const oldQ = entry?.qValue ?? DEFAULT_Q;
+    const newQ = oldQ + ALPHA * (reward - oldQ);
+
+    this.entries.set(lineNum, {
+      qValue: newQ,
+      updateCount: (entry?.updateCount ?? 0) + 1,
+      exposureCount: entry?.exposureCount ?? 0,
+      rewardSum: (entry?.rewardSum ?? 0) + reward,
+      rewardSqSum: (entry?.rewardSqSum ?? 0) + reward * reward,
+    });
+    this.totalUpdates++;
+  }
+
+  /** Batch update multiple lines with rewards */
+  batchUpdate(rewards: Map<number, number>): void {
+    for (const [lineNum, reward] of rewards) {
+      this.update(lineNum, reward);
+    }
+  }
+
+  /** Increment exposure count (line was shown in results) */
+  incrementExposure(lineNum: number): void {
+    const entry = this.entries.get(lineNum);
+    if (entry) {
+      entry.exposureCount++;
+    } else {
+      this.entries.set(lineNum, {
+        qValue: DEFAULT_Q,
+        updateCount: 0,
+        exposureCount: 1,
+        rewardSum: 0,
+        rewardSqSum: 0,
+      });
+    }
+  }
+
+  /** Reward lines that appeared in previous results (auto-reward on reuse) */
+  rewardReusedLines(previousLineNums: number[], reward: number = 0.4): void {
+    for (const lineNum of previousLineNums) {
+      this.update(lineNum, reward);
+    }
+  }
+
+  getTotalUpdates(): number { return this.totalUpdates; }
+  getTotalQueries(): number { return this.totalQueries; }
+  incrementQueryCount(): void { this.totalQueries++; }
+}
+
+// ── Z-score normalization (from Ori-Mnemos rerank.ts) ───────────────
+
+export function zNormalize(values: number[]): number[] {
+  const n = values.length;
+  if (n === 0) return [];
+  const mean = values.reduce((a, b) => a + b, 0) / n;
+  const std = Math.sqrt(values.reduce((a, b) => a + (b - mean) ** 2, 0) / n) || 1;
+  return values.map((v) => (v - mean) / std);
+}
+
+// ── UCB-Tuned exploration bonus (from Ori-Mnemos qvalue.ts) ─────────
+
+export function explorationBonus(
+  stats: { mean: number; variance: number; count: number },
+  totalQueries: number,
+  c: number = UCB_C,
+): number {
+  if (stats.count === 0) return c * 2.5; // big bonus for unseen lines
+  const logT = Math.log(totalQueries + 1);
+  const V = stats.variance + Math.sqrt((2 * logT) / stats.count);
+  return c * Math.sqrt((logT / stats.count) * Math.min(0.25, V));
+}
+
+// ── Lambda computation (from Ori-Mnemos rerank.ts) ──────────────────
+
+export function computeLambda(totalQUpdates: number): number {
+  return LAMBDA_MIN + (LAMBDA_MAX - LAMBDA_MIN) * Math.min(totalQUpdates / LAMBDA_MATURITY, 1.0);
+}
+
+// ── Rerank (Phase B from Ori-Mnemos rerank.ts) ──────────────────────
+
+/**
+ * Rerank results using Q-value learning.
+ *
+ * Blend: final = (1-λ) × sim_normalized + λ × q_normalized + ucb_bonus
+ * With cumulative bias cap to prevent runaway boosts.
+ *
+ * @param results - Search results to rerank
+ * @param store - Q-value store with learned values
+ * @returns Reranked results sorted by blended score
+ */
+export function rerank(
+  results: LineResult[],
+  store: QValueStore,
+): RerankedResult[] {
+  if (results.length === 0) return [];
+
+  const lambda = computeLambda(store.getTotalUpdates());
+  const totalQueries = store.getTotalQueries();
+
+  // Raw scores
+  const simRaw = results.map(r => r.score);
+  const qRaw = results.map(r => store.getQ(r.lineNum));
+
+  // Z-score normalize both
+  const simNorm = zNormalize(simRaw);
+  const qNorm = zNormalize(qRaw);
+
+  const reranked: RerankedResult[] = results.map((r, i) => {
+    // Lambda blend
+    const blended = (1 - lambda) * simNorm[i] + lambda * qNorm[i];
+
+    // UCB exploration bonus
+    const stats = store.getRewardStats(r.lineNum);
+    const ucb = explorationBonus(stats, totalQueries);
+
+    // Raw score
+    const score = blended + ucb;
+
+    // Increment exposure
+    store.incrementExposure(r.lineNum);
+
+    return { ...r, score, qScore: qRaw[i] };
+  });
+
+  // Increment query count
+  store.incrementQueryCount();
+
+  reranked.sort((a, b) => b.score - a.score);
+  return reranked;
+}

--- a/src/logic/type-inference.ts
+++ b/src/logic/type-inference.ts
@@ -64,6 +64,10 @@ function infer(term: LCTerm, env: TypeEnv): LCType {
       // dampen returns array of {line, lineNum, score} (same shape, adjusted scores)
       return { tag: "array", element: { tag: "any" } };
 
+    case "rerank":
+      // rerank returns array of {line, lineNum, score, qScore}
+      return { tag: "array", element: { tag: "any" } };
+
     case "text_stats":
       // text_stats returns {length, lineCount, sample}
       return { tag: "any" };

--- a/src/logic/types.ts
+++ b/src/logic/types.ts
@@ -23,6 +23,7 @@ export type LCTerm =
   | LCBm25
   | LCFuse
   | LCDampen
+  | LCRerank
   | LCTextStats
   | LCLines
   | LCFilter
@@ -116,6 +117,15 @@ export interface LCDampen {
   tag: "dampen";
   collection: LCTerm;
   query: string;
+}
+
+/**
+ * (rerank <collection>) - rerank results using Q-value learning
+ * Blends similarity scores with learned Q-values + UCB exploration bonus
+ */
+export interface LCRerank {
+  tag: "rerank";
+  collection: LCTerm;
 }
 
 /**

--- a/tests/logic/qvalue.test.ts
+++ b/tests/logic/qvalue.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for Q-value learning (ported from Ori-Mnemos)
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  QValueStore,
+  zNormalize,
+  explorationBonus,
+  computeLambda,
+  rerank,
+  ALPHA,
+  DEFAULT_Q,
+} from "../../src/logic/qvalue.js";
+import type { LineResult } from "../../src/logic/rrf.js";
+
+describe("QValueStore", () => {
+  it("should return default Q for unseen lines", () => {
+    const store = new QValueStore();
+    expect(store.getQ(99)).toBe(DEFAULT_Q);
+  });
+
+  it("should update Q via EMA", () => {
+    const store = new QValueStore();
+    store.update(1, 1.0); // reward = 1.0
+    // newQ = 0.5 + 0.1 * (1.0 - 0.5) = 0.55
+    expect(store.getQ(1)).toBeCloseTo(0.55);
+  });
+
+  it("should accumulate Q over multiple updates", () => {
+    const store = new QValueStore();
+    store.update(1, 1.0); // 0.5 + 0.1*(1.0-0.5) = 0.55
+    store.update(1, 1.0); // 0.55 + 0.1*(1.0-0.55) = 0.595
+    store.update(1, 1.0); // 0.595 + 0.1*(1.0-0.595) = 0.6355
+    expect(store.getQ(1)).toBeCloseTo(0.6355);
+  });
+
+  it("should decrease Q on negative reward", () => {
+    const store = new QValueStore();
+    store.update(1, -0.15); // 0.5 + 0.1*(-0.15 - 0.5) = 0.435
+    expect(store.getQ(1)).toBeCloseTo(0.435);
+  });
+
+  it("should track reward statistics", () => {
+    const store = new QValueStore();
+    expect(store.getRewardStats(1).count).toBe(0);
+
+    store.update(1, 0.5);
+    store.update(1, 1.0);
+    const stats = store.getRewardStats(1);
+    expect(stats.count).toBe(2);
+    expect(stats.mean).toBeCloseTo(0.75);
+    expect(stats.variance).toBeGreaterThanOrEqual(0);
+  });
+
+  it("should batch update multiple lines", () => {
+    const store = new QValueStore();
+    const rewards = new Map<number, number>([[1, 0.8], [2, 0.3], [3, -0.1]]);
+    store.batchUpdate(rewards);
+    expect(store.getQ(1)).toBeCloseTo(0.5 + ALPHA * (0.8 - 0.5));
+    expect(store.getQ(2)).toBeCloseTo(0.5 + ALPHA * (0.3 - 0.5));
+    expect(store.getQ(3)).toBeCloseTo(0.5 + ALPHA * (-0.1 - 0.5));
+  });
+
+  it("should track exposure count", () => {
+    const store = new QValueStore();
+    store.incrementExposure(1);
+    store.incrementExposure(1);
+    store.incrementExposure(1);
+    // Internal — verified through rerank behavior
+    expect(store.getQ(1)).toBe(DEFAULT_Q); // exposure doesn't change Q
+  });
+
+  it("should reward reused lines", () => {
+    const store = new QValueStore();
+    store.rewardReusedLines([1, 2, 3], 0.5);
+    expect(store.getQ(1)).toBeCloseTo(0.5 + ALPHA * (0.5 - 0.5)); // = 0.5 (reward == Q)
+    expect(store.getTotalUpdates()).toBe(3);
+  });
+
+  it("should track total updates and queries", () => {
+    const store = new QValueStore();
+    expect(store.getTotalUpdates()).toBe(0);
+    expect(store.getTotalQueries()).toBe(0);
+    store.update(1, 0.5);
+    store.update(2, 0.5);
+    store.incrementQueryCount();
+    expect(store.getTotalUpdates()).toBe(2);
+    expect(store.getTotalQueries()).toBe(1);
+  });
+});
+
+describe("zNormalize", () => {
+  it("should normalize to zero mean and unit variance", () => {
+    const result = zNormalize([1, 2, 3, 4, 5]);
+    const mean = result.reduce((a, b) => a + b, 0) / result.length;
+    expect(mean).toBeCloseTo(0);
+  });
+
+  it("should handle constant values", () => {
+    const result = zNormalize([5, 5, 5]);
+    // std=0 → use 1, so (5-5)/1 = 0 for all
+    expect(result).toEqual([0, 0, 0]);
+  });
+
+  it("should return empty for empty input", () => {
+    expect(zNormalize([])).toEqual([]);
+  });
+
+  it("should handle single value", () => {
+    const result = zNormalize([42]);
+    expect(result).toEqual([0]); // (42-42)/1 = 0
+  });
+});
+
+describe("explorationBonus", () => {
+  it("should give big bonus for unseen items", () => {
+    const bonus = explorationBonus({ mean: 0, variance: 0.25, count: 0 }, 10);
+    expect(bonus).toBe(0.2 * 2.5); // = 0.5
+  });
+
+  it("should decrease with more observations", () => {
+    const bonus1 = explorationBonus({ mean: 0.5, variance: 0.1, count: 1 }, 10);
+    const bonus10 = explorationBonus({ mean: 0.5, variance: 0.1, count: 10 }, 10);
+    expect(bonus1).toBeGreaterThan(bonus10);
+  });
+
+  it("should increase with more total queries (exploration pressure)", () => {
+    const bonus10 = explorationBonus({ mean: 0.5, variance: 0.1, count: 5 }, 10);
+    const bonus100 = explorationBonus({ mean: 0.5, variance: 0.1, count: 5 }, 100);
+    expect(bonus100).toBeGreaterThan(bonus10);
+  });
+});
+
+describe("computeLambda", () => {
+  it("should start at LAMBDA_MIN with no updates", () => {
+    expect(computeLambda(0)).toBeCloseTo(0.15);
+  });
+
+  it("should reach LAMBDA_MAX at maturity", () => {
+    expect(computeLambda(200)).toBeCloseTo(0.50);
+  });
+
+  it("should be between min and max during training", () => {
+    const lambda = computeLambda(100);
+    expect(lambda).toBeGreaterThan(0.15);
+    expect(lambda).toBeLessThan(0.50);
+  });
+});
+
+describe("rerank", () => {
+  const results: LineResult[] = [
+    { line: "ERROR: database failed", lineNum: 1, score: 0.9 },
+    { line: "INFO: retry scheduled", lineNum: 2, score: 0.7 },
+    { line: "ERROR: timeout", lineNum: 3, score: 0.5 },
+    { line: "DEBUG: trace output", lineNum: 4, score: 0.3 },
+  ];
+
+  it("should rerank based on Q-values", () => {
+    const store = new QValueStore();
+    // Train line 3 to have high Q
+    for (let i = 0; i < 10; i++) store.update(3, 1.0);
+    // Train line 1 to have low Q
+    for (let i = 0; i < 10; i++) store.update(1, -0.15);
+
+    const reranked = rerank(results, store);
+    expect(reranked.length).toBe(4);
+    // Line 3 should be boosted by high Q-value
+    // Check that it's not at the bottom anymore
+    const line3Rank = reranked.findIndex(r => r.lineNum === 3);
+    expect(line3Rank).toBeLessThan(3); // should be boosted from rank 2
+  });
+
+  it("should return empty for empty input", () => {
+    const store = new QValueStore();
+    expect(rerank([], store)).toEqual([]);
+  });
+
+  it("should sort by score descending", () => {
+    const store = new QValueStore();
+    const reranked = rerank(results, store);
+    for (let i = 1; i < reranked.length; i++) {
+      expect(reranked[i - 1].score).toBeGreaterThanOrEqual(reranked[i].score);
+    }
+  });
+
+  it("should include qScore in output", () => {
+    const store = new QValueStore();
+    store.update(1, 0.8);
+    const reranked = rerank(results, store);
+    const line1 = reranked.find(r => r.lineNum === 1)!;
+    expect(line1.qScore).toBeDefined();
+    expect(typeof line1.qScore).toBe("number");
+  });
+
+  it("should give exploration bonus to unseen lines", () => {
+    const store = new QValueStore();
+    // Only train line 1, leave others unseen
+    store.update(1, 0.5);
+    store.incrementQueryCount();
+    store.incrementQueryCount();
+
+    const reranked = rerank(results, store);
+    // Unseen lines get UCB bonus — they shouldn't all be at bottom
+    const unseenLineNums = [2, 3, 4];
+    const unseenRanks = unseenLineNums.map(ln =>
+      reranked.findIndex(r => r.lineNum === ln)
+    );
+    // At least one unseen line should not be last
+    expect(unseenRanks.some(r => r < 3)).toBe(true);
+  });
+});

--- a/tests/logic/rerank-nucleus.test.ts
+++ b/tests/logic/rerank-nucleus.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for (rerank ...) Nucleus integration
+ */
+
+import { describe, it, expect } from "vitest";
+import { parse, prettyPrint } from "../../src/logic/lc-parser.js";
+import { solve, type SolverTools, type Bindings } from "../../src/logic/lc-solver.js";
+import { inferType } from "../../src/logic/type-inference.js";
+import { QValueStore } from "../../src/logic/qvalue.js";
+
+function createMockTools(context: string): SolverTools {
+  const lines = context.split("\n");
+  return {
+    context,
+    grep: (pattern: string) => {
+      const regex = new RegExp(pattern, "gi");
+      const results: Array<{ match: string; line: string; lineNum: number; index: number; groups: string[] }> = [];
+      let match;
+      while ((match = regex.exec(context)) !== null) {
+        const beforeMatch = context.slice(0, match.index);
+        const lineNum = (beforeMatch.match(/\n/g) || []).length + 1;
+        results.push({ match: match[0], line: lines[lineNum - 1] || "", lineNum, index: match.index, groups: match.slice(1) });
+      }
+      return results;
+    },
+    fuzzy_search: (query: string, limit = 10) =>
+      lines.map((line, idx) => ({ line, lineNum: idx + 1, score: line.toLowerCase().includes(query.toLowerCase()) ? 100 : 0 })).filter(r => r.score > 0).slice(0, limit),
+    bm25: (query: string, limit = 10) => {
+      const terms = query.toLowerCase().split(/\s+/);
+      return lines.map((line, idx) => ({ line, lineNum: idx + 1, score: terms.reduce((s, t) => s + (line.toLowerCase().includes(t) ? 10 : 0), 0) })).filter(r => r.score > 0).sort((a, b) => b.score - a.score).slice(0, limit);
+    },
+    text_stats: () => ({ length: context.length, lineCount: lines.length, sample: { start: "", middle: "", end: "" } }),
+  };
+}
+
+const testContext = `[10:00] INFO: System started
+[10:01] ERROR: Failed to connect to database
+[10:02] INFO: Retry scheduled
+[10:03] ERROR: Connection timeout
+[10:04] INFO: Connection established`;
+
+describe("rerank Parser", () => {
+  it("should parse rerank with collection", () => {
+    const result = parse('(rerank (bm25 "error"))');
+    expect(result.success).toBe(true);
+    expect(result.term?.tag).toBe("rerank");
+    if (result.term?.tag === "rerank") {
+      expect(result.term.collection.tag).toBe("bm25");
+    }
+  });
+
+  it("should parse rerank with variable", () => {
+    const result = parse("(rerank RESULTS)");
+    expect(result.success).toBe(true);
+    if (result.term?.tag === "rerank") {
+      expect(result.term.collection.tag).toBe("var");
+    }
+  });
+
+  it("should fail on empty rerank", () => {
+    expect(parse("(rerank)").success).toBe(false);
+  });
+});
+
+describe("rerank prettyPrint", () => {
+  it("should round-trip", () => {
+    const result = parse('(rerank (bm25 "error"))');
+    expect(result.success).toBe(true);
+    expect(prettyPrint(result.term!)).toBe('(rerank (bm25 "error"))');
+  });
+});
+
+describe("rerank Type Inference", () => {
+  it("should infer array type", () => {
+    const result = parse('(rerank (bm25 "error"))');
+    expect(result.success).toBe(true);
+    const typeResult = inferType(result.term!);
+    expect(typeResult.valid).toBe(true);
+    expect(typeResult.type?.tag).toBe("array");
+  });
+});
+
+describe("rerank Solver", () => {
+  it("should rerank bm25 results", () => {
+    const tools = createMockTools(testContext);
+    const bindings: Bindings = new Map();
+    bindings.set("_qstore", new QValueStore());
+
+    const result = parse('(rerank (bm25 "error connection"))');
+    expect(result.success).toBe(true);
+    const solveResult = solve(result.term!, tools, bindings);
+    expect(solveResult.success).toBe(true);
+    expect(Array.isArray(solveResult.value)).toBe(true);
+    const results = solveResult.value as Array<{ line: string; score: number }>;
+    expect(results.length).toBeGreaterThan(0);
+    // Should be sorted by score
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score);
+    }
+  });
+
+  it("should work without explicit QValueStore (creates one)", () => {
+    const tools = createMockTools(testContext);
+    const result = parse('(rerank (bm25 "error"))');
+    expect(result.success).toBe(true);
+    const solveResult = solve(result.term!, tools);
+    expect(solveResult.success).toBe(true);
+    expect(Array.isArray(solveResult.value)).toBe(true);
+  });
+
+  it("should compose with filter", () => {
+    const tools = createMockTools(testContext);
+    const bindings: Bindings = new Map();
+
+    const rerankParse = parse('(rerank (bm25 "error"))');
+    const rerankResult = solve(rerankParse.term!, tools);
+    expect(rerankResult.success).toBe(true);
+    bindings.set("RESULTS", rerankResult.value);
+
+    const filterParse = parse('(filter RESULTS (lambda x (match x "timeout" 0)))');
+    const filterResult = solve(filterParse.term!, tools, bindings);
+    expect(filterResult.success).toBe(true);
+  });
+
+  it("should auto-reward previous RESULTS lines", () => {
+    const tools = createMockTools(testContext);
+    const bindings: Bindings = new Map();
+    const store = new QValueStore();
+    bindings.set("_qstore", store);
+
+    // First turn: bm25 search
+    const bm25Parse = parse('(bm25 "error")');
+    const bm25Result = solve(bm25Parse.term!, tools, bindings);
+    bindings.set("RESULTS", bm25Result.value);
+
+    // Second turn: rerank — should auto-reward lines from RESULTS
+    const rerankParse = parse('(rerank (bm25 "error connection"))');
+    expect(rerankParse.success).toBe(true);
+    const rerankResult = solve(rerankParse.term!, tools, bindings);
+    expect(rerankResult.success).toBe(true);
+
+    // Q-store should have updates from auto-reward
+    expect(store.getTotalUpdates()).toBeGreaterThan(0);
+  });
+
+  it("should compose with fuse then rerank", () => {
+    const tools = createMockTools(testContext);
+    const result = parse('(rerank (fuse (grep "ERROR") (bm25 "error")))');
+    expect(result.success).toBe(true);
+    const solveResult = solve(result.term!, tools);
+    expect(solveResult.success).toBe(true);
+    expect(Array.isArray(solveResult.value)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Port Q-value store (EMA update, UCB-Tuned exploration bonus) and reranker (z-normalize, lambda blend) from Ori-Mnemos
- Add `(rerank collection)` Nucleus operation that learns which lines are useful across turns
- Session-scoped in-memory Q-value store with auto-reward: when previous RESULTS are reused in a subsequent `rerank`, those lines get positive feedback

## How Q-Value Learning Works
1. **First use**: All lines start at Q=0.5 with UCB exploration bonus for unseen lines
2. **Auto-reward**: When `rerank` runs and bindings contain previous RESULTS, those lines get +0.4 reward (they were useful enough to trigger another query)
3. **EMA blend**: `final = (1-λ) × sim_normalized + λ × q_normalized + ucb_bonus`
4. **Lambda adapts**: Starts at 0.15 (trust similarity), grows to 0.50 as Q-values accumulate updates

## Usage
```scheme
;; Basic rerank
(rerank (bm25 "error handling"))

;; Full pipeline: fuse → dampen → rerank
(rerank (dampen (fuse (grep "ERROR") (bm25 "error")) "error"))

;; Across turns: RESULTS from turn 1 auto-rewarded in turn 2
;; Turn 1: (bm25 "error")
;; Turn 2: (rerank (bm25 "error connection"))  ; previous RESULTS lines get +0.4 reward
```

## Review fixes
- Removed bias cap (scale mismatch: z-normalized scores vs raw scores made cap either useless or destructive)
- Added auto-reward path — without it, Q-values never learned (the learning half was dead code)

## Test plan
- [x] 24 Q-value core tests (EMA, UCB, z-normalize, lambda, store, batch update)
- [x] 10 Nucleus integration tests (parser, prettyPrint, type inference, solver, auto-reward, composition)
- [x] Full test suite: 178 files, 2800 tests passing
- [x] `tsc --noEmit` clean