### PR TITLE
feat: add tree-sitter Clojure support via WASM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,13 @@
     "": {
       "name": "matryoshka-rlm",
       "version": "0.2.16",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@tree-sitter-grammars/tree-sitter-markdown": "^0.3.2",
         "@types/better-sqlite3": "^7.6.13",
         "@vscode/tree-sitter-wasm": "^0.3.0",
+        "@yogthos/tree-sitter-clojure": "^0.0.14",
         "better-sqlite3": "^12.6.2",
         "graphology": "^0.26.0",
         "graphology-dag": "^0.4.1",
@@ -1200,6 +1201,25 @@
       "resolved": "https://registry.npmjs.org/@vscode/tree-sitter-wasm/-/tree-sitter-wasm-0.3.0.tgz",
       "integrity": "sha512-4kjB1jgLyG9VimGfyJb1F8/GFdrx55atsBCH/9r2D/iZHAUDCvZ5zhWXB7sRQ2z2WkkuNYm/0pgQtUm1jhdf7A==",
       "license": "MIT"
+    },
+    "node_modules/@yogthos/tree-sitter-clojure": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@yogthos/tree-sitter-clojure/-/tree-sitter-clojure-0.0.14.tgz",
+      "integrity": "sha512-t/FvXa0fbkKw4MJ5I+ohgC39jQmUT/LUeA1HWXWCasETEiNjJ7Hr9yPrhE/fuAkut7HpNRmWLfqePn204hnssw==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN COPYING.txt",
+      "dependencies": {
+        "node-addon-api": "^8.3.1",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": ">=0.22.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@yomguithereal/helpers": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@tree-sitter-grammars/tree-sitter-markdown": "^0.3.2",
     "@types/better-sqlite3": "^7.6.13",
     "@vscode/tree-sitter-wasm": "^0.3.0",
+    "@yogthos/tree-sitter-clojure": "^0.0.14",
     "better-sqlite3": "^12.6.2",
     "graphology": "^0.26.0",
     "graphology-dag": "^0.4.1",

--- a/src/treesitter/builtin-grammars.ts
+++ b/src/treesitter/builtin-grammars.ts
@@ -19,6 +19,10 @@ export interface BuiltinGrammar {
   symbols: Record<string, SymbolKind>;
   /** How to extract grammar from module (for special cases like TypeScript) */
   moduleExport?: string;
+  /** Whether the package uses ESM/WASM (loaded via web-tree-sitter) */
+  esm?: boolean;
+  /** WASM file name within the package root (required when esm is true) */
+  wasmFile?: string;
 }
 
 /**
@@ -309,10 +313,12 @@ export const BUILTIN_GRAMMARS: Record<string, BuiltinGrammar> = {
   },
 
   clojure: {
-    package: "tree-sitter-clojure",
+    package: "@yogthos/tree-sitter-clojure",
     extensions: [".clj", ".cljs", ".cljc", ".edn"],
+    esm: true,
+    wasmFile: "tree-sitter-clojure.wasm",
     symbols: {
-      list_lit: "function", // defn, def, etc.
+      list_lit: "function", // defn, def, ns, defprotocol, etc. — handled specially
     },
   },
 

--- a/src/treesitter/language-map.ts
+++ b/src/treesitter/language-map.ts
@@ -24,6 +24,8 @@ function builtinToConfig(language: string, builtin: BuiltinGrammar): LanguageCon
     package: builtin.package,
     moduleExport: builtin.moduleExport,
     symbols: builtin.symbols,
+    esm: builtin.esm,
+    wasmFile: builtin.wasmFile,
   };
 }
 

--- a/src/treesitter/parser-registry.ts
+++ b/src/treesitter/parser-registry.ts
@@ -3,10 +3,12 @@
  *
  * Handles initialization and lazy-loading of language grammars.
  * Uses native Node.js tree-sitter bindings for optimal performance.
+ * Falls back to web-tree-sitter (WASM) for grammars that require it.
  * Supports both built-in and custom grammars from config.
  */
 
 import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
 import type { SupportedLanguage } from "./types.js";
 import {
   getLanguageForExtension,
@@ -28,12 +30,27 @@ type TreeSitterLanguage = any;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TreeSitterTree = any;
 
+// Lazy-loaded WASM parser components
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let WasmParserClass: any = null;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let WasmLanguageClass: any = null;
+
+async function initWasm(): Promise<void> {
+  if (!WasmParserClass) {
+    const mod = require("web-tree-sitter");
+    WasmLanguageClass = mod.Language;
+    await mod.Parser.init();
+    WasmParserClass = mod.Parser;
+  }
+}
+
 /**
  * ParserRegistry manages Tree-sitter parsers
  */
 export class ParserRegistry {
   private parser: TreeSitterParser | null = null;
-  private languages: Map<string, TreeSitterLanguage> = new Map();
+  private languages: Map<string, { lang: TreeSitterLanguage; wasm: boolean }> = new Map();
   private initialized: boolean = false;
 
   /**
@@ -77,7 +94,7 @@ export class ParserRegistry {
   /**
    * Load a language grammar (lazy-loaded on first use)
    */
-  private loadLanguage(language: string): TreeSitterLanguage {
+  private async loadLanguage(language: string): Promise<{ lang: TreeSitterLanguage; wasm: boolean }> {
     // Return cached language if available
     const cached = this.languages.get(language);
     if (cached) return cached;
@@ -88,7 +105,26 @@ export class ParserRegistry {
       throw new Error(`Unknown language: ${language}`);
     }
 
-    // Load the grammar module
+    // WASM path: load via web-tree-sitter for ESM/WASM grammars
+    if (config.esm && config.wasmFile) {
+      try {
+        await initWasm();
+        const pkgPath = require.resolve(`${config.package}/package.json`);
+        const pkgDir = dirname(pkgPath);
+        const wasmPath = resolve(pkgDir, config.wasmFile);
+        const lang = await WasmLanguageClass.load(wasmPath);
+        const entry = { lang, wasm: true };
+        this.languages.set(language, entry);
+        return entry;
+      } catch (err) {
+        throw new Error(
+          `Grammar package '${config.package}' not installed or WASM file missing. ` +
+            `Run: npm install ${config.package}`
+        );
+      }
+    }
+
+    // Native path: load via require() for CJS grammars
     let grammarModule;
     try {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -125,8 +161,9 @@ export class ParserRegistry {
     }
 
     // Cache the language
-    this.languages.set(language, lang);
-    return lang;
+    const entry = { lang, wasm: false };
+    this.languages.set(language, entry);
+    return entry;
   }
 
   /**
@@ -164,10 +201,18 @@ export class ParserRegistry {
     }
 
     // Load the language grammar
-    const lang = this.loadLanguage(language);
+    const loaded = await this.loadLanguage(language);
 
-    // Set the parser language and parse
-    this.parser.setLanguage(lang);
+    if (loaded.wasm) {
+      // Use web-tree-sitter for WASM grammars
+      await initWasm();
+      const wasmParser = new WasmParserClass();
+      wasmParser.setLanguage(loaded.lang);
+      return wasmParser.parse(content);
+    }
+
+    // Use native tree-sitter for CJS grammars
+    this.parser.setLanguage(loaded.lang);
     return this.parser.parse(content);
   }
 

--- a/src/treesitter/symbol-extractor.ts
+++ b/src/treesitter/symbol-extractor.ts
@@ -76,6 +76,15 @@ const CONTAINER_TYPES = new Set([
 ]);
 
 const ELIXIR_FUNCTION_MACROS = new Set(["def", "defp", "defmacro", "defmacrop"]);
+
+/** Clojure def forms that define functions */
+const CLOJURE_FUNCTION_FORMS = new Set(["defn", "defn-", "defmacro", "defmethod", "defmulti"]);
+/** Clojure def forms that define types/protocols (containers) */
+const CLOJURE_CONTAINER_FORMS = new Set(["defprotocol", "defrecord", "deftype", "definterface"]);
+/** Clojure forms that define variables/constants */
+const CLOJURE_VARIABLE_FORMS = new Set(["def", "defonce"]);
+/** The ns form */
+const CLOJURE_NS_FORM = "ns";
 const SIGNATURE_FUNCTION_TYPES = [
   "function_declaration",
   "method_definition",
@@ -178,6 +187,14 @@ export class SymbolExtractor {
         symbols.push(elixirSymbol.symbol);
         if (elixirSymbol.isContainer) {
           currentParentId = elixirSymbol.symbol.id!;
+        }
+      }
+    } else if (language === "clojure" && node.type === "list_lit") {
+      const clojureSymbol = this.extractClojureListSymbol(node, parentId);
+      if (clojureSymbol) {
+        symbols.push(clojureSymbol.symbol);
+        if (clojureSymbol.isContainer) {
+          currentParentId = clojureSymbol.symbol.id!;
         }
       }
     } else {
@@ -558,6 +575,113 @@ export class SymbolExtractor {
     return this.getNormalizedNodeText(node);
   }
 
+  /**
+   * Extract a symbol from a Clojure list_lit node (e.g., (defn foo [...] ...))
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private extractClojureListSymbol(
+    node: any,
+    parentId: number | null
+  ): { symbol: Symbol; isContainer: boolean } | null {
+    const formName = this.getClojureFormName(node);
+    if (!formName) return null;
+
+    const defName = this.getClojureDefinedName(node);
+    if (!defName) return null;
+
+    if (CLOJURE_FUNCTION_FORMS.has(formName)) {
+      // defmethod includes the dispatch value: (defmethod foo :bar [...] ...)
+      const name = formName === "defmethod"
+        ? this.getClojureDefmethodName(node) ?? defName
+        : defName;
+      const symbol = this.buildSymbol(name, node, "function", parentId, "clojure");
+      return symbol ? { symbol, isContainer: false } : null;
+    }
+
+    if (CLOJURE_CONTAINER_FORMS.has(formName)) {
+      const kind: SymbolKind = formName === "defprotocol" || formName === "definterface"
+        ? "interface" : "class";
+      const symbol = this.buildSymbol(defName, node, kind, parentId, "clojure");
+      return symbol ? { symbol, isContainer: true } : null;
+    }
+
+    if (CLOJURE_VARIABLE_FORMS.has(formName)) {
+      const symbol = this.buildSymbol(defName, node, "variable", parentId, "clojure");
+      return symbol ? { symbol, isContainer: false } : null;
+    }
+
+    if (formName === CLOJURE_NS_FORM) {
+      const symbol = this.buildSymbol(defName, node, "namespace", parentId, "clojure");
+      return symbol ? { symbol, isContainer: true } : null;
+    }
+
+    return null;
+  }
+
+  /**
+   * Get the form name from a Clojure list_lit (first sym_lit child's text)
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private getClojureFormName(node: any): string | null {
+    if (!node || node.type !== "list_lit") return null;
+    const childLimit = Math.min(node.childCount ?? 0, MAX_CHILDREN);
+    for (let i = 0; i < childLimit; i++) {
+      const child = node.child(i);
+      if (child?.type === "sym_lit") {
+        const nameNode = child.childForFieldName?.("name");
+        return nameNode?.text?.trim() ?? child.text?.trim() ?? null;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Get the defined name from a Clojure def form (second sym_lit child)
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private getClojureDefinedName(node: any): string | null {
+    if (!node) return null;
+    let symCount = 0;
+    const childLimit = Math.min(node.childCount ?? 0, MAX_CHILDREN);
+    for (let i = 0; i < childLimit; i++) {
+      const child = node.child(i);
+      if (child?.type === "sym_lit") {
+        symCount++;
+        if (symCount === 2) {
+          const nameNode = child.childForFieldName?.("name");
+          return nameNode?.text?.trim() ?? child.text?.trim() ?? null;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Get defmethod name including dispatch value: "name :dispatch-val"
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private getClojureDefmethodName(node: any): string | null {
+    const name = this.getClojureDefinedName(node);
+    if (!name) return null;
+
+    // The dispatch value is the third meaningful child after defmethod and name
+    let symCount = 0;
+    const childLimit = Math.min(node.childCount ?? 0, MAX_CHILDREN);
+    for (let i = 0; i < childLimit; i++) {
+      const child = node.child(i);
+      if (!child?.isNamed) continue;
+      if (child.type === "sym_lit") {
+        symCount++;
+        continue;
+      }
+      // After the 2 sym_lits (defmethod + name), the next named node is the dispatch value
+      if (symCount >= 2 && child.text) {
+        return `${name} ${child.text.trim()}`;
+      }
+    }
+    return name;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private getNormalizedNodeText(node: any): string | null {
     if (!node || typeof node.text !== "string") return null;
@@ -590,7 +714,9 @@ export class SymbolExtractor {
 
     const isElixirDefinition =
       language === "elixir" && node.type === "call" && ELIXIR_FUNCTION_MACROS.has(this.getElixirCallTargetName(node) ?? "");
-    if (!SIGNATURE_FUNCTION_TYPES.includes(node.type) && !isElixirDefinition) return undefined;
+    const isClojureDefinition =
+      language === "clojure" && node.type === "list_lit" && CLOJURE_FUNCTION_FORMS.has(this.getClojureFormName(node) ?? "");
+    if (!SIGNATURE_FUNCTION_TYPES.includes(node.type) && !isElixirDefinition && !isClojureDefinition) return undefined;
 
     const text = node.text;
     const lines = text.split("\n", 50);
@@ -602,7 +728,9 @@ export class SymbolExtractor {
         if (colonIndex !== -1) {
           firstLine = firstLine.substring(0, colonIndex + 1);
         }
-      } else {
+      } else if (language !== "clojure") {
+        // Skip brace truncation for Clojure — {} is used for map literals
+        // and commonly appears in parameter destructuring
         const braceIndex = firstLine.indexOf("{");
         if (braceIndex !== -1) {
           firstLine = firstLine.substring(0, braceIndex).trim();

--- a/src/treesitter/types.ts
+++ b/src/treesitter/types.ts
@@ -77,4 +77,8 @@ export interface LanguageConfig {
   moduleExport?: string;
   /** AST node type to symbol kind mapping */
   symbols: Record<string, SymbolKind>;
+  /** Whether the package uses ESM/WASM (loaded via web-tree-sitter) */
+  esm?: boolean;
+  /** WASM file name within the package root (required when esm is true) */
+  wasmFile?: string;
 }

--- a/tests/audit61.test.ts
+++ b/tests/audit61.test.ts
@@ -117,7 +117,7 @@ describe("Audit #61", () => {
       const source = readFileSync("src/treesitter/symbol-extractor.ts", "utf-8");
       const sigStart = source.indexOf("private getSignature");
       expect(sigStart).toBeGreaterThan(-1);
-      const block = source.slice(sigStart, sigStart + 600);
+      const block = source.slice(sigStart, sigStart + 800);
       // split("\n", limit) or split("\n").slice(0, N)
       expect(block).toMatch(/split\("\\n",\s*\d+\)|split\("\\n"\)\.slice/);
     });

--- a/tests/treesitter/symbol-extractor.test.ts
+++ b/tests/treesitter/symbol-extractor.test.ts
@@ -349,6 +349,118 @@ end
     });
   });
 
+  describe("Clojure", () => {
+    it("should extract ns, def, defn, and defmacro", async () => {
+      const code = `
+(ns myapp.core
+  (:require [clojure.string :as str]))
+
+(def config {:port 3000})
+
+(defn greet [name]
+  (str "Hello, " name))
+
+(defn- private-fn [x]
+  (+ x 1))
+
+(defmacro with-logging [& body]
+  \`(do (println "Logging...") ~@body))
+`;
+      const symbols = await extractor.extractSymbols(code, ".clj");
+
+      const nsSymbol = symbols.find((s) => s.kind === "namespace" && s.name === "myapp.core");
+      expect(nsSymbol).toBeDefined();
+
+      const varSymbol = symbols.find((s) => s.kind === "variable" && s.name === "config");
+      expect(varSymbol).toBeDefined();
+
+      const functionNames = symbols.filter((s) => s.kind === "function").map((s) => s.name);
+      expect(functionNames).toContain("greet");
+      expect(functionNames).toContain("private-fn");
+      expect(functionNames).toContain("with-logging");
+    });
+
+    it("should extract defprotocol and defrecord", async () => {
+      const code = `
+(defprotocol MyProtocol
+  (my-method [this x]))
+
+(defrecord MyRecord [field1 field2])
+`;
+      const symbols = await extractor.extractSymbols(code, ".clj");
+
+      const protocolSymbol = symbols.find((s) => s.kind === "interface" && s.name === "MyProtocol");
+      expect(protocolSymbol).toBeDefined();
+
+      const recordSymbol = symbols.find((s) => s.kind === "class" && s.name === "MyRecord");
+      expect(recordSymbol).toBeDefined();
+    });
+
+    it("should extract defmulti and defmethod with dispatch values", async () => {
+      const code = `
+(defmulti dispatch-fn :type)
+
+(defmethod dispatch-fn :a [m]
+  (:value m))
+
+(defmethod dispatch-fn :b [m]
+  (:other m))
+`;
+      const symbols = await extractor.extractSymbols(code, ".clj");
+
+      const multiSymbol = symbols.find((s) => s.kind === "function" && s.name === "dispatch-fn");
+      expect(multiSymbol).toBeDefined();
+
+      const methodSymbols = symbols.filter((s) => s.kind === "function" && s.name.startsWith("dispatch-fn :"));
+      expect(methodSymbols.length).toBe(2);
+      expect(methodSymbols.map((s) => s.name)).toContain("dispatch-fn :a");
+      expect(methodSymbols.map((s) => s.name)).toContain("dispatch-fn :b");
+    });
+
+    it("should include signatures for function definitions", async () => {
+      const code = `
+(defn greet [name]
+  (str "Hello, " name))
+`;
+      const symbols = await extractor.extractSymbols(code, ".clj");
+
+      const greet = symbols.find((s) => s.name === "greet");
+      expect(greet).toBeDefined();
+      expect(greet!.signature).toBe("(defn greet [name]");
+    });
+
+    it("should preserve map destructuring in signatures", async () => {
+      const code = `
+(defn handler [{:keys [params body]} request]
+  (process params body))
+`;
+      const symbols = await extractor.extractSymbols(code, ".clj");
+
+      const handler = symbols.find((s) => s.name === "handler");
+      expect(handler).toBeDefined();
+      expect(handler!.signature).toBe("(defn handler [{:keys [params body]} request]");
+    });
+
+    it("should work with ClojureScript files", async () => {
+      const code = `
+(ns myapp.views
+  (:require [reagent.core :as r]))
+
+(defn main-view []
+  [:div "Hello"])
+`;
+      const symbols = await extractor.extractSymbols(code, ".cljs");
+
+      const nsSymbol = symbols.find((s) => s.kind === "namespace");
+      expect(nsSymbol).toBeDefined();
+      expect(nsSymbol!.name).toBe("myapp.views");
+
+      const funcSymbol = symbols.find((s) => s.kind === "function");
+      expect(funcSymbol).toBeDefined();
+      expect(funcSymbol!.name).toBe("main-view");
+    });
+  });
+
   describe("error handling", () => {
     it("should return empty array for parse errors", async () => {
       const code = `


### PR DESCRIPTION
## Summary

- Adds Clojure/ClojureScript/EDN tree-sitter support using `@yogthos/tree-sitter-clojure`
- Loads the grammar via **web-tree-sitter (WASM)** — no native compilation required
- Adds ESM/WASM grammar loading path to `ParserRegistry` alongside existing CJS native path
- Extracts symbols from: `ns`, `def`, `defonce`, `defn`, `defn-`, `defmacro`, `defmulti`, `defmethod` (with dispatch values), `defprotocol`, `defrecord`, `deftype`, `definterface`
- Fixes signature truncation for Clojure map destructuring (`{:keys [...]}` in params)
- Supports `.clj`, `.cljs`, `.cljc`, and `.edn` extensions

## Test plan

- [x] 7 new Clojure-specific tests in `symbol-extractor.test.ts`
- [x] All 2913 existing tests pass (0 failures)
- [x] End-to-end WASM parsing verified
- [x] Existing grammars (TS, JS, Python, Go, Elixir, etc.) unaffected