### PR TITLE
feat(lc): add (llm_query ...) symbolic-recursion primitive + full async refactor

### DIFF
--- a/src/adapters/nucleus.ts
+++ b/src/adapters/nucleus.ts
@@ -37,12 +37,17 @@ TRANSFORM:
 (count RESULTS)   (sum RESULTS)
 
 SUB-LLM (semantic work on what grep/filter can't express):
-(llm_query "Classify each error into a category: {items}" (items RESULTS))
+(llm_query "Summarize the data below: {items}" (items RESULTS))
+  — one sub-LLM call over the whole binding
+(map RESULTS (lambda x (llm_query "classify: {item}" (item x))))
+  — one sub-LLM call PER ITEM, returns an array of strings
+(filter RESULTS (lambda x (match (llm_query "keep?: {item}" (item x)) "keep" 0)))
+  — semantic predicate, keep items whose sub-LLM response matches
+Rules:
   — prompt is a literal string with {name} placeholders
-  — each (name BINDING) fills one placeholder with the binding's value
+  — each (name TERM) fills one placeholder with TERM's evaluated value
   — use for open-ended semantic tasks (classification, summarization,
     paraphrase) that don't reduce to regex patterns
-  — result is a string bound to _N; the next turn sees its provenance
 
 CODE (when analyzing code):
 (list_symbols)  (list_symbols "function")

--- a/src/adapters/nucleus.ts
+++ b/src/adapters/nucleus.ts
@@ -36,6 +36,14 @@ TRANSFORM:
 (map RESULTS (lambda x (match x "pat" 1)))
 (count RESULTS)   (sum RESULTS)
 
+SUB-LLM (semantic work on what grep/filter can't express):
+(llm_query "Classify each error into a category: {items}" (items RESULTS))
+  — prompt is a literal string with {name} placeholders
+  — each (name BINDING) fills one placeholder with the binding's value
+  — use for open-ended semantic tasks (classification, summarization,
+    paraphrase) that don't reduce to regex patterns
+  — result is a string bound to _N; the next turn sees its provenance
+
 CODE (when analyzing code):
 (list_symbols)  (list_symbols "function")
 (get_symbol_body "name")  (find_references "name")
@@ -198,7 +206,7 @@ function extractCode(response: string): string | null {
 
   // Check for plain S-expression in raw text
   // Find opening paren and balance to closing
-  const KNOWN_COMMANDS = ["grep", "filter", "map", "reduce", "count", "sum", "lines", "fuzzy_search", "bm25", "semantic", "fuse", "dampen", "rerank", "text_stats", "match", "replace", "split", "parseInt", "parseFloat", "parseDate", "parseCurrency", "parseNumber", "coerce", "extract", "synthesize", "lambda", "if", "classify", "predicate", "define-fn", "apply-fn", "list_symbols", "get_symbol_body", "find_references", "callers", "callees", "ancestors", "descendants", "implementations", "dependents", "symbol_graph"];
+  const KNOWN_COMMANDS = ["grep", "filter", "map", "reduce", "count", "sum", "lines", "fuzzy_search", "bm25", "semantic", "fuse", "dampen", "rerank", "text_stats", "match", "replace", "split", "parseInt", "parseFloat", "parseDate", "parseCurrency", "parseNumber", "coerce", "extract", "synthesize", "lambda", "if", "classify", "predicate", "define-fn", "apply-fn", "list_symbols", "get_symbol_body", "find_references", "callers", "callees", "ancestors", "descendants", "implementations", "dependents", "symbol_graph", "llm_query"];
 
   const MAX_SEXP_ITERATIONS = 200;
   let sexpIterations = 0;

--- a/src/engine/handle-session.ts
+++ b/src/engine/handle-session.ts
@@ -333,12 +333,12 @@ export class HandleSession {
    * Arrays are stored in SQLite and a handle stub is returned.
    * Scalars are returned directly.
    */
-  execute(command: string): HandleResult {
+  async execute(command: string): Promise<HandleResult> {
     this.lastAccessedAt = new Date();
     this.queryCount++;
 
     // Execute via NucleusEngine
-    const result = this.engine.execute(command);
+    const result = await this.engine.execute(command);
 
     if (!result.success) {
       return {

--- a/src/engine/nucleus-engine.ts
+++ b/src/engine/nucleus-engine.ts
@@ -263,10 +263,14 @@ export class NucleusEngine {
   /**
    * Execute a Nucleus command
    *
+   * Became async in the chunked refactor that made `solve()` return
+   * `Promise<SolveResult>`. Callers that previously did
+   * `const r = engine.execute(cmd)` must now `await` it.
+   *
    * @param command - Nucleus S-expression (e.g., "(grep \"pattern\")")
    * @returns Execution result with value, logs, and any errors
    */
-  execute(command: string): ExecutionResult {
+  async execute(command: string): Promise<ExecutionResult> {
     if (!this.solverTools) {
       return {
         success: false,
@@ -299,7 +303,7 @@ export class NucleusEngine {
     }
 
     // Execute the term
-    const solverResult = solveTerm(parseResult.term, this.solverTools, this.bindings);
+    const solverResult = await solveTerm(parseResult.term, this.solverTools, this.bindings);
 
     // Update bindings for cross-query state
     this.turnCounter++;
@@ -369,11 +373,19 @@ export class NucleusEngine {
   /**
    * Execute multiple commands in sequence
    *
+   * Must be sequential, not parallel (`Promise.all(map(execute))`),
+   * because each command may mutate cross-turn bindings (`_1`, `_2`,
+   * `RESULTS`) that a later command reads.
+   *
    * @param commands - Array of Nucleus commands
    * @returns Array of execution results
    */
-  executeAll(commands: string[]): ExecutionResult[] {
-    return commands.map(cmd => this.execute(cmd));
+  async executeAll(commands: string[]): Promise<ExecutionResult[]> {
+    const results: ExecutionResult[] = [];
+    for (const cmd of commands) {
+      results.push(await this.execute(cmd));
+    }
+    return results;
   }
 
   /**

--- a/src/fsm/rlm-states.ts
+++ b/src/fsm/rlm-states.ts
@@ -14,7 +14,7 @@ import type { FSMSpec, State } from "repl-sandbox";
 import { parse as parseLC } from "../logic/lc-parser.js";
 import { isClassifyTerm, validateClassifyExamples } from "../logic/lc-compiler.js";
 import { inferType, typeToString } from "../logic/type-inference.js";
-import { solve as solveTerm } from "../logic/lc-solver.js";
+import { solveAsync as solveTermAsync } from "../logic/lc-solver.js";
 import { analyzeExecution, getEncouragement } from "../feedback/execution-feedback.js";
 import { verifyResult } from "../constraints/verifier.js";
 import { generateClassifierGuidance } from "../rlm.js";
@@ -38,6 +38,16 @@ export interface RLMContext {
   turn: number;
   history: Array<{ role: "system" | "user" | "assistant"; content: string }>;
   solverBindings: Bindings;
+  /**
+   * Per-binding provenance — the raw LC source of the term that produced
+   * each binding. Populated in `handleExecute` from `ctx.extractedCode`
+   * and surfaced to the LLM in the "Bindings available" section of the
+   * analysis feedback. Without this, opaque names like `_3` carry no
+   * semantic information across turns, which matters a lot once sub-LLM
+   * calls chain together (a later `(llm_query …)` needs to know what
+   * `_3` contains to reference it sensibly).
+   */
+  solverBindingProvenance: Map<string, string>;
 
   // Turn-specific (reset each turn)
   response: string;
@@ -269,7 +279,7 @@ function handleValidate(ctx: RLMContext): RLMContext {
   return ctx;
 }
 
-function handleExecute(ctx: RLMContext): RLMContext {
+async function handleExecute(ctx: RLMContext): Promise<RLMContext> {
   if (!ctx.parsedTerm || !ctx.extractedCode) return ctx;
 
   ctx.log(`[Turn ${ctx.turn}] Executing LC term with solver...`);
@@ -278,7 +288,9 @@ function handleExecute(ctx: RLMContext): RLMContext {
     ctx.log(`[Turn ${ctx.turn}] Available bindings: ${[...ctx.solverBindings.keys()].join(", ")}`);
   }
 
-  const solverResult = solveTerm(ctx.parsedTerm, ctx.solverTools, ctx.solverBindings);
+  // solveTermAsync handles top-level `(llm_query …)` by calling
+  // `tools.llmQuery`; everything else flows through the sync `solve()`.
+  const solverResult = await solveTermAsync(ctx.parsedTerm, ctx.solverTools, ctx.solverBindings);
   ctx.solverResult = {
     success: solverResult.success,
     value: solverResult.value,
@@ -290,12 +302,26 @@ function handleExecute(ctx: RLMContext): RLMContext {
   if (solverResult.success && solverResult.value !== null && solverResult.value !== undefined) {
     ctx.solverBindings.set(`_${ctx.turn}`, solverResult.value);
 
+    // Record provenance — the raw LC source the LLM emitted this turn.
+    // This is what makes `_N` descriptive across turns: the next
+    // "Bindings available" section shows each name next to the code
+    // that produced it, so the LLM doesn't have to remember what `_3`
+    // was for.
+    const MAX_PROVENANCE_LEN = 160;
+    const provenance = (ctx.extractedCode || "").length > MAX_PROVENANCE_LEN
+      ? (ctx.extractedCode || "").slice(0, MAX_PROVENANCE_LEN) + "…"
+      : (ctx.extractedCode || "");
+    ctx.solverBindingProvenance.set(`_${ctx.turn}`, provenance);
+
     if (Array.isArray(solverResult.value)) {
       const MAX_RESULTS_SIZE = 100000;
       const cappedValue = solverResult.value.length > MAX_RESULTS_SIZE
         ? solverResult.value.slice(0, MAX_RESULTS_SIZE)
         : solverResult.value;
       ctx.solverBindings.set("RESULTS", cappedValue);
+      // RESULTS always reflects the most recent array binding — its
+      // provenance is whatever produced this turn's result.
+      ctx.solverBindingProvenance.set("RESULTS", provenance);
       ctx.previousResultCount = ctx.lastResultCount;
       ctx.lastResultCount = cappedValue.length;
       ctx.log(`[Turn ${ctx.turn}] Bound result to RESULTS and _${ctx.turn}`);
@@ -319,6 +345,9 @@ function handleExecute(ctx: RLMContext): RLMContext {
       const toRemove = turnKeys.slice(0, Math.max(0, turnKeys.length - maxTurnKeys));
       for (const key of toRemove) {
         ctx.solverBindings.delete(key);
+        // Keep provenance in lockstep so we never surface a stub for a
+        // binding that has already been evicted from the values map.
+        ctx.solverBindingProvenance.delete(key);
       }
     }
   } else {
@@ -454,6 +483,41 @@ function handleAnalyze(ctx: RLMContext): RLMContext {
   }
 
   feedback += `\n\n${ctx.adapter.getSuccessFeedback(ctx.lastResultCount, ctx.previousResultCount, ctx.query)}`;
+
+  // Bindings summary with provenance — lets the LLM see what each `_N`
+  // contains without having to remember or re-derive it from history.
+  // Essential for chaining `(llm_query …)` calls, where a later call
+  // needs to know which prior binding to reference.
+  if (ctx.solverBindings.size > 0) {
+    const MAX_BINDINGS_SHOWN = 16;
+    const keys = [...ctx.solverBindings.keys()];
+    const shown = keys.slice(-MAX_BINDINGS_SHOWN);
+    const skipped = keys.length - shown.length;
+
+    const summarizeValue = (val: unknown): string => {
+      if (val === null || val === undefined) return "null";
+      if (Array.isArray(val)) return `Array(${val.length})`;
+      if (typeof val === "string") return `String(${val.length})`;
+      if (typeof val === "number") return `Number(${val})`;
+      if (typeof val === "boolean") return `Bool(${val})`;
+      return typeof val;
+    };
+
+    const lines = shown.map((name) => {
+      const val = ctx.solverBindings.get(name);
+      const provenance = ctx.solverBindingProvenance.get(name);
+      const shape = summarizeValue(val);
+      return provenance
+        ? `  ${name} : ${shape}   ← ${provenance}`
+        : `  ${name} : ${shape}`;
+    });
+    const bindingsBlock = lines.join("\n");
+    const prefix = skipped > 0
+      ? `\n\nBindings available for next turn (${skipped} older entries omitted):\n`
+      : `\n\nBindings available for next turn:\n`;
+    feedback += `${prefix}${bindingsBlock}`;
+  }
+
   ctx.history.push({ role: "user", content: feedback });
 
   return ctx;
@@ -624,6 +688,7 @@ export function createInitialContext(opts: {
       { role: "user", content: opts.userMessage },
     ],
     solverBindings: new Map(),
+    solverBindingProvenance: new Map(),
 
     response: "",
     extractedCode: null,

--- a/src/fsm/rlm-states.ts
+++ b/src/fsm/rlm-states.ts
@@ -14,7 +14,7 @@ import type { FSMSpec, State } from "repl-sandbox";
 import { parse as parseLC } from "../logic/lc-parser.js";
 import { isClassifyTerm, validateClassifyExamples } from "../logic/lc-compiler.js";
 import { inferType, typeToString } from "../logic/type-inference.js";
-import { solveAsync as solveTermAsync } from "../logic/lc-solver.js";
+import { solve as solveTerm } from "../logic/lc-solver.js";
 import { analyzeExecution, getEncouragement } from "../feedback/execution-feedback.js";
 import { verifyResult } from "../constraints/verifier.js";
 import { generateClassifierGuidance } from "../rlm.js";
@@ -288,9 +288,10 @@ async function handleExecute(ctx: RLMContext): Promise<RLMContext> {
     ctx.log(`[Turn ${ctx.turn}] Available bindings: ${[...ctx.solverBindings.keys()].join(", ")}`);
   }
 
-  // solveTermAsync handles top-level `(llm_query …)` by calling
-  // `tools.llmQuery`; everything else flows through the sync `solve()`.
-  const solverResult = await solveTermAsync(ctx.parsedTerm, ctx.solverTools, ctx.solverBindings);
+  // solve() is fully async — it handles `(llm_query …)` both at the
+  // top level and inside nested map/filter/reduce lambdas, dispatching
+  // via `tools.llmQuery` when available.
+  const solverResult = await solveTerm(ctx.parsedTerm, ctx.solverTools, ctx.solverBindings);
   ctx.solverResult = {
     success: solverResult.success,
     value: solverResult.value,

--- a/src/lattice-mcp-server.ts
+++ b/src/lattice-mcp-server.ts
@@ -564,7 +564,7 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
 
         resetInactivityTimer();
 
-        const result = session.execute(command);
+        const result = await session.execute(command);
         return { content: [{ type: "text", text: formatHandleResult(result) }] };
       }
 

--- a/src/logic/lc-parser.ts
+++ b/src/logic/lc-parser.ts
@@ -864,6 +864,59 @@ function parseList(state: ParserState, depth: number = 0): LCTerm | null {
       return { tag: "symbol_graph", name: sgNameTerm.value };
     }
 
+    case "llm_query": {
+      // (llm_query "prompt" [(name binding) ...])
+      //
+      // Required first argument: string literal prompt.
+      // Optional trailing arguments: (name binding) pairs that fill `{name}`
+      // placeholders in the prompt with the named binding's value.
+      const promptTerm = parseTerm(state, d);
+      if (!promptTerm || promptTerm.tag !== "lit" || typeof promptTerm.value !== "string") {
+        return null;
+      }
+      const promptStr = promptTerm.value;
+
+      // A safety cap matching `escapeForSexp` in the adapter to keep an
+      // accidentally-huge literal from blowing the parser's working set.
+      const MAX_PROMPT_LENGTH = 500_000;
+      if (promptStr.length > MAX_PROMPT_LENGTH) {
+        return null;
+      }
+
+      const bindings: Array<{ name: string; value: LCTerm }> = [];
+      const MAX_BINDINGS = 16;
+
+      while (true) {
+        const next = peek(state);
+        if (!next || next.type === "rparen") break;
+        if (bindings.length >= MAX_BINDINGS) return null;
+
+        // Each binding must be a (name term) paren group.
+        if (next.type !== "lparen") return null;
+        consume(state);
+
+        const bindingNameTok = peek(state);
+        if (!bindingNameTok || bindingNameTok.type !== "symbol") return null;
+        const bindingName = bindingNameTok.value;
+        // Only allow conservative identifiers for the placeholder name so
+        // that string interpolation can't inject odd characters.
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(bindingName)) return null;
+        if (bindingName.length > 64) return null;
+        consume(state);
+
+        const valueTerm = parseTerm(state, d);
+        if (!valueTerm) return null;
+
+        const closing = peek(state);
+        if (!closing || closing.type !== "rparen") return null;
+        consume(state);
+
+        bindings.push({ name: bindingName, value: valueTerm });
+      }
+
+      return { tag: "llm_query", prompt: promptStr, bindings };
+    }
+
     default: {
       const fn: LCTerm = { tag: "var", name: op };
       const arg = parseTerm(state, d);

--- a/src/logic/lc-solver.ts
+++ b/src/logic/lc-solver.ts
@@ -39,19 +39,17 @@ export interface SolverTools {
    */
   lines: string[];
   /**
-   * Optional sub-LLM invoker.
+   * Optional sub-LLM invoker for the `(llm_query …)` primitive.
    *
-   * When present, the FSM-level `solveAsync()` entry point dispatches
-   * top-level `(llm_query …)` terms through this function. Non-FSM
-   * callers (NucleusEngine, HandleSession, the standalone lattice-mcp
-   * path) omit this field, and the sync `solve()` path rejects
-   * `llm_query` with an explicit "top-level only" error so a nested
-   * `(map RESULTS (lambda x (llm_query …)))` fails loudly rather than
-   * silently returning garbage.
+   * When present, the solver dispatches every `(llm_query …)` term
+   * through this function — both top-level and nested inside
+   * `map`/`filter`/`reduce` lambdas. When absent, `(llm_query …)`
+   * throws a clear error naming the execution context.
    *
-   * Full nested support requires making `solve()` itself async — a
-   * deliberate POC limitation, not an oversight. See the GAP 1
-   * discussion in the paper-vs-project review.
+   * Only `runRLM` threads an `llmClient` through to here. Direct
+   * `NucleusEngine` / `HandleSession` / `LatticeTool` consumers
+   * deliberately leave this undefined — they run deterministic LC
+   * queries without the option to recurse into an LLM.
    */
   llmQuery?: (prompt: string) => Promise<string>;
 }
@@ -134,77 +132,11 @@ export async function solve(
     log(`[Solver] Available bindings: ${[...bindings.keys()].join(", ")}`);
   }
 
-  // Top-level `(llm_query …)` dispatch. This sits above the constraint
-  // resolver and the sync evaluator because `await evaluate()` is currently
-  // sync and cannot make sub-LLM calls directly. The follow-up Chunk 4
-  // of this refactor makes `await evaluate()` async and moves this handling
-  // inline into the switch so that nested use (inside `map` / `filter`
-  // lambdas) works — at which point this top-level branch becomes
-  // redundant and can be removed.
-  if (term.tag === "llm_query") {
-    if (!tools.llmQuery) {
-      return {
-        success: false,
-        value: null,
-        logs,
-        error:
-          "llm_query is not available in this execution context. The RLM loop " +
-          "provides it; direct NucleusEngine / lattice-mcp sessions do not.",
-      };
-    }
-
-    try {
-      let interpolated = term.prompt;
-      const MAX_INTERP_LEN = 500_000;
-
-      for (const b of term.bindings) {
-        const resolved = resolveConstraints(b.value);
-        // Nested bindings still use the sync evaluator — `llm_query`
-        // inside a binding expression is rejected with "top level only"
-        // until Chunk 4 makes await evaluate() async.
-        const val = await evaluate(resolved.term, tools, bindings, log, 0);
-        let serialized: string;
-        try {
-          serialized =
-            typeof val === "string" ? val : JSON.stringify(val, null, 2);
-        } catch {
-          serialized = String(val);
-        }
-        if (serialized.length > MAX_INTERP_LEN) {
-          serialized =
-            serialized.slice(0, MAX_INTERP_LEN) +
-            `\n…[truncated ${serialized.length - MAX_INTERP_LEN} chars]`;
-        }
-        const escapedName = b.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        interpolated = interpolated.replace(
-          new RegExp(`\\{${escapedName}\\}`, "g"),
-          serialized.replace(/\$/g, "$$$$")
-        );
-      }
-
-      log(`[Solver] llm_query prompt length: ${interpolated.length} chars`);
-      log(
-        `[Solver] llm_query bindings: ${term.bindings.map((b) => b.name).join(", ") || "(none)"}`
-      );
-
-      const response = await tools.llmQuery(interpolated);
-
-      log(`[Solver] llm_query response length: ${response.length} chars`);
-
-      return { success: true, value: response, logs };
-    } catch (err) {
-      return {
-        success: false,
-        value: null,
-        logs,
-        error: err instanceof Error ? err.message : String(err),
-      };
-    }
-  }
-
   try {
     // Resolve constraints first
     const resolved = resolveConstraints(term);
+    // evaluate() handles every term tag uniformly, including
+    // `(llm_query …)` in both top-level and nested positions.
     const value = await evaluate(resolved.term, tools, bindings, log, 0);
     return { success: true, value, logs };
   } catch (err) {
@@ -217,16 +149,6 @@ export async function solve(
   }
 }
 
-/**
- * Deprecated alias for `solve()`. Prior to the async refactor `solve`
- * was sync and `solveAsync` dispatched top-level `(llm_query …)`
- * separately. Now `solve` itself is async and handles every term
- * uniformly (including nested `llm_query` inside `map`/`filter`/etc.).
- * Existing imports of `solveAsync` keep working while callers migrate.
- *
- * @deprecated Use `solve()` directly — this alias will be removed.
- */
-export const solveAsync = solve;
 
 const MAX_EVAL_DEPTH = 200;
 
@@ -487,6 +409,16 @@ async function evaluate(
       const transformLambda = term.transform;
       log(`[Solver] Mapping over ${collection.length} items`);
 
+      // Sequential iteration by design. When the lambda is pure (just
+      // regex match/extract) the sequential cost is negligible. When
+      // the lambda contains `(llm_query …)`, each iteration fires a
+      // sub-LLM call and sequential means N blocking round-trips —
+      // slow but deterministic. A future optimization can parallelize
+      // pure map bodies via `Promise.all`, or run llm_query lambdas
+      // with a bounded concurrency limit; both are separate PRs that
+      // need their own latency/ordering testing and are flagged in
+      // the paper's own limitations as the biggest performance win
+      // still on the table.
       const results: unknown[] = [];
       for (const item of collection) {
         // Handle both grep results (objects with .line) and raw values
@@ -1147,13 +1079,11 @@ async function evaluate(
     }
 
     case "llm_query": {
-      // Now that evaluate() is async (Chunk 4), `llm_query` works in
-      // any nested position — inside map/filter/reduce lambdas —
-      // because the surrounding evaluator can now `await` its result.
-      // The top-level fast-path in `solve()` still handles the common
-      // case without descending into the switch; this branch fires
-      // when `llm_query` appears inside a containing term like:
-      //   (map RESULTS (lambda x (llm_query "classify {item}" (item x))))
+      // Symbolic-recursion primitive. Works in any position the LC
+      // grammar allows — top-level, and nested inside map/filter/
+      // reduce lambdas — because evaluate() is async. The common
+      // OOLONG pattern looks like:
+      //   (map RESULTS (lambda x (llm_query "classify: {item}" (item x))))
       if (!tools.llmQuery) {
         throw new Error(
           "llm_query is not available in this execution context. " +
@@ -1183,8 +1113,13 @@ async function evaluate(
           serialized.replace(/\$/g, "$$$$")
         );
       }
-      log(`[Solver] llm_query (nested) prompt length: ${interpolated.length} chars`);
-      return await tools.llmQuery(interpolated);
+      log(`[Solver] llm_query prompt length: ${interpolated.length} chars`);
+      log(
+        `[Solver] llm_query bindings: ${term.bindings.map((b) => b.name).join(", ") || "(none)"}`
+      );
+      const response = await tools.llmQuery(interpolated);
+      log(`[Solver] llm_query response length: ${response.length} chars`);
+      return response;
     }
 
     default:

--- a/src/logic/lc-solver.ts
+++ b/src/logic/lc-solver.ts
@@ -135,9 +135,9 @@ export async function solve(
   }
 
   // Top-level `(llm_query …)` dispatch. This sits above the constraint
-  // resolver and the sync evaluator because `evaluate()` is currently
+  // resolver and the sync evaluator because `await evaluate()` is currently
   // sync and cannot make sub-LLM calls directly. The follow-up Chunk 4
-  // of this refactor makes `evaluate()` async and moves this handling
+  // of this refactor makes `await evaluate()` async and moves this handling
   // inline into the switch so that nested use (inside `map` / `filter`
   // lambdas) works — at which point this top-level branch becomes
   // redundant and can be removed.
@@ -161,8 +161,8 @@ export async function solve(
         const resolved = resolveConstraints(b.value);
         // Nested bindings still use the sync evaluator — `llm_query`
         // inside a binding expression is rejected with "top level only"
-        // until Chunk 4 makes evaluate() async.
-        const val = evaluate(resolved.term, tools, bindings, log, 0);
+        // until Chunk 4 makes await evaluate() async.
+        const val = await evaluate(resolved.term, tools, bindings, log, 0);
         let serialized: string;
         try {
           serialized =
@@ -234,13 +234,13 @@ const MAX_EVAL_DEPTH = 200;
  * Evaluate an LC term
  * Impure operations execute directly, pure operations use miniKanren
  */
-function evaluate(
+async function evaluate(
   term: LCTerm,
   tools: SolverTools,
   bindings: Bindings,
   log: (msg: string) => void,
   depth: number = 0
-): unknown {
+): Promise<unknown> {
   if (depth > MAX_EVAL_DEPTH) {
     throw new Error("Maximum evaluation depth exceeded (possible infinite recursion)");
   }
@@ -324,7 +324,7 @@ function evaluate(
       // Evaluate all collection sub-expressions
       const signals: LineResult[][] = [];
       for (const coll of term.collections) {
-        const result = evaluate(coll, tools, bindings, log, depth + 1);
+        const result = await evaluate(coll, tools, bindings, log, depth + 1);
         if (!Array.isArray(result)) {
           throw new Error(`fuse: expected array argument, got ${typeof result}`);
         }
@@ -348,7 +348,7 @@ function evaluate(
     }
 
     case "dampen": {
-      const collection = evaluate(term.collection, tools, bindings, log, depth + 1);
+      const collection = await evaluate(term.collection, tools, bindings, log, depth + 1);
       if (!Array.isArray(collection)) {
         throw new Error(`dampen: expected array, got ${typeof collection}`);
       }
@@ -370,7 +370,7 @@ function evaluate(
     }
 
     case "rerank": {
-      const collection = evaluate(term.collection, tools, bindings, log, depth + 1);
+      const collection = await evaluate(term.collection, tools, bindings, log, depth + 1);
       if (!Array.isArray(collection)) {
         throw new Error(`rerank: expected array, got ${typeof collection}`);
       }
@@ -439,7 +439,7 @@ function evaluate(
 
     case "filter": {
       // Evaluate the collection first (may be grep, fuzzy_search, etc.)
-      const collection = evaluate(term.collection, tools, bindings, log, depth + 1) as Array<{ line: string; lineNum: number }>;
+      const collection = await evaluate(term.collection, tools, bindings, log, depth + 1) as Array<{ line: string; lineNum: number }>;
       if (!Array.isArray(collection)) {
         throw new Error(`filter: expected array, got ${typeof collection}`);
       }
@@ -464,7 +464,7 @@ function evaluate(
           ? (item as { line: string }).line
           : String(item ?? "");
 
-        const matches = evaluatePredicate(predBody, predLambda.param, itemValue, tools, bindings, log, depth + 1);
+        const matches = await evaluatePredicate(predBody, predLambda.param, itemValue, tools, bindings, log, depth + 1);
         if (matches) {
           results.push(item);
         }
@@ -475,7 +475,7 @@ function evaluate(
     }
 
     case "map": {
-      const collection = evaluate(term.collection, tools, bindings, log, depth + 1) as Array<{ line: string; lineNum: number }>;
+      const collection = await evaluate(term.collection, tools, bindings, log, depth + 1) as Array<{ line: string; lineNum: number }>;
       if (!Array.isArray(collection)) {
         throw new Error(`map: expected array, got ${typeof collection}`);
       }
@@ -494,7 +494,7 @@ function evaluate(
           ? (item as { line: string }).line
           : String(item ?? "");
 
-        const value = evaluateTransform(
+        const value = await evaluateTransform(
           transformLambda.body,
           transformLambda.param,
           itemValue,
@@ -511,7 +511,7 @@ function evaluate(
 
     case "sum": {
       // Sum numeric values in array - works with any numeric array
-      const collection = evaluate(term.collection, tools, bindings, log, depth + 1);
+      const collection = await evaluate(term.collection, tools, bindings, log, depth + 1);
       if (!Array.isArray(collection)) {
         throw new Error(`sum: expected array, got ${typeof collection}`);
       }
@@ -566,7 +566,7 @@ function evaluate(
 
     case "count": {
       // Count items in array
-      const collection = evaluate(term.collection, tools, bindings, log, depth + 1);
+      const collection = await evaluate(term.collection, tools, bindings, log, depth + 1);
       if (!Array.isArray(collection)) {
         throw new Error(`count: expected array, got ${typeof collection}`);
       }
@@ -576,11 +576,11 @@ function evaluate(
 
     case "reduce": {
       const MAX_REDUCE_ITERATIONS = 10000;
-      const collection = evaluate(term.collection, tools, bindings, log, depth + 1);
+      const collection = await evaluate(term.collection, tools, bindings, log, depth + 1);
       if (!Array.isArray(collection)) {
         throw new Error(`reduce: expected array, got ${typeof collection}`);
       }
-      const init = evaluate(term.init, tools, bindings, log, depth + 1);
+      const init = await evaluate(term.init, tools, bindings, log, depth + 1);
       if (term.fn.tag !== "lambda") {
         throw new Error(`reduce: fn must be a lambda`);
       }
@@ -591,7 +591,7 @@ function evaluate(
       log(`[Solver] Reducing ${items.length} items`);
       let acc = init;
       for (const item of items) {
-        acc = evaluateReduceFn(term.fn, acc, item, tools, bindings, log, depth + 1);
+        acc = await evaluateReduceFn(term.fn, acc, item, tools, bindings, log, depth + 1);
       }
       return acc;
     }
@@ -629,7 +629,7 @@ function evaluate(
     // ==========================
 
     case "match": {
-      const str = evaluate(term.str, tools, bindings, log, depth + 1) as string;
+      const str = await evaluate(term.str, tools, bindings, log, depth + 1) as string;
       if (typeof str !== "string") {
         throw new Error(`match: expected string, got ${typeof str}`);
       }
@@ -650,7 +650,7 @@ function evaluate(
     }
 
     case "replace": {
-      const str = evaluate(term.str, tools, bindings, log, depth + 1) as string;
+      const str = await evaluate(term.str, tools, bindings, log, depth + 1) as string;
       if (typeof str !== "string") {
         throw new Error(`replace: expected string, got ${typeof str}`);
       }
@@ -667,7 +667,7 @@ function evaluate(
     }
 
     case "split": {
-      const str = evaluate(term.str, tools, bindings, log, depth + 1) as string;
+      const str = await evaluate(term.str, tools, bindings, log, depth + 1) as string;
       if (typeof str !== "string") {
         throw new Error(`split: expected string, got ${typeof str}`);
       }
@@ -680,7 +680,7 @@ function evaluate(
     }
 
     case "parseInt": {
-      const str = evaluate(term.str, tools, bindings, log, depth + 1);
+      const str = await evaluate(term.str, tools, bindings, log, depth + 1);
       const strForInt = String(str);
       if (strForInt.length > 200) return null;
       const intResult = parseInt(strForInt, 10);
@@ -688,7 +688,7 @@ function evaluate(
     }
 
     case "parseFloat": {
-      const str = evaluate(term.str, tools, bindings, log, depth + 1);
+      const str = await evaluate(term.str, tools, bindings, log, depth + 1);
       const strForFloat = String(str);
       if (strForFloat.length > 200) return null;
       const floatResult = parseFloat(strForFloat);
@@ -696,7 +696,7 @@ function evaluate(
     }
 
     case "parseDate": {
-      const str = evaluate(term.str, tools, bindings, log, depth + 1);
+      const str = await evaluate(term.str, tools, bindings, log, depth + 1);
       log(`[Lattice] Parsing date from: "${str}"`);
 
       // If examples are provided, prefer synthesis for consistency
@@ -721,7 +721,7 @@ function evaluate(
     }
 
     case "parseCurrency": {
-      const str = evaluate(term.str, tools, bindings, log, depth + 1);
+      const str = await evaluate(term.str, tools, bindings, log, depth + 1);
       log(`[Lattice] Parsing currency from: "${str}"`);
 
       // If examples are provided, prefer synthesis for consistency
@@ -746,7 +746,7 @@ function evaluate(
     }
 
     case "parseNumber": {
-      const str = evaluate(term.str, tools, bindings, log, depth + 1);
+      const str = await evaluate(term.str, tools, bindings, log, depth + 1);
       log(`[Lattice] Parsing number from: "${str}"`);
 
       // If examples are provided, prefer synthesis for consistency
@@ -771,7 +771,7 @@ function evaluate(
     }
 
     case "coerce": {
-      const value = evaluate(term.term, tools, bindings, log, depth + 1);
+      const value = await evaluate(term.term, tools, bindings, log, depth + 1);
       log(`[Lattice] Coercing "${value}" to ${term.targetType}`);
       const coerced = coerceValue(value, term.targetType);
       log(`[Lattice] Coerced result: ${coerced}`);
@@ -779,7 +779,7 @@ function evaluate(
     }
 
     case "extract": {
-      const str = evaluate(term.str, tools, bindings, log, depth + 1) as string;
+      const str = await evaluate(term.str, tools, bindings, log, depth + 1) as string;
       if (typeof str !== "string") {
         throw new Error(`extract: expected string, got ${typeof str}`);
       }
@@ -883,8 +883,8 @@ function evaluate(
     }
 
     case "add": {
-      const left = evaluate(term.left, tools, bindings, log, depth + 1);
-      const right = evaluate(term.right, tools, bindings, log, depth + 1);
+      const left = await evaluate(term.left, tools, bindings, log, depth + 1);
+      const right = await evaluate(term.right, tools, bindings, log, depth + 1);
       if (typeof left !== "number" || typeof right !== "number") {
         throw new Error(`add: expected numbers, got ${typeof left} and ${typeof right}`);
       }
@@ -896,11 +896,11 @@ function evaluate(
     }
 
     case "if": {
-      const cond = evaluate(term.cond, tools, bindings, log, depth + 1);
+      const cond = await evaluate(term.cond, tools, bindings, log, depth + 1);
       if (cond) {
-        return evaluate(term.then, tools, bindings, log, depth + 1);
+        return await evaluate(term.then, tools, bindings, log, depth + 1);
       } else {
-        return evaluate(term.else, tools, bindings, log, depth + 1);
+        return await evaluate(term.else, tools, bindings, log, depth + 1);
       }
     }
 
@@ -909,19 +909,19 @@ function evaluate(
       return { _type: "closure", param: term.param, body: term.body };
 
     case "app": {
-      const fn = evaluate(term.fn, tools, bindings, log, depth + 1);
+      const fn = await evaluate(term.fn, tools, bindings, log, depth + 1);
       if (!fn || typeof fn !== "object" || (fn as { _type?: string })._type !== "closure") {
         throw new Error(`app: expected closure, got ${typeof fn}`);
       }
       const closure = fn as { _type: "closure"; param: string; body: LCTerm };
-      const arg = evaluate(term.arg, tools, bindings, log, depth + 1);
+      const arg = await evaluate(term.arg, tools, bindings, log, depth + 1);
       // Substitute arg for param in body and evaluate
       // For simplicity, we evaluate directly here
-      return evaluateWithBinding(closure.body, closure.param, arg, tools, bindings, log, depth + 1);
+      return await evaluateWithBinding(closure.body, closure.param, arg, tools, bindings, log, depth + 1);
     }
 
     case "constrained":
-      return evaluate(term.term, tools, bindings, log, depth + 1);
+      return await evaluate(term.term, tools, bindings, log, depth + 1);
 
     case "define-fn": {
       // Synthesize a function from examples and return it for storage
@@ -957,14 +957,14 @@ function evaluate(
       if (storedFn._type !== "synthesized-fn" || typeof storedFn.fn !== "function") {
         throw new Error(`apply-fn: function "${term.name}" not found or invalid in bindings`);
       }
-      const arg = evaluate(term.arg, tools, bindings, log, depth + 1);
+      const arg = await evaluate(term.arg, tools, bindings, log, depth + 1);
       log(`[Lattice] Applying function "${term.name}" to "${arg}"`);
       return (storedFn.fn as (input: string) => unknown)(String(arg));
     }
 
     case "predicate": {
       // Synthesize a predicate from examples
-      const str = evaluate(term.str, tools, bindings, log, depth + 1);
+      const str = await evaluate(term.str, tools, bindings, log, depth + 1);
       if (term.examples && term.examples.length > 0) {
         log(`[Lattice] Synthesizing predicate from ${term.examples.length} examples`);
         const result = synthesisIntegrator.synthesizeOnFailure({
@@ -1014,7 +1014,7 @@ function evaluate(
         throw new Error("get_symbol_body: No symbol database available. Load a code file first.");
       }
 
-      const symbolRef = evaluate(term.symbol, tools, bindings, log, depth + 1);
+      const symbolRef = await evaluate(term.symbol, tools, bindings, log, depth + 1);
       let symbol: import("../treesitter/types.js").Symbol | null = null;
 
       // Handle different input types
@@ -1146,16 +1146,46 @@ function evaluate(
       return neighborhood;
     }
 
-    case "llm_query":
-      // `llm_query` is only reachable at the top level of a query via
-      // `solveAsync` (the FSM path). If the sync solver encounters one
-      // it means it was nested inside another term — the POC doesn't
-      // support that because `solve()` is sync. Fail loudly so the LLM
-      // sees a clear error and can restructure into a top-level call.
-      throw new Error(
-        "llm_query must be used at the top level of a query, not nested inside another term. " +
-        "Emit it as its own term and reference the previous result via a binding."
-      );
+    case "llm_query": {
+      // Now that evaluate() is async (Chunk 4), `llm_query` works in
+      // any nested position — inside map/filter/reduce lambdas —
+      // because the surrounding evaluator can now `await` its result.
+      // The top-level fast-path in `solve()` still handles the common
+      // case without descending into the switch; this branch fires
+      // when `llm_query` appears inside a containing term like:
+      //   (map RESULTS (lambda x (llm_query "classify {item}" (item x))))
+      if (!tools.llmQuery) {
+        throw new Error(
+          "llm_query is not available in this execution context. " +
+          "The RLM loop provides it; direct NucleusEngine / lattice-mcp " +
+          "sessions do not."
+        );
+      }
+      let interpolated = term.prompt;
+      const MAX_INTERP_LEN = 500_000;
+      for (const b of term.bindings) {
+        const val = await evaluate(b.value, tools, bindings, log, depth + 1);
+        let serialized: string;
+        try {
+          serialized =
+            typeof val === "string" ? val : JSON.stringify(val, null, 2);
+        } catch {
+          serialized = String(val);
+        }
+        if (serialized.length > MAX_INTERP_LEN) {
+          serialized =
+            serialized.slice(0, MAX_INTERP_LEN) +
+            `\n…[truncated ${serialized.length - MAX_INTERP_LEN} chars]`;
+        }
+        const escapedName = b.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        interpolated = interpolated.replace(
+          new RegExp(`\\{${escapedName}\\}`, "g"),
+          serialized.replace(/\$/g, "$$$$")
+        );
+      }
+      log(`[Solver] llm_query (nested) prompt length: ${interpolated.length} chars`);
+      return await tools.llmQuery(interpolated);
+    }
 
     default:
       throw new Error(`Unknown term tag: ${(term as LCTerm).tag}`);
@@ -1166,7 +1196,7 @@ function evaluate(
  * Evaluate a predicate term with a bound variable
  * Returns true if the predicate matches
  */
-function evaluatePredicate(
+async function evaluatePredicate(
   body: LCTerm,
   param: string,
   value: string,
@@ -1174,11 +1204,19 @@ function evaluatePredicate(
   bindings: Bindings,
   log: (msg: string) => void,
   depth: number = 0
-): boolean {
+): Promise<boolean> {
   // Simple pattern: (match var "pattern" 0)
   if (body.tag === "match") {
     if (!Number.isInteger(body.group) || body.group < 0) return false;
-    const str = body.str.tag === "var" && body.str.name === param ? value : String(evaluate(body.str, tools, bindings, log, depth + 1));
+    // Use evaluateWithBinding (not evaluate) for the non-var fast path
+    // so the predicate's lambda parameter remains in scope. Without
+    // this, a nested term like (llm_query "…" (item x)) would look up
+    // `x` against the outer bindings and fail. Discovered when the
+    // filter-with-llm_query test from llm-query-nested.test.ts broke
+    // after the async refactor removed the top-level-only restriction.
+    const str = body.str.tag === "var" && body.str.name === param
+      ? value
+      : String(await evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1));
     const patternValidation = validateRegex(body.pattern);
     if (!patternValidation.valid) return false;
     // Case-insensitive for consistency with grep and extract
@@ -1198,14 +1236,14 @@ function evaluatePredicate(
   }
 
   // For complex predicates, evaluate and check truthiness
-  const result = evaluateWithBinding(body, param, value, tools, bindings, log, depth + 1);
+  const result = await evaluateWithBinding(body, param, value, tools, bindings, log, depth + 1);
   return Boolean(result);
 }
 
 /**
  * Evaluate a transform term with a bound variable
  */
-function evaluateTransform(
+async function evaluateTransform(
   body: LCTerm,
   param: string,
   value: string,
@@ -1213,14 +1251,14 @@ function evaluateTransform(
   bindings: Bindings,
   log: (msg: string) => void,
   depth: number = 0
-): unknown {
-  return evaluateWithBinding(body, param, value, tools, bindings, log, depth + 1);
+): Promise<unknown> {
+  return await evaluateWithBinding(body, param, value, tools, bindings, log, depth + 1);
 }
 
 /**
  * Evaluate reduce function with two bindings (acc, item)
  */
-function evaluateReduceFn(
+async function evaluateReduceFn(
   fn: LCTerm & { tag: "lambda" },
   acc: unknown,
   item: unknown,
@@ -1228,7 +1266,7 @@ function evaluateReduceFn(
   bindings: Bindings,
   log: (msg: string) => void,
   depth: number = 0
-): unknown {
+): Promise<unknown> {
   // For now, assume a simple two-parameter lambda pattern
   // The lambda body references the accumulator and current item
   const body = fn.body;
@@ -1242,7 +1280,7 @@ function evaluateReduceFn(
     const newBindings = new Map(bindings);
     newBindings.set(param, acc);
     newBindings.set(itemParam, item);
-    return evaluate(innerBody, tools, newBindings, log, depth + 1);
+    return await evaluate(innerBody, tools, newBindings, log, depth + 1);
   }
 
   // Single param - bind it to the item, use existing bindings for acc
@@ -1252,13 +1290,13 @@ function evaluateReduceFn(
   if (param !== "acc") {
     newBindings.set("acc", acc);
   }
-  return evaluate(body, tools, newBindings, log, depth + 1);
+  return await evaluate(body, tools, newBindings, log, depth + 1);
 }
 
 /**
  * Evaluate a term with a variable binding
  */
-function evaluateWithBinding(
+async function evaluateWithBinding(
   body: LCTerm,
   param: string,
   value: unknown,
@@ -1266,7 +1304,7 @@ function evaluateWithBinding(
   bindings: Bindings,
   log: (msg: string) => void,
   depth: number = 0
-): unknown {
+): Promise<unknown> {
   if (depth > MAX_EVAL_DEPTH) {
     throw new Error("evaluateWithBinding: maximum recursion depth exceeded");
   }
@@ -1274,7 +1312,7 @@ function evaluateWithBinding(
   switch (body.tag) {
     case "var":
       if (body.name === param) return value;
-      return evaluate(body, tools, bindings, log, depth + 1);
+      return await evaluate(body, tools, bindings, log, depth + 1);
 
     case "lit":
       return body.value;
@@ -1282,7 +1320,7 @@ function evaluateWithBinding(
     case "match": {
       const str = body.str.tag === "var" && body.str.name === param
         ? String(value)
-        : String(evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1));
+        : String(await evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1));
       const matchVal = validateRegex(body.pattern);
       if (!matchVal.valid) {
         throw new Error(`match: ${matchVal.error}`);
@@ -1297,7 +1335,7 @@ function evaluateWithBinding(
     case "replace": {
       const str = body.str.tag === "var" && body.str.name === param
         ? String(value)
-        : String(evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1));
+        : String(await evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1));
       const replaceVal = validateRegex(body.from);
       if (!replaceVal.valid) {
         throw new Error(`replace: ${replaceVal.error}`);
@@ -1311,7 +1349,7 @@ function evaluateWithBinding(
       if (!body.delim || body.delim.length === 0 || body.delim.length > 1000) return null;
       const str = body.str.tag === "var" && body.str.name === param
         ? String(value)
-        : String(evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1));
+        : String(await evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1));
       const MAX_EVAL_SPLIT_PARTS = 10_000;
       const parts = str.split(body.delim);
       if (parts.length > MAX_EVAL_SPLIT_PARTS) return null;
@@ -1319,7 +1357,7 @@ function evaluateWithBinding(
     }
 
     case "parseInt": {
-      const str = evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1);
+      const str = await evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1);
       const strForInt = String(str);
       if (strForInt.length > 200) return null;
       const intResult = parseInt(strForInt, 10);
@@ -1327,7 +1365,7 @@ function evaluateWithBinding(
     }
 
     case "parseFloat": {
-      const str = evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1);
+      const str = await evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1);
       const strForFloat = String(str);
       if (strForFloat.length > 200) return null;
       const floatResult = parseFloat(strForFloat);
@@ -1335,8 +1373,8 @@ function evaluateWithBinding(
     }
 
     case "add": {
-      const left = evaluateWithBinding(body.left, param, value, tools, bindings, log, depth + 1);
-      const right = evaluateWithBinding(body.right, param, value, tools, bindings, log, depth + 1);
+      const left = await evaluateWithBinding(body.left, param, value, tools, bindings, log, depth + 1);
+      const right = await evaluateWithBinding(body.right, param, value, tools, bindings, log, depth + 1);
       if (typeof left !== "number" || typeof right !== "number") {
         throw new Error(`add: expected numbers, got ${typeof left} and ${typeof right}`);
       }
@@ -1348,7 +1386,7 @@ function evaluateWithBinding(
     }
 
     case "parseDate": {
-      const str = evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1);
+      const str = await evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1);
       const strValue = String(str);
 
       // If examples are provided, prefer synthesis for consistency
@@ -1368,7 +1406,7 @@ function evaluateWithBinding(
     }
 
     case "parseCurrency": {
-      const str = evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1);
+      const str = await evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1);
       const strValue = String(str);
 
       // If examples are provided, prefer synthesis for consistency
@@ -1388,7 +1426,7 @@ function evaluateWithBinding(
     }
 
     case "parseNumber": {
-      const str = evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1);
+      const str = await evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1);
       const strValue = String(str);
 
       // If examples are provided, prefer synthesis for consistency
@@ -1408,13 +1446,13 @@ function evaluateWithBinding(
     }
 
     case "coerce": {
-      const termValue = evaluateWithBinding(body.term, param, value, tools, bindings, log, depth + 1);
+      const termValue = await evaluateWithBinding(body.term, param, value, tools, bindings, log, depth + 1);
       return coerceValue(termValue, body.targetType);
     }
 
     case "extract": {
       if (!Number.isInteger(body.group) || body.group < 0) return null;
-      const str = evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1) as string;
+      const str = await evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1) as string;
       if (typeof str !== "string") return null;
       const extractPatternValidation = validateRegex(body.pattern);
       if (!extractPatternValidation.valid) return null;
@@ -1454,7 +1492,7 @@ function evaluateWithBinding(
     }
 
     case "predicate": {
-      const str = evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1);
+      const str = await evaluateWithBinding(body.str, param, value, tools, bindings, log, depth + 1);
       // Handle grep result objects - extract the line property
       const strValue =
         typeof str === "object" && str !== null && "line" in str
@@ -1478,7 +1516,7 @@ function evaluateWithBinding(
       // For unhandled cases, create a temporary binding and evaluate
       const newBindings = new Map(bindings);
       newBindings.set(param, value);
-      return evaluate(body, tools, newBindings, log, depth + 1);
+      return await evaluate(body, tools, newBindings, log, depth + 1);
   }
 }
 

--- a/src/logic/lc-solver.ts
+++ b/src/logic/lc-solver.ts
@@ -115,11 +115,11 @@ export interface SolveResult {
  * @param tools Document tools (grep, fuzzy_search, etc.)
  * @param bindings Optional variable bindings from previous turns
  */
-export function solve(
+export async function solve(
   term: LCTerm,
   tools: SolverTools,
   bindings: Bindings = new Map()
-): SolveResult {
+): Promise<SolveResult> {
   const logs: string[] = [];
   const MAX_LOG_ENTRIES = 10000;
   const MAX_LOG_MSG_LENGTH = 2000;
@@ -134,10 +134,78 @@ export function solve(
     log(`[Solver] Available bindings: ${[...bindings.keys()].join(", ")}`);
   }
 
+  // Top-level `(llm_query …)` dispatch. This sits above the constraint
+  // resolver and the sync evaluator because `evaluate()` is currently
+  // sync and cannot make sub-LLM calls directly. The follow-up Chunk 4
+  // of this refactor makes `evaluate()` async and moves this handling
+  // inline into the switch so that nested use (inside `map` / `filter`
+  // lambdas) works — at which point this top-level branch becomes
+  // redundant and can be removed.
+  if (term.tag === "llm_query") {
+    if (!tools.llmQuery) {
+      return {
+        success: false,
+        value: null,
+        logs,
+        error:
+          "llm_query is not available in this execution context. The RLM loop " +
+          "provides it; direct NucleusEngine / lattice-mcp sessions do not.",
+      };
+    }
+
+    try {
+      let interpolated = term.prompt;
+      const MAX_INTERP_LEN = 500_000;
+
+      for (const b of term.bindings) {
+        const resolved = resolveConstraints(b.value);
+        // Nested bindings still use the sync evaluator — `llm_query`
+        // inside a binding expression is rejected with "top level only"
+        // until Chunk 4 makes evaluate() async.
+        const val = evaluate(resolved.term, tools, bindings, log, 0);
+        let serialized: string;
+        try {
+          serialized =
+            typeof val === "string" ? val : JSON.stringify(val, null, 2);
+        } catch {
+          serialized = String(val);
+        }
+        if (serialized.length > MAX_INTERP_LEN) {
+          serialized =
+            serialized.slice(0, MAX_INTERP_LEN) +
+            `\n…[truncated ${serialized.length - MAX_INTERP_LEN} chars]`;
+        }
+        const escapedName = b.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        interpolated = interpolated.replace(
+          new RegExp(`\\{${escapedName}\\}`, "g"),
+          serialized.replace(/\$/g, "$$$$")
+        );
+      }
+
+      log(`[Solver] llm_query prompt length: ${interpolated.length} chars`);
+      log(
+        `[Solver] llm_query bindings: ${term.bindings.map((b) => b.name).join(", ") || "(none)"}`
+      );
+
+      const response = await tools.llmQuery(interpolated);
+
+      log(`[Solver] llm_query response length: ${response.length} chars`);
+
+      return { success: true, value: response, logs };
+    } catch (err) {
+      return {
+        success: false,
+        value: null,
+        logs,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
   try {
     // Resolve constraints first
     const resolved = resolveConstraints(term);
-    const value = evaluate(resolved.term, tools, bindings, log, 0);
+    const value = await evaluate(resolved.term, tools, bindings, log, 0);
     return { success: true, value, logs };
   } catch (err) {
     return {
@@ -150,112 +218,15 @@ export function solve(
 }
 
 /**
- * Async entry point — dispatches top-level `(llm_query …)` terms through
- * `tools.llmQuery` and delegates everything else to the synchronous
- * `solve()` above.
+ * Deprecated alias for `solve()`. Prior to the async refactor `solve`
+ * was sync and `solveAsync` dispatched top-level `(llm_query …)`
+ * separately. Now `solve` itself is async and handles every term
+ * uniformly (including nested `llm_query` inside `map`/`filter`/etc.).
+ * Existing imports of `solveAsync` keep working while callers migrate.
  *
- * This is the POC for symbolic recursion (GAP 1 in the paper review).
- * Deliberately limited to top-level `llm_query` so the underlying
- * `solve()` / `evaluate()` machinery can stay synchronous — the full
- * async refactor (which would enable `(map RESULTS (lambda x (llm_query …)))`)
- * is a follow-up PR.
- *
- * Placeholders in the prompt string are interpolated from the `bindings`
- * argument list. Each `(name value)` pair is evaluated via `solve()`
- * (not `solveAsync()` — no recursive `llm_query` inside bindings), its
- * value is JSON-stringified, and `{name}` in the prompt is replaced.
- *
- * @param term          The top-level LC term. If it is `llm_query`, this
- *                      function does the sub-LLM call; otherwise it
- *                      delegates straight to sync `solve()`.
- * @param tools         Tools providing document access + (optionally)
- *                      `llmQuery` for symbolic recursion.
- * @param bindings      Cross-turn variable bindings.
+ * @deprecated Use `solve()` directly — this alias will be removed.
  */
-export async function solveAsync(
-  term: LCTerm,
-  tools: SolverTools,
-  bindings: Bindings = new Map()
-): Promise<SolveResult> {
-  if (term.tag !== "llm_query") {
-    // Fast path: no symbolic recursion requested, use the sync solver.
-    return solve(term, tools, bindings);
-  }
-
-  const logs: string[] = [];
-  const MAX_LOG_ENTRIES = 10000;
-  const MAX_LOG_MSG_LENGTH = 2000;
-  const log = (msg: string) => {
-    if (logs.length < MAX_LOG_ENTRIES) {
-      logs.push(msg.length > MAX_LOG_MSG_LENGTH ? msg.slice(0, MAX_LOG_MSG_LENGTH) + "..." : msg);
-    }
-  };
-
-  if (!tools.llmQuery) {
-    return {
-      success: false,
-      value: null,
-      logs,
-      error:
-        "llm_query is not available in this execution context. The RLM loop " +
-        "provides it; direct NucleusEngine / lattice-mcp sessions do not.",
-    };
-  }
-
-  try {
-    // Interpolate each `{name}` placeholder with the JSON-stringified
-    // value of its matching binding. We evaluate the binding's LC term
-    // with the *sync* solver — `llm_query` is not recursively allowed
-    // inside a binding expression (the sync solver will throw with the
-    // clear "top-level only" message if one is encountered).
-    let interpolated = term.prompt;
-    const MAX_INTERP_LEN = 500_000;
-
-    for (const b of term.bindings) {
-      const resolved = resolveConstraints(b.value);
-      const val = evaluate(resolved.term, tools, bindings, log, 0);
-      let serialized: string;
-      try {
-        serialized =
-          typeof val === "string"
-            ? val
-            : JSON.stringify(val, null, 2);
-      } catch {
-        serialized = String(val);
-      }
-      if (serialized.length > MAX_INTERP_LEN) {
-        serialized =
-          serialized.slice(0, MAX_INTERP_LEN) +
-          `\n…[truncated ${serialized.length - MAX_INTERP_LEN} chars]`;
-      }
-      // Replace every literal occurrence of `{name}` in the prompt.
-      // Escape regex metacharacters in the name defensively even though
-      // the parser already restricts names to identifier characters.
-      const escapedName = b.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      interpolated = interpolated.replace(
-        new RegExp(`\\{${escapedName}\\}`, "g"),
-        // $-sequences in the replacement would otherwise be interpreted.
-        serialized.replace(/\$/g, "$$$$")
-      );
-    }
-
-    log(`[Solver] llm_query prompt length: ${interpolated.length} chars`);
-    log(`[Solver] llm_query bindings: ${term.bindings.map((b) => b.name).join(", ") || "(none)"}`);
-
-    const response = await tools.llmQuery(interpolated);
-
-    log(`[Solver] llm_query response length: ${response.length} chars`);
-
-    return { success: true, value: response, logs };
-  } catch (err) {
-    return {
-      success: false,
-      value: null,
-      logs,
-      error: err instanceof Error ? err.message : String(err),
-    };
-  }
-}
+export const solveAsync = solve;
 
 const MAX_EVAL_DEPTH = 200;
 

--- a/src/logic/lc-solver.ts
+++ b/src/logic/lc-solver.ts
@@ -38,6 +38,22 @@ export interface SolverTools {
    * session lets the line array be garbage-collected.
    */
   lines: string[];
+  /**
+   * Optional sub-LLM invoker.
+   *
+   * When present, the FSM-level `solveAsync()` entry point dispatches
+   * top-level `(llm_query …)` terms through this function. Non-FSM
+   * callers (NucleusEngine, HandleSession, the standalone lattice-mcp
+   * path) omit this field, and the sync `solve()` path rejects
+   * `llm_query` with an explicit "top-level only" error so a nested
+   * `(map RESULTS (lambda x (llm_query …)))` fails loudly rather than
+   * silently returning garbage.
+   *
+   * Full nested support requires making `solve()` itself async — a
+   * deliberate POC limitation, not an oversight. See the GAP 1
+   * discussion in the paper-vs-project review.
+   */
+  llmQuery?: (prompt: string) => Promise<string>;
 }
 
 /**
@@ -123,6 +139,114 @@ export function solve(
     const resolved = resolveConstraints(term);
     const value = evaluate(resolved.term, tools, bindings, log, 0);
     return { success: true, value, logs };
+  } catch (err) {
+    return {
+      success: false,
+      value: null,
+      logs,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Async entry point — dispatches top-level `(llm_query …)` terms through
+ * `tools.llmQuery` and delegates everything else to the synchronous
+ * `solve()` above.
+ *
+ * This is the POC for symbolic recursion (GAP 1 in the paper review).
+ * Deliberately limited to top-level `llm_query` so the underlying
+ * `solve()` / `evaluate()` machinery can stay synchronous — the full
+ * async refactor (which would enable `(map RESULTS (lambda x (llm_query …)))`)
+ * is a follow-up PR.
+ *
+ * Placeholders in the prompt string are interpolated from the `bindings`
+ * argument list. Each `(name value)` pair is evaluated via `solve()`
+ * (not `solveAsync()` — no recursive `llm_query` inside bindings), its
+ * value is JSON-stringified, and `{name}` in the prompt is replaced.
+ *
+ * @param term          The top-level LC term. If it is `llm_query`, this
+ *                      function does the sub-LLM call; otherwise it
+ *                      delegates straight to sync `solve()`.
+ * @param tools         Tools providing document access + (optionally)
+ *                      `llmQuery` for symbolic recursion.
+ * @param bindings      Cross-turn variable bindings.
+ */
+export async function solveAsync(
+  term: LCTerm,
+  tools: SolverTools,
+  bindings: Bindings = new Map()
+): Promise<SolveResult> {
+  if (term.tag !== "llm_query") {
+    // Fast path: no symbolic recursion requested, use the sync solver.
+    return solve(term, tools, bindings);
+  }
+
+  const logs: string[] = [];
+  const MAX_LOG_ENTRIES = 10000;
+  const MAX_LOG_MSG_LENGTH = 2000;
+  const log = (msg: string) => {
+    if (logs.length < MAX_LOG_ENTRIES) {
+      logs.push(msg.length > MAX_LOG_MSG_LENGTH ? msg.slice(0, MAX_LOG_MSG_LENGTH) + "..." : msg);
+    }
+  };
+
+  if (!tools.llmQuery) {
+    return {
+      success: false,
+      value: null,
+      logs,
+      error:
+        "llm_query is not available in this execution context. The RLM loop " +
+        "provides it; direct NucleusEngine / lattice-mcp sessions do not.",
+    };
+  }
+
+  try {
+    // Interpolate each `{name}` placeholder with the JSON-stringified
+    // value of its matching binding. We evaluate the binding's LC term
+    // with the *sync* solver — `llm_query` is not recursively allowed
+    // inside a binding expression (the sync solver will throw with the
+    // clear "top-level only" message if one is encountered).
+    let interpolated = term.prompt;
+    const MAX_INTERP_LEN = 500_000;
+
+    for (const b of term.bindings) {
+      const resolved = resolveConstraints(b.value);
+      const val = evaluate(resolved.term, tools, bindings, log, 0);
+      let serialized: string;
+      try {
+        serialized =
+          typeof val === "string"
+            ? val
+            : JSON.stringify(val, null, 2);
+      } catch {
+        serialized = String(val);
+      }
+      if (serialized.length > MAX_INTERP_LEN) {
+        serialized =
+          serialized.slice(0, MAX_INTERP_LEN) +
+          `\n…[truncated ${serialized.length - MAX_INTERP_LEN} chars]`;
+      }
+      // Replace every literal occurrence of `{name}` in the prompt.
+      // Escape regex metacharacters in the name defensively even though
+      // the parser already restricts names to identifier characters.
+      const escapedName = b.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      interpolated = interpolated.replace(
+        new RegExp(`\\{${escapedName}\\}`, "g"),
+        // $-sequences in the replacement would otherwise be interpreted.
+        serialized.replace(/\$/g, "$$$$")
+      );
+    }
+
+    log(`[Solver] llm_query prompt length: ${interpolated.length} chars`);
+    log(`[Solver] llm_query bindings: ${term.bindings.map((b) => b.name).join(", ") || "(none)"}`);
+
+    const response = await tools.llmQuery(interpolated);
+
+    log(`[Solver] llm_query response length: ${response.length} chars`);
+
+    return { success: true, value: response, logs };
   } catch (err) {
     return {
       success: false,
@@ -1050,6 +1174,17 @@ function evaluate(
       log(`[Solver] Graph: ${neighborhood.nodes.length} nodes, ${neighborhood.edges.length} edges`);
       return neighborhood;
     }
+
+    case "llm_query":
+      // `llm_query` is only reachable at the top level of a query via
+      // `solveAsync` (the FSM path). If the sync solver encounters one
+      // it means it was nested inside another term — the POC doesn't
+      // support that because `solve()` is sync. Fail loudly so the LLM
+      // sees a clear error and can restructure into a top-level call.
+      throw new Error(
+        "llm_query must be used at the top level of a query, not nested inside another term. " +
+        "Emit it as its own term and reference the previous result via a binding."
+      );
 
     default:
       throw new Error(`Unknown term tag: ${(term as LCTerm).tag}`);

--- a/src/logic/type-inference.ts
+++ b/src/logic/type-inference.ts
@@ -255,6 +255,9 @@ function infer(term: LCTerm, env: TypeEnv): LCType {
     case "symbol_graph":
       return { tag: "any" };
 
+    case "llm_query":
+      return { tag: "string" };
+
     default:
       return { tag: "any" };
   }

--- a/src/logic/types.ts
+++ b/src/logic/types.ts
@@ -62,7 +62,8 @@ export type LCTerm =
   | LCDescendants
   | LCImplementations
   | LCDependents
-  | LCSymbolGraph;
+  | LCSymbolGraph
+  | LCLLMQuery;
 
 /**
  * (input) - reference to the current input string
@@ -511,6 +512,28 @@ export interface LCSymbolGraph {
   tag: "symbol_graph";
   name: string;
   depth?: number;
+}
+
+/**
+ * (llm_query "prompt" [(name binding) ...]) — symbolic recursion primitive
+ *
+ * Invokes a sub-LLM with a literal prompt string. The prompt may contain
+ * `{name}` placeholders, each of which is filled by a named binding
+ * argument. The result is a string bound to the next auto-sequenced `_N`.
+ *
+ * Top-level only in the POC — nested use inside `map`/`filter`/etc.
+ * throws an error. Full nested support requires making `solve()` async.
+ *
+ * Examples:
+ *   (llm_query "Summarize in one sentence.")
+ *   (llm_query "Classify each: {errors}" (errors _1))
+ *   (llm_query "Apply {rules} to {data}" (rules _1) (data _2))
+ */
+export interface LCLLMQuery {
+  tag: "llm_query";
+  prompt: string;
+  /** Named bindings that fill `{name}` placeholders in the prompt. */
+  bindings: Array<{ name: string; value: LCTerm }>;
 }
 
 /**

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -271,7 +271,7 @@ export function createMCPServer(options: MCPServerOptions = {}): MCPServerInstan
 
         try {
           const engine = await getEngine(filePath, sessionId);
-          const result = engine.execute(command);
+          const result = await engine.execute(command);
 
           if (!result.success) {
             return {

--- a/src/repl/lattice-repl.ts
+++ b/src/repl/lattice-repl.ts
@@ -297,7 +297,7 @@ export async function startREPL(options: REPLOptions = {}): Promise<void> {
       return true;
     }
 
-    const result = session.execute(trimmed);
+    const result = await session.execute(trimmed);
 
     if (!result.success) {
       output.write(`Error: ${result.error}\n`);

--- a/src/rlm.ts
+++ b/src/rlm.ts
@@ -165,10 +165,10 @@ function createSolverTools(
 
     text_stats: () => ({ ...textStats }),
 
-    // Optional symbolic-recursion hook — threaded through only when the
-    // caller (runRLM) provides an llmClient. Other consumers that build
-    // a solver tools instance without an llmClient get undefined here,
-    // and `(llm_query …)` at solveAsync time returns a clear error.
+    // Optional symbolic-recursion hook — threaded through only when
+    // the caller (runRLM) provides an llmClient. Other consumers that
+    // build a solver tools instance without an llmClient get undefined
+    // here, and `(llm_query …)` at solve time throws a clear error.
     //
     // The sub-LLM is invoked with a standalone prompt that prefixes a
     // brief role-setting sentence so it doesn't try to act like a root
@@ -382,7 +382,7 @@ export async function runRLM(
 
   // Create solver tools for document operations. Passing llmClient here
   // enables the `(llm_query …)` LC primitive — the symbolic-recursion
-  // entry point used by solveAsync in the FSM handleExecute state.
+  // entry point used by solve() when the FSM's handleExecute dispatches.
   const solverTools = createSolverTools(documentContent, llmClient);
 
   // Build user message with optional constraints

--- a/src/rlm.ts
+++ b/src/rlm.ts
@@ -24,7 +24,10 @@ import { buildRLMSpec, createInitialContext, type RLMContext } from "./fsm/rlm-s
  * Create SolverTools from document content
  * These are the same tools the sandbox provides, but standalone for the solver
  */
-function createSolverTools(context: string): SolverTools {
+function createSolverTools(
+  context: string,
+  llmClient?: LLMQueryFn
+): SolverTools {
   const MAX_SOLVER_LINES = 500_000;
   let lines = context.split("\n");
   if (lines.length > MAX_SOLVER_LINES) {
@@ -161,6 +164,27 @@ function createSolverTools(context: string): SolverTools {
     })(),
 
     text_stats: () => ({ ...textStats }),
+
+    // Optional symbolic-recursion hook — threaded through only when the
+    // caller (runRLM) provides an llmClient. Other consumers that build
+    // a solver tools instance without an llmClient get undefined here,
+    // and `(llm_query …)` at solveAsync time returns a clear error.
+    //
+    // The sub-LLM is invoked with a standalone prompt that prefixes a
+    // brief role-setting sentence so it doesn't try to act like a root
+    // RLM (which would emit S-expressions, <<<FINAL>>> tags, etc.).
+    llmQuery: llmClient
+      ? async (subPrompt: string) => {
+          const framedPrompt =
+            "You are a sub-LLM invoked by a parent RLM run. Answer the " +
+            "prompt concisely and directly. Do not emit control tags " +
+            "like <<<FINAL>>> or S-expressions — your caller uses your " +
+            "response as a plain string.\n\n" +
+            subPrompt;
+          const response = await llmClient(framedPrompt);
+          return String(response ?? "");
+        }
+      : undefined,
   };
 }
 
@@ -356,8 +380,10 @@ export async function runRLM(
     log(`  4. If synthesis fails, LLM gets feedback and refines constraints`);
   }
 
-  // Create solver tools for document operations
-  const solverTools = createSolverTools(documentContent);
+  // Create solver tools for document operations. Passing llmClient here
+  // enables the `(llm_query …)` LC primitive — the symbolic-recursion
+  // entry point used by solveAsync in the FSM handleExecute state.
+  const solverTools = createSolverTools(documentContent, llmClient);
 
   // Build user message with optional constraints
   let userMessage = `Query: ${query}`;

--- a/src/tool/adapters/claude-code.ts
+++ b/src/tool/adapters/claude-code.ts
@@ -150,26 +150,26 @@ export class ClaudeCodeAdapter {
         if (typeof args.command !== "string") {
           throw new Error("lattice_query: command must be a string");
         }
-        response = this.tool.execute({
+        response = await this.tool.execute({
           type: "query",
           command: args.command,
         });
         break;
 
       case "lattice_bindings":
-        response = this.tool.execute({ type: "bindings" });
+        response = await this.tool.execute({ type: "bindings" });
         break;
 
       case "lattice_reset":
-        response = this.tool.execute({ type: "reset" });
+        response = await this.tool.execute({ type: "reset" });
         break;
 
       case "lattice_stats":
-        response = this.tool.execute({ type: "stats" });
+        response = await this.tool.execute({ type: "stats" });
         break;
 
       case "lattice_help":
-        response = this.tool.execute({ type: "help" });
+        response = await this.tool.execute({ type: "help" });
         break;
 
       default:

--- a/src/tool/adapters/http.ts
+++ b/src/tool/adapters/http.ts
@@ -260,7 +260,7 @@ export class HttpAdapter {
           break;
 
         case "/bindings":
-          response = this.handleWithSession((session) => session.tool.execute({ type: "bindings" }));
+          response = await this.handleWithSession((session) => session.tool.execute({ type: "bindings" }));
           break;
 
         case "/reset":
@@ -268,16 +268,16 @@ export class HttpAdapter {
             this.sendError(res, 405, "Method not allowed");
             return;
           }
-          response = this.handleWithSession((session) => session.tool.execute({ type: "reset" }));
+          response = await this.handleWithSession((session) => session.tool.execute({ type: "reset" }));
           break;
 
         case "/stats":
-          response = this.handleWithSession((session) => session.tool.execute({ type: "stats" }));
+          response = await this.handleWithSession((session) => session.tool.execute({ type: "stats" }));
           break;
 
         case "/help":
           if (!this.helpResponse) {
-            this.helpResponse = new LatticeTool().execute({ type: "help" });
+            this.helpResponse = await new LatticeTool().execute({ type: "help" });
           }
           response = this.helpResponse;
           break;
@@ -325,7 +325,7 @@ export class HttpAdapter {
     if (typeof body.filePath === "string") {
       response = await tool.executeAsync({ type: "load", filePath: body.filePath });
     } else if (typeof body.content === "string") {
-      response = tool.execute({
+      response = await tool.execute({
         type: "loadContent",
         content: body.content,
         name: typeof body.name === "string" ? body.name : undefined,
@@ -387,7 +387,7 @@ export class HttpAdapter {
   /**
    * Handle request that requires an active session
    */
-  private handleWithSession(fn: (session: Session) => LatticeResponse): LatticeResponse {
+  private async handleWithSession(fn: (session: Session) => Promise<LatticeResponse>): Promise<LatticeResponse> {
     if (!this.session) {
       return { success: false, error: "No active session. POST /load first." };
     }

--- a/src/tool/lattice-tool.ts
+++ b/src/tool/lattice-tool.ts
@@ -53,8 +53,13 @@ export class LatticeTool {
 
   /**
    * Execute a command
+   *
+   * Became async when the underlying NucleusEngine.execute() became
+   * async (the sub-LLM symbolic-recursion refactor). Non-query commands
+   * (load, reset, stats, help) don't actually do async work but return
+   * via an awaited path for uniform callers.
    */
-  execute(command: LatticeCommand): LatticeResponse {
+  async execute(command: LatticeCommand): Promise<LatticeResponse> {
     switch (command.type) {
       case "load":
         return this.load(command.filePath);
@@ -196,7 +201,7 @@ export class LatticeTool {
   /**
    * Execute a Nucleus query
    */
-  private query(command: string): LatticeResponse {
+  private async query(command: string): Promise<LatticeResponse> {
     if (!this.engine.isLoaded()) {
       return {
         success: false,
@@ -204,7 +209,7 @@ export class LatticeTool {
       };
     }
 
-    const result = this.engine.execute(command);
+    const result = await this.engine.execute(command);
 
     if (!result.success) {
       return {

--- a/tests/audit13.test.ts
+++ b/tests/audit13.test.ts
@@ -101,7 +101,8 @@ describe("Issue #2: evaluateWithBinding depth should propagate", () => {
     const ewbBody = ewbFn![0];
 
     // Find the default case - it should not have evaluate(..., 0)
-    const defaultCase = ewbBody.match(/default:[\s\S]*?return evaluate\([^)]+\)/);
+    // (The `await ` prefix is part of the match after the async refactor.)
+    const defaultCase = ewbBody.match(/default:[\s\S]*?return (?:await )?evaluate\([^)]+\)/);
     expect(defaultCase).not.toBeNull();
     // The default case should NOT pass 0 as the depth argument
     expect(defaultCase![0]).not.toMatch(/evaluate\([^)]+,\s*0\s*\)/);

--- a/tests/audit13.test.ts
+++ b/tests/audit13.test.ts
@@ -112,17 +112,17 @@ describe("Issue #2: evaluateWithBinding depth should propagate", () => {
 // Issue #5 — canProduceType misses null for parseInt/parseFloat/add
 // =========================================================================
 describe("Issue #5: canProduceType should return true for null on parseInt/parseFloat/add", () => {
-  it("canProduceType(parseInt, null) should be true", () => {
+  it("canProduceType(parseInt, null) should be true", async () => {
     const e: Extractor = { tag: "parseInt", str: { tag: "input" } };
     expect(canProduceType(e, "null")).toBe(true);
   });
 
-  it("canProduceType(parseFloat, null) should be true", () => {
+  it("canProduceType(parseFloat, null) should be true", async () => {
     const e: Extractor = { tag: "parseFloat", str: { tag: "input" } };
     expect(canProduceType(e, "null")).toBe(true);
   });
 
-  it("canProduceType(add, null) should be true", () => {
+  it("canProduceType(add, null) should be true", async () => {
     const e: Extractor = {
       tag: "add",
       left: { tag: "input" },
@@ -136,7 +136,7 @@ describe("Issue #5: canProduceType should return true for null on parseInt/parse
 // Issue #9 — parseDate uses local-time accessors not UTC
 // =========================================================================
 describe("Issue #9: parseDate should use UTC accessors", () => {
-  it("parseDate fallback should produce consistent date regardless of timezone", () => {
+  it("parseDate fallback should produce consistent date regardless of timezone", async () => {
     // "December 25, 2024" is a natural language date that hits the JS Date fallback path
     // With local time, getMonth()/getDate() can shift to a different day depending on TZ
     const tools = createMockTools("");
@@ -145,7 +145,7 @@ describe("Issue #9: parseDate should use UTC accessors", () => {
     // (parseDate "December 25, 2024")
     const parsed = parse('(parseDate "December 25, 2024")');
     expect(parsed.success).toBe(true);
-    const result = solve(parsed.term!, tools, bindings);
+    const result = await solve(parsed.term!, tools, bindings);
     expect(result.success).toBe(true);
     // Should always be 2024-12-25 regardless of timezone
     expect(result.value).toBe("2024-12-25");
@@ -156,25 +156,25 @@ describe("Issue #9: parseDate should use UTC accessors", () => {
 // Issue #10 — parseCurrencyImpl double-negative wrong sign
 // =========================================================================
 describe("Issue #10: parseCurrency double-negative produces wrong sign", () => {
-  it("should correctly parse negative with minus sign: -$1,234", () => {
+  it("should correctly parse negative with minus sign: -$1,234", async () => {
     const tools = createMockTools("");
     const bindings: Bindings = new Map();
 
     const parsed = parse('(parseCurrency "-$1,234")');
     expect(parsed.success).toBe(true);
-    const result = solve(parsed.term!, tools, bindings);
+    const result = await solve(parsed.term!, tools, bindings);
     expect(result.success).toBe(true);
     // Should be -1234, not 1234 (the minus should be preserved)
     expect(result.value).toBe(-1234);
   });
 
-  it("should correctly parse negative parens: ($1,234)", () => {
+  it("should correctly parse negative parens: ($1,234)", async () => {
     const tools = createMockTools("");
     const bindings: Bindings = new Map();
 
     const parsed = parse('(parseCurrency "($1,234)")');
     expect(parsed.success).toBe(true);
-    const result = solve(parsed.term!, tools, bindings);
+    const result = await solve(parsed.term!, tools, bindings);
     expect(result.success).toBe(true);
     // Should be -1234
     expect(result.value).toBe(-1234);
@@ -203,7 +203,7 @@ describe("Issue #11: buildQuarterMapper parseInt with NaN guard", () => {
 // Issue #12 — Percentage parser returns raw value not /100
 // =========================================================================
 describe("Issue #12: percentage parser should return raw value (not /100)", () => {
-  it("synthesized percentage extractor should match examples exactly", () => {
+  it("synthesized percentage extractor should match examples exactly", async () => {
     const integrator = new SynthesisIntegrator();
     // When examples say 25.5% -> 25.5, the parser should return 25.5 (not 0.255)
     const result = integrator.synthesizeOnFailure({
@@ -240,7 +240,7 @@ describe("Issue #14: lattice-tool path traversal check", () => {
 // Issue #15 — --port/--timeout accept NaN silently
 // =========================================================================
 describe("Issue #15: HTTP adapter should reject NaN port/timeout", () => {
-  it("parseInt with no radix should still work for valid numbers", () => {
+  it("parseInt with no radix should still work for valid numbers", async () => {
     // This is tested via reading the source - the fix adds NaN validation
     // We verify NaN detection works
     const portStr = "notanumber";

--- a/tests/audit14.test.ts
+++ b/tests/audit14.test.ts
@@ -14,7 +14,7 @@ import { formatValue, evaluate, type SandboxTools } from "../src/logic/lc-interp
 // Issue #1 — evalo.ts: evalExtractor uses new RegExp without validateRegex
 // =========================================================================
 describe("Issue #1: evalExtractor should validate regex patterns", () => {
-  it("should return null for ReDoS pattern in match", () => {
+  it("should return null for ReDoS pattern in match", async () => {
     const e: Extractor = {
       tag: "match",
       str: { tag: "input" },
@@ -27,7 +27,7 @@ describe("Issue #1: evalExtractor should validate regex patterns", () => {
     expect(result).toBeNull();
   });
 
-  it("should return null for ReDoS pattern in replace", () => {
+  it("should return null for ReDoS pattern in replace", async () => {
     const e: Extractor = {
       tag: "replace",
       str: { tag: "input" },
@@ -45,7 +45,7 @@ describe("Issue #1: evalExtractor should validate regex patterns", () => {
 // Issue #2 — compile.ts: compiled code embeds regex without ReDoS check
 // =========================================================================
 describe("Issue #2: compile should validate regex patterns", () => {
-  it("compiled match with ReDoS pattern should return null", () => {
+  it("compiled match with ReDoS pattern should return null", async () => {
     const e: Extractor = {
       tag: "match",
       str: { tag: "input" },
@@ -104,7 +104,7 @@ describe("Issue #4: coordinator should validate knowledge base regex", () => {
 // Issue #5 — lc-interpreter.ts: formatValue no depth limit
 // =========================================================================
 describe("Issue #5: formatValue should have depth limit", () => {
-  it("should not stack overflow on deeply nested object", () => {
+  it("should not stack overflow on deeply nested object", async () => {
     // Build deeply nested object
     let obj: any = { value: "leaf" };
     for (let i = 0; i < 200; i++) {
@@ -121,7 +121,7 @@ describe("Issue #5: formatValue should have depth limit", () => {
 // Issue #6 — lc-interpreter.ts:242: replace backreference injection
 // =========================================================================
 describe("Issue #6: interpreter replace should escape replacement backreferences", () => {
-  it("should treat $1 in replacement as literal, not backreference", () => {
+  it("should treat $1 in replacement as literal, not backreference", async () => {
     const tools: SandboxTools = {
       grep: () => [],
       fuzzy_search: () => [],
@@ -211,7 +211,7 @@ describe("Issue #9: split with empty delimiter should be bounded", () => {
     // (split "aaa..." "" 0) — empty delimiter splits into per-character array
     const parsed = parse(`(split "${bigString.slice(0, 50)}" "" 0)`);
     expect(parsed.success).toBe(true);
-    const result = solverMod.solve(parsed.term!, tools);
+    const result = await solverMod.solve(parsed.term!, tools);
     // Should either return "a" (first char) or handle the split safely
     // The key check is it shouldn't create a 100K element array
     expect(result.success).toBe(true);
@@ -235,7 +235,7 @@ describe("Issue #10: solver replace should escape replacement backreferences", (
 
     const parsed = parse('(replace "hello world" "(\\\\w+)" "$1-test")');
     expect(parsed.success).toBe(true);
-    const result = solverMod2.solve(parsed.term!, tools);
+    const result = await solverMod2.solve(parsed.term!, tools);
     expect(result.success).toBe(true);
     // Should contain literal "$1-test", not a backreference substitution
     expect(String(result.value)).toContain("$1-test");
@@ -292,7 +292,7 @@ describe("Issue #13: lattice-tool should use path.basename", () => {
 // Issue #14 — lc-interpreter.ts:251: negative split index not validated
 // =========================================================================
 describe("Issue #14: interpreter split should reject negative index", () => {
-  it("should return null for negative split index", () => {
+  it("should return null for negative split index", async () => {
     const tools: SandboxTools = {
       grep: () => [],
       fuzzy_search: () => [],
@@ -317,7 +317,7 @@ describe("Issue #14: interpreter split should reject negative index", () => {
 // Issue #15 — typeo.ts: inferType missing default case
 // =========================================================================
 describe("Issue #15: inferType should return unknown for unrecognized tags", () => {
-  it("should return 'unknown' for a made-up tag", () => {
+  it("should return 'unknown' for a made-up tag", async () => {
     const e = { tag: "nonexistent" } as unknown as Extractor;
     const result = inferType(e);
     // Should return "unknown", not undefined

--- a/tests/audit14.test.ts
+++ b/tests/audit14.test.ts
@@ -75,7 +75,8 @@ describe("Issue #3: evaluateWithBinding var case should not reset depth", () => 
     const ewbBody = ewbFn![0];
 
     // Find the var case — it should NOT call evaluate with depth 0
-    const varCase = ewbBody.match(/case "var":\s*\n[^}]*?return evaluate\([^)]+\)/);
+    // (The `await ` prefix is part of the match after the async refactor.)
+    const varCase = ewbBody.match(/case "var":\s*\n[^}]*?return (?:await )?evaluate\([^)]+\)/);
     expect(varCase).not.toBeNull();
     // The var case should pass depth + 1, not 0
     expect(varCase![0]).not.toMatch(/evaluate\([^,]+,[^,]+,[^,]+,[^,]+,\s*0\s*\)/);

--- a/tests/audit15.test.ts
+++ b/tests/audit15.test.ts
@@ -32,7 +32,7 @@ describe("Audit15 #1: regex case consistency", () => {
       context: "",
     };
     const term: any = { tag: "match", str: { tag: "lit", value: "ABC" }, pattern: "abc", group: 0 };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     // Should match — solver uses "i" flag for consistency with grep
     expect(result.value).toBe("ABC");
   });
@@ -128,7 +128,7 @@ describe("Audit15 #6: evaluateWithBinding match group<0", () => {
         body: { tag: "match", str: { tag: "var", name: "x" }, pattern: "hello", group: -1 },
       },
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     // Each result should be null because group is negative
     expect(result.success).toBe(true);
     const arr = result.value as any[];
@@ -232,7 +232,7 @@ describe("Audit15 #11: parseCurrency $-1234 negative", () => {
       tag: "parseCurrency",
       str: { tag: "lit", value: "$-1,234" },
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     expect(result.value).toBe(-1234);
   });
 });
@@ -287,7 +287,7 @@ describe("Audit15 #14: sum regex multi-number lines", () => {
       tag: "sum",
       collection: { tag: "grep", pattern: "Item" },
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     // Currently matches first number only ($100, $200) which is actually correct for the "dollar amount" case
     expect(typeof result.value).toBe("number");
     expect(result.value as number).toBeGreaterThan(0);

--- a/tests/audit16.test.ts
+++ b/tests/audit16.test.ts
@@ -43,7 +43,7 @@ describe("Audit16 #2: solver extract group<0", () => {
       pattern: "(\\d+)",
       group: -1,
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     // Should return null for negative group, not access result[-1]
     expect(result.value).toBe(null);
   });
@@ -70,7 +70,7 @@ describe("Audit16 #3: evaluateWithBinding extract group<0", () => {
         body: { tag: "extract", str: { tag: "var", name: "x" }, pattern: "(\\d+)", group: -1 },
       },
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     expect(result.success).toBe(true);
     const arr = result.value as any[];
     if (arr.length > 0) {
@@ -95,7 +95,7 @@ describe("Audit16 #4: solver split negative index", () => {
       delim: ",",
       index: -1,
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     // Negative index should return null, not access from end of array
     expect(result.value).toBe(null);
   });
@@ -122,7 +122,7 @@ describe("Audit16 #5: evaluateWithBinding split negative index", () => {
         body: { tag: "split", str: { tag: "var", name: "x" }, delim: ",", index: -1 },
       },
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     expect(result.success).toBe(true);
     const arr = result.value as any[];
     if (arr.length > 0) {
@@ -154,7 +154,7 @@ describe("Audit16 #6: evaluatePredicate group<0", () => {
         body: { tag: "match", str: { tag: "var", name: "x" }, pattern: "hello", group: -1 },
       },
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     expect(result.success).toBe(true);
     // With group -1, match should fail, so filter should return empty
     const arr = result.value as any[];
@@ -243,7 +243,7 @@ describe("Audit16 #9: parseCurrency operator precedence", () => {
       tag: "parseCurrency",
       str: { tag: "lit", value: "(1234" },
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     // Without explicit parens in the OR chain, JS may misparse the precedence
     // The result should be positive 1234, not -1234
     expect(result.value).toBe(1234);

--- a/tests/audit17.test.ts
+++ b/tests/audit17.test.ts
@@ -90,7 +90,7 @@ describe("Audit17 #3: find_references validateRegex", () => {
       tag: "find_references",
       name: longName,
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     // Should succeed (returning empty array) without hanging
     expect(result.success).toBe(true);
   });
@@ -108,7 +108,7 @@ describe("Audit17 #3: find_references validateRegex", () => {
       tag: "find_references",
       name: "test",
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     expect(result.success).toBe(true);
     expect(grepCalled).toBe(true);
   });

--- a/tests/audit18.test.ts
+++ b/tests/audit18.test.ts
@@ -168,7 +168,7 @@ describe("Audit18 #8: findDistinguishingPattern regex validation", () => {
         { input: "all good", output: false },
       ],
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     expect(result.success).toBe(true);
   });
 });
@@ -187,7 +187,7 @@ describe("Audit18 #9: parseDate trailing text", () => {
       tag: "parseDate",
       str: { tag: "lit", value: "2024-01-15 extra garbage" },
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     // Should not silently accept trailing text
     expect(result.value).toBe(null);
   });
@@ -237,7 +237,7 @@ describe("Audit18 #13: evaluateWithBinding depth constant", () => {
       left: { tag: "lit", value: 1 },
       right: { tag: "lit", value: 2 },
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     expect(result.value).toBe(3);
   });
 });

--- a/tests/audit19.test.ts
+++ b/tests/audit19.test.ts
@@ -57,7 +57,7 @@ describe("Audit19 #2: parseDate natural language day validation", () => {
       tag: "parseDate",
       str: { tag: "lit", value: "February 31, 2024" },
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     expect(result.success).toBe(true);
     expect(result.value).toBe(null);  // Invalid date should return null
   });
@@ -74,7 +74,7 @@ describe("Audit19 #2: parseDate natural language day validation", () => {
       tag: "parseDate",
       str: { tag: "lit", value: "31 February 2024" },
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     expect(result.success).toBe(true);
     expect(result.value).toBe(null);
   });
@@ -91,7 +91,7 @@ describe("Audit19 #2: parseDate natural language day validation", () => {
       tag: "parseDate",
       str: { tag: "lit", value: "April 31, 2024" },
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     expect(result.success).toBe(true);
     expect(result.value).toBe(null);
   });
@@ -108,7 +108,7 @@ describe("Audit19 #2: parseDate natural language day validation", () => {
       tag: "parseDate",
       str: { tag: "lit", value: "January 15, 2024" },
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     expect(result.success).toBe(true);
     expect(result.value).toBe("2024-01-15");
   });
@@ -132,7 +132,7 @@ describe("Audit19 #3: lc-solver classify empty string filter", () => {
         { input: "ok", output: false },
       ],
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     expect(result.success).toBe(true);
     // The classifier should be a function
     const classifyFn = result.value;
@@ -245,7 +245,7 @@ describe("Audit19 #6: match group index bounds", () => {
       pattern: "(\\d+)",
       group: 5,
     };
-    const result = solve(term, tools);
+    const result = await solve(term, tools);
     expect(result.success).toBe(true);
     expect(result.value).toBe(null);
   });

--- a/tests/audit25.test.ts
+++ b/tests/audit25.test.ts
@@ -38,7 +38,7 @@ describe("Audit25 #2: grep empty pattern guard", () => {
       grep: null as any,
     };
     // Create solver tools by calling solve with a grep on empty pattern
-    const result = mod.solve(
+    const result = await mod.solve(
       { tag: "grep" as const, pattern: "" },
       { context: "hello\nworld", grep: () => [], fuzzy_search: () => [], text_stats: () => ({}) },
       new Map()
@@ -163,7 +163,7 @@ describe("Audit25 #8: grep groups filter undefined", () => {
       text_stats: () => ({}),
     };
     // A pattern with an optional group: (foo)?(hello)
-    const result = mod.solve(
+    const result = await mod.solve(
       { tag: "grep" as const, pattern: "(foo)?(hello)" },
       tools,
       new Map()

--- a/tests/audit26.test.ts
+++ b/tests/audit26.test.ts
@@ -188,7 +188,7 @@ describe("Audit26 #11: lc-solver word split empty string filter", () => {
       fuzzy_search: () => [],
       text_stats: () => ({}),
     };
-    const result = mod.solve(
+    const result = await mod.solve(
       {
         tag: "classify" as const,
         examples: [

--- a/tests/audit79.test.ts
+++ b/tests/audit79.test.ts
@@ -31,7 +31,10 @@ describe("Audit #79", () => {
       // Make sure we're in evaluate, not evaluateWithBinding
       const evalWithBinding = source.indexOf("function evaluateWithBinding(");
       expect(addCase).toBeLessThan(evalWithBinding);
-      const block = source.slice(addCase, addCase + 500);
+      // Bumped from 500 → 700 after the async refactor added `await` prefixes
+      // to every evaluate() call, pushing the `Number.isFinite(addResult)`
+      // check past the end of the 500-char window.
+      const block = source.slice(addCase, addCase + 700);
       expect(block).toMatch(/isFinite\(.*(?:result|addResult|left\s*\+\s*right)/);
     });
   });

--- a/tests/audit96.test.ts
+++ b/tests/audit96.test.ts
@@ -68,9 +68,9 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       ].join("\n"));
     });
 
-    it("top-level (match \"Error\" \"error\" 0) returns match (case-insensitive)", () => {
+    it("top-level (match \"Error\" \"error\" 0) returns match (case-insensitive)", async () => {
       // This hits evaluate() match case at lc-solver.ts:547
-      const result = engine.execute('(match "Error 500" "error" 0)');
+      const result = await engine.execute('(match "Error 500" "error" 0)');
       expect(result.success).toBe(true);
       // Case-insensitive regex matches "Error"
       expect(result.value).not.toBeNull();
@@ -78,14 +78,14 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       expect((result.value as string).toLowerCase()).toBe("error");
     });
 
-    it("(filter RESULTS (lambda x (match x \"error\" 0))) keeps upper-case matches", () => {
+    it("(filter RESULTS (lambda x (match x \"error\" 0))) keeps upper-case matches", async () => {
       // This hits evaluatePredicate match case at lc-solver.ts:1078
-      const grepResult = engine.execute('(grep "error")');
+      const grepResult = await engine.execute('(grep "error")');
       expect(grepResult.success).toBe(true);
       // Grep is case-insensitive — finds "Error 500" and "Error" in "Internal Server Error"
       expect(Array.isArray(grepResult.value)).toBe(true);
 
-      const filterResult = engine.execute(
+      const filterResult = await engine.execute(
         '(filter RESULTS (lambda x (match x "error" 0)))'
       );
       expect(filterResult.success).toBe(true);
@@ -98,12 +98,12 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       expect(hasError500).toBe(true);
     });
 
-    it("(map RESULTS (lambda x (match x \"fatal\" 0))) matches upper-case FATAL", () => {
+    it("(map RESULTS (lambda x (match x \"fatal\" 0))) matches upper-case FATAL", async () => {
       // This hits evaluateWithBinding match case at lc-solver.ts:1184
-      const grepResult = engine.execute('(grep "fatal")');
+      const grepResult = await engine.execute('(grep "fatal")');
       expect(grepResult.success).toBe(true);
 
-      const mapResult = engine.execute(
+      const mapResult = await engine.execute(
         '(map RESULTS (lambda x (match x "fatal" 0)))'
       );
       expect(mapResult.success).toBe(true);
@@ -142,7 +142,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       };
     }
 
-    it("sums $100 + $200, NOT $100+5 + $200+10 (multi-number line)", () => {
+    it("sums $100 + $200, NOT $100+5 + $200+10 (multi-number line)", async () => {
       // Before the fix: regex accumulates ALL numbers per line:
       //   Line 1: 100 + 5 = 105
       //   Line 2: 200 + 10 = 210
@@ -156,12 +156,12 @@ describe("Audit #96 — Chiasmus review round 2", () => {
         tag: "sum",
         collection: { tag: "grep", pattern: "Item" },
       };
-      const result = solve(term, tools);
+      const result = await solve(term, tools);
       expect(result.success).toBe(true);
       expect(result.value).toBe(300);
     });
 
-    it("sums error code 500 + error code 404 = 904 (no currency case)", () => {
+    it("sums error code 500 + error code 404 = 904 (no currency case)", async () => {
       // Before the fix: "Error 500: timeout 30s" would sum 500+30 = 530
       //                 "Error 404: attempt 2 of 3" would sum 404+2+3 = 409
       //                 Total = 939 (garbage)
@@ -175,17 +175,17 @@ describe("Audit #96 — Chiasmus review round 2", () => {
         tag: "sum",
         collection: { tag: "grep", pattern: "Error" },
       };
-      const result = solve(term, tools);
+      const result = await solve(term, tools);
       expect(result.success).toBe(true);
       expect(result.value).toBe(904);
     });
 
-    it("plain numeric-string entries still parse correctly (no regression)", () => {
+    it("plain numeric-string entries still parse correctly (no regression)", async () => {
       // Plain strings go through the `typeof val === "string"` branch, not
       // the grep-object branch. Verify that branch is unaffected by the fix.
       const stringEngine = new NucleusEngine();
       stringEngine.loadContent("$1,000\n$2,500.50");
-      const result = stringEngine.execute("(sum (lines 1 2))");
+      const result = await stringEngine.execute("(sum (lines 1 2))");
       expect(result.success).toBe(true);
       expect(result.value).toBe(3500.5);
     });
@@ -211,28 +211,28 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       };
     }
 
-    it("(lines 1 2) respects tools.lines even when it diverges from context", () => {
+    it("(lines 1 2) respects tools.lines even when it diverges from context", async () => {
       // Intentionally construct a tools object where `context` would, if
       // re-split, produce a DIFFERENT array than `lines`. The solver must
       // trust `tools.lines` rather than falling back to a cached reparse of
       // `tools.context` (which is exactly what the old module-level cache did).
       const tools = makeTools("aaa\nbbb\nccc", ["XXX", "YYY", "ZZZ"]);
       const term: LCTerm = { tag: "lines", start: 1, end: 2 };
-      const result = solve(term, tools);
+      const result = await solve(term, tools);
       expect(result.success).toBe(true);
       expect(result.value).toEqual(["XXX", "YYY"]);
     });
 
-    it("two tools instances do not leak state between each other", () => {
+    it("two tools instances do not leak state between each other", async () => {
       // Call A with one tools, then B with another. If A's call cached data
       // at module scope, B's call could accidentally see it.
       const toolsA = makeTools("line 1\nline 2", ["alpha", "beta"]);
       const toolsB = makeTools("line 3\nline 4", ["gamma", "delta"]);
       const term: LCTerm = { tag: "lines", start: 1, end: 2 };
 
-      const resultA1 = solve(term, toolsA);
-      const resultB = solve(term, toolsB);
-      const resultA2 = solve(term, toolsA);
+      const resultA1 = await solve(term, toolsA);
+      const resultB = await solve(term, toolsB);
+      const resultA2 = await solve(term, toolsA);
 
       expect(resultA1.value).toEqual(["alpha", "beta"]);
       expect(resultB.value).toEqual(["gamma", "delta"]);
@@ -244,7 +244,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
   // #4 MEDIUM — execute() should not re-serialize full array for token metadata
   // =========================================================================
   describe("#4 — execute() uses DB-side byte size, not full JSON.stringify", () => {
-    it("SessionDB.getHandleDataByteSize returns the sum of stored data sizes", () => {
+    it("SessionDB.getHandleDataByteSize returns the sum of stored data sizes", async () => {
       const db = new SessionDB();
       // createHandle stores each item as JSON via JSON.stringify
       const handle = db.createHandle(["hello", "world", 42]);
@@ -254,13 +254,13 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       db.close();
     });
 
-    it("getHandleDataByteSize returns 0 for unknown handle", () => {
+    it("getHandleDataByteSize returns 0 for unknown handle", async () => {
       const db = new SessionDB();
       expect(db.getHandleDataByteSize("$res999")).toBe(0);
       db.close();
     });
 
-    it("execute() routes token-metadata sizing through SessionDB, not JSON.stringify", () => {
+    it("execute() routes token-metadata sizing through SessionDB, not JSON.stringify", async () => {
       const session = new HandleSession();
       session.loadContent(
         Array.from({ length: 500 }, (_, i) => `line ${i} some content`).join("\n"),
@@ -271,7 +271,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       // the refactor: future edits that drop the DB path would fail here.
       const dbSpy = vi.spyOn(SessionDB.prototype, "getHandleDataByteSize");
 
-      const result = session.execute('(grep "line")');
+      const result = await session.execute('(grep "line")');
 
       expect(result.success).toBe(true);
       expect(result.handle).toBeDefined();
@@ -292,12 +292,12 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       session.close();
     });
 
-    it("token metadata remains directionally correct (large result → high savings)", () => {
+    it("token metadata remains directionally correct (large result → high savings)", async () => {
       const session = new HandleSession();
       session.loadContent(
         Array.from({ length: 200 }, (_, i) => `match ${i} some text`).join("\n"),
       );
-      const result = session.execute('(grep "match")');
+      const result = await session.execute('(grep "match")');
 
       expect(result.success).toBe(true);
       expect(result.tokenMetadata).toBeDefined();
@@ -315,10 +315,10 @@ describe("Audit #96 — Chiasmus review round 2", () => {
   // #6 MEDIUM — expand() reports totalTokens > 0 when offset is past end
   // =========================================================================
   describe("#6 — expand() reports non-zero totalTokens when slice is empty", () => {
-    it("offset past end returns empty slice but still reports true total size", () => {
+    it("offset past end returns empty slice but still reports true total size", async () => {
       const session = new HandleSession();
       session.loadContent("alpha\nbeta\ngamma\ndelta\nepsilon");
-      const grep = session.execute('(grep "a")');
+      const grep = await session.execute('(grep "a")');
       expect(grep.success).toBe(true);
       expect(grep.handle).toBeDefined();
 
@@ -348,10 +348,10 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       session.close();
     });
 
-    it("limit=0 returns empty slice but still reports true total size", () => {
+    it("limit=0 returns empty slice but still reports true total size", async () => {
       const session = new HandleSession();
       session.loadContent("alpha\nbeta\ngamma");
-      const grep = session.execute('(grep "a")');
+      const grep = await session.execute('(grep "a")');
       expect(grep.success).toBe(true);
 
       const full = session.expand(grep.handle!);
@@ -374,17 +374,17 @@ describe("Audit #96 — Chiasmus review round 2", () => {
   // #5 MEDIUM — redundant eviction guard in HandleSession.execute
   // =========================================================================
   describe("#5 — handle count stays bounded via registry's internal guard", () => {
-    it("after 250+ array-result queries, handle count stays <= MAX_HANDLES", () => {
+    it("after 250+ array-result queries, handle count stays <= MAX_HANDLES", async () => {
       // HandleRegistry.MAX_HANDLES = 200. After we blow past that, the
       // registry-internal guard must keep the count bounded. The outer
-      // guard in HandleSession.execute() that this fix deletes was unused
+      // guard in await HandleSession.execute() that this fix deletes was unused
       // (it checked > 200 but store() already keeps count <= 199) — so
       // removing it should change nothing behaviorally.
       const session = new HandleSession();
       session.loadContent("a\nb\nc\nd\ne");
 
       for (let i = 0; i < 250; i++) {
-        const r = session.execute('(grep "a")');
+        const r = await session.execute('(grep "a")');
         expect(r.success).toBe(true);
       }
 
@@ -413,7 +413,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       };
     }
 
-    it("finds a node reachable only via a mixed out→in path", () => {
+    it("finds a node reachable only via a mixed out→in path", async () => {
       // Graph: A → B ← C
       // neighborhood(A, 2) should include C — it's 2 undirected hops away
       // (A→B, then B←C). The old implementation only walked pure-outgoing
@@ -430,7 +430,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       expect(nodeNames).toEqual(["A", "B", "C"]);
     });
 
-    it("finds a chain through alternating directions", () => {
+    it("finds a chain through alternating directions", async () => {
       // Graph: A → B ← C → D
       // neighborhood(A, 3) should include D — 3 undirected hops via
       // A→B←C→D. Old impl stopped at B.
@@ -445,7 +445,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       expect(nodeNames).toEqual(["A", "B", "C", "D"]);
     });
 
-    it("respects the depth limit (doesn't grab the whole graph)", () => {
+    it("respects the depth limit (doesn't grab the whole graph)", async () => {
       // Graph: A → B → C → D  (chain)
       // neighborhood(A, 2) should only reach {A, B, C}, not D.
       const graph = new SymbolGraph();
@@ -459,7 +459,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       expect(nodeNames).toEqual(["A", "B", "C"]);
     });
 
-    it("returns only the root for depth 0", () => {
+    it("returns only the root for depth 0", async () => {
       const graph = new SymbolGraph();
       graph.addSymbol(mkSymbol("A"));
       graph.addSymbol(mkSymbol("B"));
@@ -489,7 +489,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       return { db, search };
     }
 
-    it("highlighted output escapes < > & from original content", () => {
+    it("highlighted output escapes < > & from original content", async () => {
       const { db, search } = setupSearch();
       const results = search.searchWithHighlights("alert");
       expect(results.length).toBeGreaterThan(0);
@@ -508,7 +508,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       db.close();
     });
 
-    it("snippet output escapes < > & from original content", () => {
+    it("snippet output escapes < > & from original content", async () => {
       const { db, search } = setupSearch();
       const results = search.searchWithSnippets("alert");
       expect(results.length).toBeGreaterThan(0);
@@ -524,7 +524,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       db.close();
     });
 
-    it("pre-existing &amp; in content is re-encoded to &amp;amp;", () => {
+    it("pre-existing &amp; in content is re-encoded to &amp;amp;", async () => {
       // Escape must be idempotent-hostile: if we see `&amp;` in the input,
       // we must NOT leave it alone (that would double-decode on render).
       // Instead, every `&` becomes `&amp;` so the literal source text
@@ -543,14 +543,14 @@ describe("Audit #96 — Chiasmus review round 2", () => {
   // #11 LOW — parseAll must track ()/[]/{} as independent bracket kinds
   // =========================================================================
   describe("#11 — parseAll separates paren/bracket/brace depth", () => {
-    it("two top-level s-expressions back to back are split correctly", () => {
+    it("two top-level s-expressions back to back are split correctly", async () => {
       const results = parseAll('(grep "foo") (grep "bar")');
       expect(results.length).toBe(2);
       expect(results[0].success).toBe(true);
       expect(results[1].success).toBe(true);
     });
 
-    it("does not split mid-expression on a brace inside a string", () => {
+    it("does not split mid-expression on a brace inside a string", async () => {
       // `(grep "}")` — the closing brace is inside a string, so parseAll's
       // depth counter must not touch it. Already handled by the inString
       // check. Keep this as a regression guard.
@@ -559,7 +559,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       expect(results[0].success).toBe(true);
     });
 
-    it("stray `)` without matching `(` is ignored, not treated as expression close", () => {
+    it("stray `)` without matching `(` is ignored, not treated as expression close", async () => {
       // `[x) (grep "foo")`:
       //
       // Buggy behavior (single depth counter):
@@ -582,7 +582,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       expect(results[0].success).toBe(false);
     });
 
-    it("valid consecutive expressions with different bracket shapes", () => {
+    it("valid consecutive expressions with different bracket shapes", async () => {
       // `(grep "foo") [list] (grep "bar")` — three top-level forms.
       // Note: `[list]` won't parse as a valid LC term (no leading op),
       // but parseAll should still emit three slices, not two.
@@ -597,7 +597,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
   // #12 LOW — tokenize must error instead of silently truncating
   // =========================================================================
   describe("#12 — parse() errors out on oversize input, doesn't silently truncate", () => {
-    it("an input with > MAX_TOKENS tokens produces a parse failure, not a partial success", () => {
+    it("an input with > MAX_TOKENS tokens produces a parse failure, not a partial success", async () => {
       // MAX_TOKENS = 100_000. Generate a list with enough tokens to blow
       // through the cap. Each `a` symbol is ~1 token, plus whitespace.
       const tokens = Array.from({ length: 120_000 }, () => "a").join(" ");
@@ -619,7 +619,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
   // #14 LOW — setBinding must accept hyphens (matches auto-register regex)
   // =========================================================================
   describe("#14 — setBinding and synthesized-fn auto-register use one regex", () => {
-    it("setBinding accepts hyphenated names so `_fn_parse-date` round-trips", () => {
+    it("setBinding accepts hyphenated names so `_fn_parse-date` round-trips", async () => {
       const engine = new NucleusEngine();
       engine.loadContent("anything");
       // Before the fix: setBinding rejects hyphens via
@@ -631,7 +631,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       expect(engine.getBinding("_fn_parse-date")).toEqual({ foo: 1 });
     });
 
-    it("setBinding still rejects other invalid characters", () => {
+    it("setBinding still rejects other invalid characters", async () => {
       const engine = new NucleusEngine();
       engine.loadContent("anything");
       // Quick sanity: things that should still be invalid stay invalid.
@@ -645,7 +645,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
   // #15 LOW — hasTraversalSegment replaces .includes("..") guards
   // =========================================================================
   describe("#15 — path-traversal check is segment-aware", () => {
-    it("rejects true parent-directory traversal", () => {
+    it("rejects true parent-directory traversal", async () => {
       expect(hasTraversalSegment("../etc/passwd")).toBe(true);
       expect(hasTraversalSegment("..")).toBe(true);
       expect(hasTraversalSegment("foo/../bar")).toBe(true);
@@ -654,7 +654,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       expect(hasTraversalSegment("a/b/../c/d")).toBe(true);
     });
 
-    it("accepts legitimate filenames containing the `..` substring", () => {
+    it("accepts legitimate filenames containing the `..` substring", async () => {
       // Before the fix these would have been rejected as path traversal.
       expect(hasTraversalSegment("readme..txt")).toBe(false);
       expect(hasTraversalSegment("foo..bar.md")).toBe(false);
@@ -663,7 +663,7 @@ describe("Audit #96 — Chiasmus review round 2", () => {
       expect(hasTraversalSegment("my.file..v2")).toBe(false);
     });
 
-    it("accepts normal relative paths and edge cases", () => {
+    it("accepts normal relative paths and edge cases", async () => {
       expect(hasTraversalSegment("")).toBe(false);
       expect(hasTraversalSegment(".")).toBe(false);
       expect(hasTraversalSegment("./file.txt")).toBe(false);

--- a/tests/engine/handle-session.test.ts
+++ b/tests/engine/handle-session.test.ts
@@ -21,14 +21,14 @@ DEBUG: Cache hit ratio: 95%`;
   });
 
   describe("loadContent", () => {
-    it("should load document and return stats", () => {
+    it("should load document and return stats", async () => {
       const stats = session.loadContent(testDocument);
 
       expect(stats.lineCount).toBe(7);
       expect(stats.size).toBe(testDocument.length);
     });
 
-    it("should mark session as loaded", () => {
+    it("should mark session as loaded", async () => {
       expect(session.isLoaded()).toBe(false);
       session.loadContent(testDocument);
       expect(session.isLoaded()).toBe(true);
@@ -40,8 +40,8 @@ DEBUG: Cache hit ratio: 95%`;
       session.loadContent(testDocument);
     });
 
-    it("should return handle stub for array results", () => {
-      const result = session.execute('(grep "ERROR")');
+    it("should return handle stub for array results", async () => {
+      const result = await session.execute('(grep "ERROR")');
 
       expect(result.success).toBe(true);
       expect(result.handle).toMatch(/^\$res\d+$/);
@@ -49,38 +49,38 @@ DEBUG: Cache hit ratio: 95%`;
       expect(result.value).toBeUndefined(); // Full data not returned
     });
 
-    it("should return scalar values directly", () => {
+    it("should return scalar values directly", async () => {
       // First get some results
-      session.execute('(grep "ERROR")');
+      await session.execute('(grep "ERROR")');
 
       // Then count them
-      const result = session.execute("(count RESULTS)");
+      const result = await session.execute("(count RESULTS)");
 
       expect(result.success).toBe(true);
       expect(result.value).toBe(3);
       expect(result.handle).toBeUndefined(); // No handle for scalars
     });
 
-    it("should include preview in stub", () => {
-      const result = session.execute('(grep "ERROR")');
+    it("should include preview in stub", async () => {
+      const result = await session.execute('(grep "ERROR")');
 
       expect(result.stub).toContain("ERROR"); // Preview should show first item
     });
 
-    it("should chain queries using RESULTS", () => {
+    it("should chain queries using RESULTS", async () => {
       // Get all errors
-      const grep = session.execute('(grep "ERROR")');
+      const grep = await session.execute('(grep "ERROR")');
       expect(grep.success).toBe(true);
 
       // Filter to timeout errors - note: lambda syntax is (lambda x ...) not (lambda (x) ...)
-      const filtered = session.execute(
+      const filtered = await session.execute(
         '(filter RESULTS (lambda x (match x "timeout" 0)))'
       );
       expect(filtered.success).toBe(true);
       expect(filtered.handle).toBeDefined();
 
       // Count filtered results
-      const count = session.execute("(count RESULTS)");
+      const count = await session.execute("(count RESULTS)");
       expect(count.value).toBe(2); // "Connection timeout" and "Request timeout"
     });
   });
@@ -90,8 +90,8 @@ DEBUG: Cache hit ratio: 95%`;
       session.loadContent(testDocument);
     });
 
-    it("should expand handle to full data", () => {
-      const grep = session.execute('(grep "ERROR")');
+    it("should expand handle to full data", async () => {
+      const grep = await session.execute('(grep "ERROR")');
       const expanded = session.expand(grep.handle!);
 
       expect(expanded.success).toBe(true);
@@ -99,8 +99,8 @@ DEBUG: Cache hit ratio: 95%`;
       expect(expanded.total).toBe(3);
     });
 
-    it("should support limit for partial expansion", () => {
-      const grep = session.execute('(grep "ERROR")');
+    it("should support limit for partial expansion", async () => {
+      const grep = await session.execute('(grep "ERROR")');
       const expanded = session.expand(grep.handle!, { limit: 2 });
 
       expect(expanded.success).toBe(true);
@@ -109,8 +109,8 @@ DEBUG: Cache hit ratio: 95%`;
       expect(expanded.limit).toBe(2);
     });
 
-    it("should support offset for pagination", () => {
-      const grep = session.execute('(grep "ERROR")');
+    it("should support offset for pagination", async () => {
+      const grep = await session.execute('(grep "ERROR")');
       const expanded = session.expand(grep.handle!, { offset: 1, limit: 2 });
 
       expect(expanded.success).toBe(true);
@@ -118,8 +118,8 @@ DEBUG: Cache hit ratio: 95%`;
       expect(expanded.offset).toBe(1);
     });
 
-    it("should format as lines when requested", () => {
-      const grep = session.execute('(grep "ERROR")');
+    it("should format as lines when requested", async () => {
+      const grep = await session.execute('(grep "ERROR")');
       const expanded = session.expand(grep.handle!, { format: "lines" });
 
       expect(expanded.success).toBe(true);
@@ -127,7 +127,7 @@ DEBUG: Cache hit ratio: 95%`;
       expect(expanded.data![0]).toMatch(/^\[\d+\]/);
     });
 
-    it("should return error for invalid handle", () => {
+    it("should return error for invalid handle", async () => {
       const expanded = session.expand("$invalid");
 
       expect(expanded.success).toBe(false);
@@ -140,9 +140,9 @@ DEBUG: Cache hit ratio: 95%`;
       session.loadContent(testDocument);
     });
 
-    it("should list all handles as stubs", () => {
-      session.execute('(grep "ERROR")');
-      session.execute('(grep "INFO")');
+    it("should list all handles as stubs", async () => {
+      await session.execute('(grep "ERROR")');
+      await session.execute('(grep "INFO")');
 
       const bindings = session.getBindings();
 
@@ -151,8 +151,8 @@ DEBUG: Cache hit ratio: 95%`;
       expect(bindings["$res1"]).toContain("Array");
     });
 
-    it("should indicate current RESULTS binding", () => {
-      session.execute('(grep "ERROR")');
+    it("should indicate current RESULTS binding", async () => {
+      await session.execute('(grep "ERROR")');
 
       const bindings = session.getBindings();
 
@@ -161,13 +161,13 @@ DEBUG: Cache hit ratio: 95%`;
   });
 
   describe("preview and sample", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       session.loadContent(testDocument);
       // Use a pattern that matches all lines (any character sequence)
-      session.execute('(grep "[A-Z]")'); // Matches all lines starting with letters
+      await session.execute('(grep "[A-Z]")'); // Matches all lines starting with letters
     });
 
-    it("should preview first N items", () => {
+    it("should preview first N items", async () => {
       const bindings = session.getBindings();
       const handle = Object.keys(bindings).find((k) => k.startsWith("$res"))!;
 
@@ -176,7 +176,7 @@ DEBUG: Cache hit ratio: 95%`;
       expect(preview).toHaveLength(3);
     });
 
-    it("should sample random N items", () => {
+    it("should sample random N items", async () => {
       const bindings = session.getBindings();
       const handle = Object.keys(bindings).find((k) => k.startsWith("$res"))!;
 
@@ -191,8 +191,8 @@ DEBUG: Cache hit ratio: 95%`;
       session.loadContent(testDocument);
     });
 
-    it("should describe handle contents", () => {
-      const grep = session.execute('(grep "ERROR")');
+    it("should describe handle contents", async () => {
+      const grep = await session.execute('(grep "ERROR")');
       const desc = session.describe(grep.handle!);
 
       expect(desc.count).toBe(3);
@@ -207,8 +207,8 @@ DEBUG: Cache hit ratio: 95%`;
       session.loadContent(testDocument);
     });
 
-    it("should clear resultsHandle explicitly after clearing query handles", () => {
-      session.execute('(grep "ERROR")');
+    it("should clear resultsHandle explicitly after clearing query handles", async () => {
+      await session.execute('(grep "ERROR")');
 
       const registry = (session as unknown as { registry: { getResults: () => string | null } }).registry;
       expect(registry.getResults()).not.toBeNull();
@@ -218,7 +218,7 @@ DEBUG: Cache hit ratio: 95%`;
       expect(registry.getResults()).toBeNull();
     });
 
-    it("should clear resultsHandle even when it points to a surviving memo handle", () => {
+    it("should clear resultsHandle even when it points to a surviving memo handle", async () => {
       const memoResult = session.memo("test memo content", "test label");
       const registry = (session as unknown as { registry: { setResults: (h: string) => void; getResults: () => string | null } }).registry;
 
@@ -232,8 +232,8 @@ DEBUG: Cache hit ratio: 95%`;
       expect(registry.getResults()).toBeNull();
     });
 
-    it("should preserve memo handles while clearing query handles", () => {
-      session.execute('(grep "ERROR")');
+    it("should preserve memo handles while clearing query handles", async () => {
+      await session.execute('(grep "ERROR")');
       session.memo("test memo content", "test label");
 
       const bindingsBefore = session.getBindings();
@@ -253,8 +253,8 @@ DEBUG: Cache hit ratio: 95%`;
       session.loadContent(testDocument);
     });
 
-    it("should clear all handles but keep document", () => {
-      session.execute('(grep "ERROR")');
+    it("should clear all handles but keep document", async () => {
+      await session.execute('(grep "ERROR")');
       expect(Object.keys(session.getBindings()).length).toBeGreaterThan(0);
 
       session.reset();
@@ -265,7 +265,7 @@ DEBUG: Cache hit ratio: 95%`;
   });
 
   describe("close safety", () => {
-    it("should close DB even if parserRegistry.dispose() throws", () => {
+    it("should close DB even if parserRegistry.dispose() throws", async () => {
       // Create a separate session for this test to avoid afterEach double-close
       const testSession = new HandleSession();
       testSession.loadContent(testDocument);
@@ -279,7 +279,7 @@ DEBUG: Cache hit ratio: 95%`;
       expect(() => testSession.close()).not.toThrow();
     });
 
-    it("should complete close even if both parserRegistry.dispose() and db.close() throw", () => {
+    it("should complete close even if both parserRegistry.dispose() and db.close() throw", async () => {
       const testSession = new HandleSession();
       testSession.loadContent(testDocument);
 
@@ -340,7 +340,7 @@ DEBUG: Cache hit ratio: 95%`;
         size: expect.any(Number),
       });
 
-      const grepResult = session.execute('(grep "SLEEP_TOKEN")');
+      const grepResult = await session.execute('(grep "SLEEP_TOKEN")');
       expect(grepResult.success).toBe(true);
       expect(grepResult.handle).toBeDefined();
 
@@ -353,7 +353,7 @@ DEBUG: Cache hit ratio: 95%`;
       await session.loadFile("test-fixtures/short-article.md");
       await session.waitForSymbols();
 
-      const symbolResult = session.execute("(list_symbols)");
+      const symbolResult = await session.execute("(list_symbols)");
       expect(symbolResult.success).toBe(true);
       expect(symbolResult.handle).toBeDefined();
 
@@ -367,7 +367,7 @@ DEBUG: Cache hit ratio: 95%`;
       await session.loadFile("test-fixtures/setext-headings.md");
       await session.waitForSymbols();
 
-      const symbolResult = session.execute("(list_symbols)");
+      const symbolResult = await session.execute("(list_symbols)");
       expect(symbolResult.success).toBe(true);
       expect(symbolResult.handle).toBeDefined();
 
@@ -385,9 +385,9 @@ DEBUG: Cache hit ratio: 95%`;
   });
 
   describe("getSessionInfo", () => {
-    it("should return session metadata", () => {
+    it("should return session metadata", async () => {
       session.loadContent(testDocument, "test.log");
-      session.execute('(grep "ERROR")');
+      await session.execute('(grep "ERROR")');
 
       const info = session.getSessionInfo();
 
@@ -401,7 +401,7 @@ DEBUG: Cache hit ratio: 95%`;
 });
 
 describe("HandleSession - Token Savings", () => {
-  it("should demonstrate token savings with large results", () => {
+  it("should demonstrate token savings with large results", async () => {
     const session = new HandleSession();
 
     // Generate a large document
@@ -414,7 +414,7 @@ describe("HandleSession - Token Savings", () => {
     session.loadContent(largeDoc);
 
     // Execute query that returns many results
-    const result = session.execute('(grep "Log entry")');
+    const result = await session.execute('(grep "Log entry")');
 
     // Handle stub should be compact
     expect(result.stub!.length).toBeLessThan(100);

--- a/tests/engine/nucleus-engine-synthesis.test.ts
+++ b/tests/engine/nucleus-engine-synthesis.test.ts
@@ -10,11 +10,11 @@ import { NucleusEngine } from "../../src/engine/nucleus-engine.js";
 
 describe("NucleusEngine with Synthesis", () => {
   describe("synthesis integration", () => {
-    it("synthesizes currency parser via engine API", () => {
+    it("synthesizes currency parser via engine API", async () => {
       const engine = new NucleusEngine();
       engine.loadContent("Price: 1.234,56€\nPrice: 500,00€");
 
-      const result = engine.execute(`
+      const result = await engine.execute(`
         (map (grep "Price")
           (lambda x
             (parseCurrency (match x "([0-9.,]+€)" 1)
@@ -25,11 +25,11 @@ describe("NucleusEngine with Synthesis", () => {
       expect(result.value).toEqual([1234.56, 500]);
     });
 
-    it("synthesizes date parser via engine API", () => {
+    it("synthesizes date parser via engine API", async () => {
       const engine = new NucleusEngine();
       engine.loadContent("Date: 15/01/24\nDate: 20/02/24");
 
-      const result = engine.execute(`
+      const result = await engine.execute(`
         (map (grep "Date")
           (lambda x
             (parseDate (match x "(\\d+/\\d+/\\d+)" 1)
@@ -40,14 +40,14 @@ describe("NucleusEngine with Synthesis", () => {
       expect(result.value).toEqual(["2024-01-15", "2024-02-20"]);
     });
 
-    it("synthesizes predicate for filtering via engine API", () => {
+    it("synthesizes predicate for filtering via engine API", async () => {
       const engine = new NucleusEngine();
       engine.loadContent(
         "[ERROR] Connection failed\n[INFO] Started\n[ERROR] Timeout\n[DEBUG] Trace"
       );
 
       // Use lines instead of grep "" to avoid character-by-character matches
-      const result = engine.execute(`
+      const result = await engine.execute(`
         (filter (lines 1 4)
           (lambda x
             (predicate x
@@ -66,53 +66,53 @@ describe("NucleusEngine with Synthesis", () => {
   });
 
   describe("define-fn and apply-fn", () => {
-    it("defines a function and applies it directly", () => {
+    it("defines a function and applies it directly", async () => {
       const engine = new NucleusEngine();
       engine.loadContent("test");
 
       // Define a custom euro parser
-      const defineResult = engine.execute(`
+      const defineResult = await engine.execute(`
         (define-fn "euro-parser"
           :examples [("€100" 100) ("€250" 250)])
       `);
       expect(defineResult.success).toBe(true);
 
       // Apply it directly
-      const applyResult = engine.execute('(apply-fn "euro-parser" "€500")');
+      const applyResult = await engine.execute('(apply-fn "euro-parser" "€500")');
       expect(applyResult.success).toBe(true);
       expect(applyResult.value).toBe(500);
     });
 
-    it("can apply defined function in sequence", () => {
+    it("can apply defined function in sequence", async () => {
       const engine = new NucleusEngine();
       engine.loadContent("€100\n€250\n€500");
 
       // Define function first
-      engine.execute(`
+      await engine.execute(`
         (define-fn "euro-parser"
           :examples [("€100" 100) ("€250" 250)])
       `);
 
       // Get lines, then apply function in a subsequent query
-      const linesResult = engine.execute("(lines 1 3)");
+      const linesResult = await engine.execute("(lines 1 3)");
       expect(linesResult.success).toBe(true);
 
       // Apply to first result
-      const applyResult = engine.execute('(apply-fn "euro-parser" "€100")');
+      const applyResult = await engine.execute('(apply-fn "euro-parser" "€100")');
       expect(applyResult.success).toBe(true);
       expect(applyResult.value).toBe(100);
     });
   });
 
   describe("classify standalone", () => {
-    it("builds classifier from examples and uses it", () => {
+    it("builds classifier from examples and uses it", async () => {
       const engine = new NucleusEngine();
       engine.loadContent(
         "ERROR: Failed\nINFO: OK\nERROR: Timeout\nWARN: Slow"
       );
 
       // Build classifier - it returns a function stored in RESULTS
-      const classifyResult = engine.execute(`
+      const classifyResult = await engine.execute(`
         (classify
           :examples [
             ("ERROR: Failed" true)
@@ -126,14 +126,14 @@ describe("NucleusEngine with Synthesis", () => {
   });
 
   describe("complex workflows", () => {
-    it("combines synthesis with count and filter using lines", () => {
+    it("combines synthesis with count and filter using lines", async () => {
       const engine = new NucleusEngine();
       engine.loadContent(
         "Sales: $1,000\nSales: $2,500\nExpense: $500\nSales: $750"
       );
 
       // Count sales using synthesized predicate with lines
-      const result = engine.execute(`
+      const result = await engine.execute(`
         (count
           (filter (lines 1 4)
             (lambda x
@@ -148,14 +148,14 @@ describe("NucleusEngine with Synthesis", () => {
       expect(result.value).toBe(3); // 3 Sales lines
     });
 
-    it("chains map with synthesized parsers", () => {
+    it("chains map with synthesized parsers", async () => {
       const engine = new NucleusEngine();
       engine.loadContent(
         "Item A: €100,00\nItem B: €250,50\nItem C: €75,00"
       );
 
       // Sum all prices using synthesized parser
-      const result = engine.execute(`
+      const result = await engine.execute(`
         (sum
           (map (grep "Item")
             (lambda x
@@ -167,13 +167,13 @@ describe("NucleusEngine with Synthesis", () => {
       expect(result.value).toBe(425.5);
     });
 
-    it("uses extract with type hint and synthesis", () => {
+    it("uses extract with type hint and synthesis", async () => {
       const engine = new NucleusEngine();
       engine.loadContent(
         "Revenue: $1,234.56\nRevenue: $789.00"
       );
 
-      const result = engine.execute(`
+      const result = await engine.execute(`
         (map (grep "Revenue")
           (lambda x
             (extract x "\\$([0-9,.]+)" 1
@@ -187,12 +187,12 @@ describe("NucleusEngine with Synthesis", () => {
   });
 
   describe("error handling", () => {
-    it("handles synthesis failure gracefully", () => {
+    it("handles synthesis failure gracefully", async () => {
       const engine = new NucleusEngine();
       engine.loadContent("test data");
 
       // Conflicting examples should still try to work
-      const result = engine.execute(`
+      const result = await engine.execute(`
         (parseCurrency "invalid"
           :examples [("same" 1) ("same" 2)])
       `);
@@ -201,12 +201,12 @@ describe("NucleusEngine with Synthesis", () => {
       expect(result.success).toBeDefined();
     });
 
-    it("handles missing examples with fallback", () => {
+    it("handles missing examples with fallback", async () => {
       const engine = new NucleusEngine();
       engine.loadContent("$100 and $200");
 
       // No examples provided - should use built-in parser
-      const result = engine.execute(`
+      const result = await engine.execute(`
         (parseCurrency "$100")
       `);
 
@@ -216,12 +216,12 @@ describe("NucleusEngine with Synthesis", () => {
   });
 
   describe("RESULTS binding", () => {
-    it("persists synthesized results in RESULTS binding", () => {
+    it("persists synthesized results in RESULTS binding", async () => {
       const engine = new NucleusEngine();
       engine.loadContent("[ERROR] One\n[INFO] Two\n[ERROR] Three");
 
       // Filter errors using synthesis with lines
-      engine.execute(`
+      await engine.execute(`
         (filter (lines 1 3)
           (lambda x
             (predicate x
@@ -232,19 +232,19 @@ describe("NucleusEngine with Synthesis", () => {
       `);
 
       // Count should use RESULTS from previous query
-      const countResult = engine.execute("(count RESULTS)");
+      const countResult = await engine.execute("(count RESULTS)");
       expect(countResult.success).toBe(true);
       expect(countResult.value).toBe(2);
     });
   });
 
   describe("synthesize standalone command", () => {
-    it("synthesizes function from example pairs", () => {
+    it("synthesizes function from example pairs", async () => {
       const engine = new NucleusEngine();
       engine.loadContent("test");
 
       // Synthesize an uppercase transformer
-      const result = engine.execute(`
+      const result = await engine.execute(`
         (synthesize
           ("hello" "HELLO")
           ("world" "WORLD"))
@@ -256,12 +256,12 @@ describe("NucleusEngine with Synthesis", () => {
       expect(typeof result.value).toBe("function");
     });
 
-    it("synthesizes function using example keyword syntax", () => {
+    it("synthesizes function using example keyword syntax", async () => {
       const engine = new NucleusEngine();
       engine.loadContent("test");
 
       // This is the documented syntax that currently fails
-      const result = engine.execute(`
+      const result = await engine.execute(`
         (synthesize
           (example "hello" "HELLO")
           (example "world" "WORLD"))
@@ -271,12 +271,12 @@ describe("NucleusEngine with Synthesis", () => {
       expect(result.value).toBeDefined();
     });
 
-    it("synthesizes numeric transformer", () => {
+    it("synthesizes numeric transformer", async () => {
       const engine = new NucleusEngine();
       engine.loadContent("test");
 
       // Synthesize a doubling function
-      const result = engine.execute(`
+      const result = await engine.execute(`
         (synthesize
           ("1" 2)
           ("5" 10)

--- a/tests/engine/nucleus-engine.test.ts
+++ b/tests/engine/nucleus-engine.test.ts
@@ -23,38 +23,38 @@ describe("NucleusEngine", () => {
   });
 
   describe("initialization", () => {
-    it("should create engine without document", () => {
+    it("should create engine without document", async () => {
       const emptyEngine = new NucleusEngine();
       expect(emptyEngine.isLoaded()).toBe(false);
     });
 
-    it("should load document content", () => {
+    it("should load document content", async () => {
       expect(engine.isLoaded()).toBe(true);
     });
 
-    it("should report correct stats", () => {
+    it("should report correct stats", async () => {
       const stats = engine.getStats();
       expect(stats).not.toBeNull();
       expect(stats!.lineCount).toBe(12);
       expect(stats!.length).toBeGreaterThan(0);
     });
 
-    it("should get raw content", () => {
+    it("should get raw content", async () => {
       expect(engine.getContent()).toBe(SAMPLE_DOCUMENT);
     });
   });
 
   describe("grep command", () => {
-    it("should find matches with grep", () => {
-      const result = engine.execute('(grep "FATAL")');
+    it("should find matches with grep", async () => {
+      const result = await engine.execute('(grep "FATAL")');
 
       expect(result.success).toBe(true);
       expect(Array.isArray(result.value)).toBe(true);
       expect((result.value as unknown[]).length).toBe(3);
     });
 
-    it("should return match details", () => {
-      const result = engine.execute('(grep "FATAL")');
+    it("should return match details", async () => {
+      const result = await engine.execute('(grep "FATAL")');
       const matches = result.value as Array<{ match: string; line: string; lineNum: number }>;
 
       expect(matches[0].match).toBe("FATAL");
@@ -62,15 +62,15 @@ describe("NucleusEngine", () => {
       expect(matches[0].lineNum).toBe(1);
     });
 
-    it("should handle regex patterns", () => {
-      const result = engine.execute('(grep "Sales:")');
+    it("should handle regex patterns", async () => {
+      const result = await engine.execute('(grep "Sales:")');
 
       expect(result.success).toBe(true);
       expect((result.value as unknown[]).length).toBe(4);
     });
 
-    it("should return empty array for no matches", () => {
-      const result = engine.execute('(grep "NOTFOUND")');
+    it("should return empty array for no matches", async () => {
+      const result = await engine.execute('(grep "NOTFOUND")');
 
       expect(result.success).toBe(true);
       expect(result.value).toEqual([]);
@@ -78,17 +78,17 @@ describe("NucleusEngine", () => {
   });
 
   describe("count command", () => {
-    it("should count results after grep", () => {
-      engine.execute('(grep "FATAL")');
-      const result = engine.execute('(count RESULTS)');
+    it("should count results after grep", async () => {
+      await engine.execute('(grep "FATAL")');
+      const result = await engine.execute('(count RESULTS)');
 
       expect(result.success).toBe(true);
       expect(result.value).toBe(3);
     });
 
-    it("should count all lines with INFO", () => {
-      engine.execute('(grep "INFO")');
-      const result = engine.execute('(count RESULTS)');
+    it("should count all lines with INFO", async () => {
+      await engine.execute('(grep "INFO")');
+      const result = await engine.execute('(count RESULTS)');
 
       expect(result.success).toBe(true);
       expect(result.value).toBe(3);
@@ -96,17 +96,17 @@ describe("NucleusEngine", () => {
   });
 
   describe("filter command", () => {
-    it("should filter results with predicate", () => {
-      engine.execute('(grep "FATAL")');
-      const result = engine.execute('(filter RESULTS (lambda x (match x "Network" 0)))');
+    it("should filter results with predicate", async () => {
+      await engine.execute('(grep "FATAL")');
+      const result = await engine.execute('(filter RESULTS (lambda x (match x "Network" 0)))');
 
       expect(result.success).toBe(true);
       expect((result.value as unknown[]).length).toBe(1);
     });
 
-    it("should filter for specific content", () => {
-      engine.execute('(grep "FATAL")');
-      const result = engine.execute('(filter RESULTS (lambda x (match x "Database" 0)))');
+    it("should filter for specific content", async () => {
+      await engine.execute('(grep "FATAL")');
+      const result = await engine.execute('(filter RESULTS (lambda x (match x "Database" 0)))');
 
       expect(result.success).toBe(true);
       expect((result.value as unknown[]).length).toBe(1);
@@ -114,9 +114,9 @@ describe("NucleusEngine", () => {
   });
 
   describe("sum command", () => {
-    it("should sum numeric values", () => {
-      engine.execute('(grep "Sales")');
-      const result = engine.execute('(sum RESULTS)');
+    it("should sum numeric values", async () => {
+      await engine.execute('(grep "Sales")');
+      const result = await engine.execute('(sum RESULTS)');
 
       expect(result.success).toBe(true);
       // $1,500,000 + $2,300,000 + $1,800,000 + $2,400,000 = $8,000,000
@@ -125,10 +125,10 @@ describe("NucleusEngine", () => {
   });
 
   describe("map command", () => {
-    it("should extract values with map", () => {
-      engine.execute('(grep "Sales")');
+    it("should extract values with map", async () => {
+      await engine.execute('(grep "Sales")');
       // Extract the dollar amounts
-      const result = engine.execute('(map RESULTS (lambda x (match x "\\\\$([0-9,]+)" 1)))');
+      const result = await engine.execute('(map RESULTS (lambda x (match x "\\\\$([0-9,]+)" 1)))');
 
       expect(result.success).toBe(true);
       // Map extracts from the .line property of grep results
@@ -137,8 +137,8 @@ describe("NucleusEngine", () => {
   });
 
   describe("text_stats command", () => {
-    it("should return document statistics", () => {
-      const result = engine.execute('(text_stats)');
+    it("should return document statistics", async () => {
+      const result = await engine.execute('(text_stats)');
 
       expect(result.success).toBe(true);
       const stats = result.value as { length: number; lineCount: number };
@@ -148,8 +148,8 @@ describe("NucleusEngine", () => {
   });
 
   describe("lines command", () => {
-    it("should return line range", () => {
-      const result = engine.execute('(lines 1 3)');
+    it("should return line range", async () => {
+      const result = await engine.execute('(lines 1 3)');
 
       expect(result.success).toBe(true);
       // lines returns an array for compatibility with filter/map
@@ -159,36 +159,36 @@ describe("NucleusEngine", () => {
   });
 
   describe("string operations", () => {
-    it("should match pattern and extract group", () => {
-      const result = engine.execute('(match "Sales Q1: $1,500,000" "\\\\$([0-9,]+)" 1)');
+    it("should match pattern and extract group", async () => {
+      const result = await engine.execute('(match "Sales Q1: $1,500,000" "\\\\$([0-9,]+)" 1)');
 
       expect(result.success).toBe(true);
       expect(result.value).toBe("1,500,000");
     });
 
-    it("should replace pattern", () => {
-      const result = engine.execute('(replace "hello world" "world" "universe")');
+    it("should replace pattern", async () => {
+      const result = await engine.execute('(replace "hello world" "world" "universe")');
 
       expect(result.success).toBe(true);
       expect(result.value).toBe("hello universe");
     });
 
-    it("should split string", () => {
-      const result = engine.execute('(split "a,b,c" "," 1)');
+    it("should split string", async () => {
+      const result = await engine.execute('(split "a,b,c" "," 1)');
 
       expect(result.success).toBe(true);
       expect(result.value).toBe("b");
     });
 
-    it("should parse integer", () => {
-      const result = engine.execute('(parseInt "42")');
+    it("should parse integer", async () => {
+      const result = await engine.execute('(parseInt "42")');
 
       expect(result.success).toBe(true);
       expect(result.value).toBe(42);
     });
 
-    it("should parse float", () => {
-      const result = engine.execute('(parseFloat "3.14")');
+    it("should parse float", async () => {
+      const result = await engine.execute('(parseFloat "3.14")');
 
       expect(result.success).toBe(true);
       expect(result.value).toBe(3.14);
@@ -196,38 +196,38 @@ describe("NucleusEngine", () => {
   });
 
   describe("bindings and state", () => {
-    it("should maintain RESULTS across commands", () => {
-      engine.execute('(grep "FATAL")');
+    it("should maintain RESULTS across commands", async () => {
+      await engine.execute('(grep "FATAL")');
 
       const bindings = engine.getBindings();
       expect(bindings.RESULTS).toBe("Array[3]");
     });
 
-    it("should create numbered bindings", () => {
-      engine.execute('(grep "FATAL")');
-      engine.execute('(count RESULTS)');
+    it("should create numbered bindings", async () => {
+      await engine.execute('(grep "FATAL")');
+      await engine.execute('(count RESULTS)');
 
       const bindings = engine.getBindings();
       expect(bindings._1).toBe("Array[3]");
       expect(bindings._2).toBe(3);
     });
 
-    it("should allow manual binding", () => {
+    it("should allow manual binding", async () => {
       engine.setBinding("myVar", 42);
       expect(engine.getBinding("myVar")).toBe(42);
     });
 
-    it("should reset state", () => {
-      engine.execute('(grep "FATAL")');
+    it("should reset state", async () => {
+      await engine.execute('(grep "FATAL")');
       expect(Object.keys(engine.getBindings()).length).toBeGreaterThan(0);
 
       engine.reset();
       expect(Object.keys(engine.getBindings()).length).toBe(0);
     });
 
-    it("should preserve RESULTS when executing scalar operations", () => {
-      engine.execute('(grep "FATAL")');
-      const countResult = engine.execute('(count RESULTS)');
+    it("should preserve RESULTS when executing scalar operations", async () => {
+      await engine.execute('(grep "FATAL")');
+      const countResult = await engine.execute('(count RESULTS)');
 
       // RESULTS should still be the array, not the count
       const results = engine.getBinding("RESULTS") as unknown[];
@@ -238,10 +238,10 @@ describe("NucleusEngine", () => {
   });
 
   describe("turn bindings eviction", () => {
-    it("should evict old turn bindings after exceeding cap while preserving RESULTS and _fn_*", () => {
+    it("should evict old turn bindings after exceeding cap while preserving RESULTS and _fn_*", async () => {
       // Execute more than 100 queries to trigger eviction
       for (let i = 0; i < 110; i++) {
-        engine.execute('(grep "FATAL")');
+        await engine.execute('(grep "FATAL")');
       }
 
       const bindings = engine.getBindings();
@@ -257,10 +257,10 @@ describe("NucleusEngine", () => {
       expect(bindings._110).toBeDefined();
     });
 
-    it("should evict numerically oldest keys, not lexicographically first", () => {
+    it("should evict numerically oldest keys, not lexicographically first", async () => {
       // Execute 105 queries - should keep _6 through _105 (100 keys)
       for (let i = 0; i < 105; i++) {
-        engine.execute('(grep "FATAL")');
+        await engine.execute('(grep "FATAL")');
       }
 
       const bindings = engine.getBindings();
@@ -277,7 +277,7 @@ describe("NucleusEngine", () => {
   });
 
   describe("grep match limit", () => {
-    it("should cap results at MAX_GREP_MATCHES for broad patterns", () => {
+    it("should cap results at MAX_GREP_MATCHES for broad patterns", async () => {
       // Create a very large document that would produce many matches
       const bigLines: string[] = [];
       for (let i = 0; i < 15000; i++) {
@@ -287,62 +287,62 @@ describe("NucleusEngine", () => {
       bigEngine.loadContent(bigLines.join("\n"));
 
       // Pattern that matches every "line" - will produce 15000 matches
-      const result = bigEngine.execute('(grep "line")');
+      const result = await bigEngine.execute('(grep "line")');
       expect(result.success).toBe(true);
       const matches = result.value as unknown[];
       // Should be capped at 10000 (MAX_GREP_MATCHES)
       expect(matches.length).toBeLessThanOrEqual(10000);
     });
 
-    it("should return all matches when below limit", () => {
-      const result = engine.execute('(grep "FATAL")');
+    it("should return all matches when below limit", async () => {
+      const result = await engine.execute('(grep "FATAL")');
       expect(result.success).toBe(true);
       expect((result.value as unknown[]).length).toBe(3);
     });
   });
 
   describe("regex validation (ReDoS protection)", () => {
-    it("should reject catastrophic backtracking patterns", () => {
-      const result = engine.execute('(grep "(a+)+$")');
+    it("should reject catastrophic backtracking patterns", async () => {
+      const result = await engine.execute('(grep "(a+)+$")');
       expect(result.success).toBe(false);
       expect(result.error).toMatch(/regex|pattern|nested/i);
     });
 
-    it("should reject excessively long patterns", () => {
+    it("should reject excessively long patterns", async () => {
       const longPattern = "a".repeat(501);
-      const result = engine.execute(`(grep "${longPattern}")`);
+      const result = await engine.execute(`(grep "${longPattern}")`);
       expect(result.success).toBe(false);
       expect(result.error).toMatch(/regex|pattern|long/i);
     });
 
-    it("should accept normal patterns", () => {
-      const result = engine.execute('(grep "ERROR|WARN")');
+    it("should accept normal patterns", async () => {
+      const result = await engine.execute('(grep "ERROR|WARN")');
       expect(result.success).toBe(true);
     });
 
-    it("should accept digit patterns", () => {
-      const result = engine.execute('(grep "\\\\d+")');
+    it("should accept digit patterns", async () => {
+      const result = await engine.execute('(grep "\\\\d+")');
       expect(result.success).toBe(true);
     });
   });
 
   describe("error handling", () => {
-    it("should return error for invalid syntax", () => {
-      const result = engine.execute('(grep "unclosed');
+    it("should return error for invalid syntax", async () => {
+      const result = await engine.execute('(grep "unclosed');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain("Parse error");
     });
 
-    it("should return error for unknown command", () => {
-      const result = engine.execute('(unknownCommand "test")');
+    it("should return error for unknown command", async () => {
+      const result = await engine.execute('(unknownCommand "test")');
 
       expect(result.success).toBe(false);
     });
 
-    it("should return error when no document loaded", () => {
+    it("should return error when no document loaded", async () => {
       const emptyEngine = new NucleusEngine();
-      const result = emptyEngine.execute('(grep "test")');
+      const result = await emptyEngine.execute('(grep "test")');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain("No document loaded");
@@ -350,8 +350,8 @@ describe("NucleusEngine", () => {
   });
 
   describe("executeAll", () => {
-    it("should execute multiple commands in sequence", () => {
-      const results = engine.executeAll([
+    it("should execute multiple commands in sequence", async () => {
+      const results = await engine.executeAll([
         '(grep "FATAL")',
         '(count RESULTS)',
       ]);
@@ -364,7 +364,7 @@ describe("NucleusEngine", () => {
   });
 
   describe("command reference", () => {
-    it("should return command reference", () => {
+    it("should return command reference", async () => {
       const ref = NucleusEngine.getCommandReference();
 
       expect(ref).toContain("grep");
@@ -375,7 +375,7 @@ describe("NucleusEngine", () => {
 });
 
 describe("Factory functions", () => {
-  it("should create engine from content", () => {
+  it("should create engine from content", async () => {
     const engine = createEngineFromContent("test content");
 
     expect(engine.isLoaded()).toBe(true);
@@ -391,23 +391,23 @@ describe("Factory functions", () => {
 });
 
 describe("ReDoS protection in grep", () => {
-  it("should reject ReDoS pattern (a+)+", () => {
+  it("should reject ReDoS pattern (a+)+", async () => {
     const engine = createEngineFromContent("aaaaaaaaaaaa test data");
-    const result = engine.execute('(grep "(a+)+")');
+    const result = await engine.execute('(grep "(a+)+")');
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/regex|backtracking/i);
   });
 });
 
 describe("loadContent empty string edge case", () => {
-  it("should treat empty string as not loaded", () => {
+  it("should treat empty string as not loaded", async () => {
     const engine = new NucleusEngine();
     engine.loadContent("");
     // Empty document should not be considered "loaded"
     expect(engine.isLoaded()).toBe(false);
   });
 
-  it("should treat whitespace-only string as not loaded", () => {
+  it("should treat whitespace-only string as not loaded", async () => {
     const engine = new NucleusEngine();
     engine.loadContent("   \n\n  ");
     // Whitespace-only document should not be considered "loaded"
@@ -416,7 +416,7 @@ describe("loadContent empty string edge case", () => {
 });
 
 describe("dispose", () => {
-  it("should clear content and state after dispose", () => {
+  it("should clear content and state after dispose", async () => {
     const engine = createEngineFromContent("some content here");
     expect(engine.isLoaded()).toBe(true);
     expect(engine.getContent()).toBe("some content here");

--- a/tests/graph/integration.test.ts
+++ b/tests/graph/integration.test.ts
@@ -106,10 +106,10 @@ function bootstrap(): void {
     bindings.set("_symbolGraph", graph);
   }
 
-  function query(cmd: string) {
+  async function query(cmd: string) {
     const parsed = parse(cmd);
     expect(parsed.success).toBe(true);
-    const result = solve(parsed.term!, tools, bindings);
+    const result = await solve(parsed.term!, tools, bindings);
     // Bind arrays for chaining
     if (result.success && Array.isArray(result.value)) {
       bindings.set("RESULTS", result.value);
@@ -117,63 +117,63 @@ function bootstrap(): void {
     return result;
   }
 
-  it("should detect inheritance chain", () => {
+  it("should detect inheritance chain", async () => {
     setup();
-    const result = query('(ancestors "AppLogger")');
+    const result = await query('(ancestors "AppLogger")');
     expect(result.success).toBe(true);
     const names = (result.value as Symbol[]).map((s) => s.name);
     expect(names).toEqual(["Logger", "EventEmitter"]);
   });
 
-  it("should find all descendants of base class", () => {
+  it("should find all descendants of base class", async () => {
     setup();
-    const result = query('(descendants "EventEmitter")');
+    const result = await query('(descendants "EventEmitter")');
     expect(result.success).toBe(true);
     const names = (result.value as Symbol[]).map((s) => s.name).sort();
     expect(names).toEqual(["AppLogger", "Logger"]);
   });
 
-  it("should find interface implementations", () => {
+  it("should find interface implementations", async () => {
     setup();
-    const result = query('(implementations "Plugin")');
+    const result = await query('(implementations "Plugin")');
     expect(result.success).toBe(true);
     const names = (result.value as Symbol[]).map((s) => s.name);
     expect(names).toEqual(["MetricsPlugin"]);
   });
 
-  it("should detect call graph: info → log → emit", () => {
+  it("should detect call graph: info → log → emit", async () => {
     setup();
 
     // info calls log
-    let result = query('(callees "info")');
+    let result = await query('(callees "info")');
     expect(result.success).toBe(true);
     expect((result.value as Symbol[]).map((s) => s.name)).toContain("log");
 
     // log calls emit
-    result = query('(callees "log")');
+    result = await query('(callees "log")');
     expect(result.success).toBe(true);
     expect((result.value as Symbol[]).map((s) => s.name)).toContain("emit");
   });
 
-  it("should find who calls log", () => {
+  it("should find who calls log", async () => {
     setup();
-    const result = query('(callers "log")');
+    const result = await query('(callers "log")');
     expect(result.success).toBe(true);
     const callers = (result.value as Symbol[]).map((s) => s.name).sort();
     expect(callers).toContain("info");
     expect(callers).toContain("warn");
   });
 
-  it("should compose graph queries with count", () => {
+  it("should compose graph queries with count", async () => {
     setup();
-    const result = query('(count (callers "log"))');
+    const result = await query('(count (callers "log"))');
     expect(result.success).toBe(true);
     expect(result.value).toBe(2); // info and warn
   });
 
-  it("should get neighborhood of a symbol", () => {
+  it("should get neighborhood of a symbol", async () => {
     setup();
-    const result = query('(symbol_graph "Logger" 1)');
+    const result = await query('(symbol_graph "Logger" 1)');
     expect(result.success).toBe(true);
     const hood = result.value as { nodes: Symbol[]; edges: any[] };
     const names = hood.nodes.map((s) => s.name).sort();
@@ -183,7 +183,7 @@ function bootstrap(): void {
     expect(names).toContain("AppLogger");
   });
 
-  it("should report graph stats", () => {
+  it("should report graph stats", async () => {
     setup();
     const stats = graph.stats();
     expect(stats.nodes).toBe(12);

--- a/tests/handle-eviction.test.ts
+++ b/tests/handle-eviction.test.ts
@@ -33,11 +33,11 @@ describe("Handle eviction", () => {
     fs.rmSync(tempDir, { recursive: true });
   });
 
-  it("should not evict handles when count is below limit", () => {
+  it("should not evict handles when count is below limit", async () => {
     // Create a few handles
-    const r1 = session.execute('(grep "LINE_00")');
-    const r2 = session.execute('(grep "LINE_01")');
-    const r3 = session.execute('(grep "LINE_02")');
+    const r1 = await session.execute('(grep "LINE_00")');
+    const r2 = await session.execute('(grep "LINE_01")');
+    const r3 = await session.execute('(grep "LINE_02")');
 
     expect(r1.handle).toBe("$res1");
     expect(r2.handle).toBe("$res2");
@@ -50,12 +50,12 @@ describe("Handle eviction", () => {
     expect(bindings["$res3"]).toBeDefined();
   });
 
-  it("should not evict when at exactly MAX_HANDLES - 1", () => {
+  it("should not evict when at exactly MAX_HANDLES - 1", async () => {
     // Create handles up to limit minus 1. This is a conceptual test:
     // after storing a handle, the count should be the number of stored handles.
     // The eviction check should use > not >= to avoid premature eviction.
-    const r1 = session.execute('(grep "LINE_00")');
-    const r2 = session.execute('(grep "LINE_01")');
+    const r1 = await session.execute('(grep "LINE_00")');
+    const r2 = await session.execute('(grep "LINE_01")');
 
     // Both should be present - no eviction for small counts
     expect(session.expand(r1.handle!).success).toBe(true);

--- a/tests/integration/diverse-scenarios.test.ts
+++ b/tests/integration/diverse-scenarios.test.ts
@@ -72,25 +72,25 @@ SALES_DATA_EAST: $2,890,000
 SALES_DATA_WEST: $2,670,000
 SALES_DATA_CENTRAL: $1,980,000`;
 
-    it("should find sales data lines", () => {
+    it("should find sales data lines", async () => {
       const tools = createMockTools(salesData);
       const bindings: Bindings = new Map();
 
-      const result = solve(parse('(grep "SALES_DATA")').term!, tools, bindings);
+      const result = await solve(parse('(grep "SALES_DATA")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect((result.value as unknown[]).length).toBe(5);
     });
 
-    it("should filter to specific regions", () => {
+    it("should filter to specific regions", async () => {
       const tools = createMockTools(salesData);
       const bindings: Bindings = new Map();
 
       // First grep
-      const grepResult = solve(parse('(grep "SALES_DATA")').term!, tools, bindings);
+      const grepResult = await solve(parse('(grep "SALES_DATA")').term!, tools, bindings);
       bindings.set("RESULTS", grepResult.value);
 
       // Then filter
-      const filterResult = solve(
+      const filterResult = await solve(
         parse('(filter RESULTS (lambda x (match x "NORTH" 0)))').term!,
         tools,
         bindings
@@ -99,16 +99,16 @@ SALES_DATA_CENTRAL: $1,980,000`;
       expect((filterResult.value as unknown[]).length).toBe(1);
     });
 
-    it("should extract and sum numeric values", () => {
+    it("should extract and sum numeric values", async () => {
       const tools = createMockTools(salesData);
       const bindings: Bindings = new Map();
 
       // Grep for sales data
-      const grepResult = solve(parse('(grep "SALES_DATA")').term!, tools, bindings);
+      const grepResult = await solve(parse('(grep "SALES_DATA")').term!, tools, bindings);
       bindings.set("RESULTS", grepResult.value);
 
       // Map to extract amounts
-      const mapResult = solve(
+      const mapResult = await solve(
         parse('(map RESULTS (lambda x (match x "[0-9,]+" 0)))').term!,
         tools,
         bindings
@@ -116,7 +116,7 @@ SALES_DATA_CENTRAL: $1,980,000`;
       bindings.set("RESULTS", mapResult.value);
 
       // Sum the values
-      const sumResult = solve(parse('(sum RESULTS)').term!, tools, bindings);
+      const sumResult = await solve(parse('(sum RESULTS)').term!, tools, bindings);
       expect(sumResult.success).toBe(true);
       // 2340000 + 3120000 + 2890000 + 2670000 + 1980000 = 13000000
       expect(sumResult.value).toBe(13000000);
@@ -130,25 +130,25 @@ SALES_DATA_CENTRAL: $1,980,000`;
 [06:16:04] ERROR: Webhook delivery failed - webhook_id=WH-001
 [06:16:05] INFO: Request completed successfully`;
 
-    it("should find error lines", () => {
+    it("should find error lines", async () => {
       const tools = createMockTools(serverLogs);
       const bindings: Bindings = new Map();
 
-      const result = solve(parse('(grep "ERROR")').term!, tools, bindings);
+      const result = await solve(parse('(grep "ERROR")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect((result.value as unknown[]).length).toBe(3);
     });
 
-    it("should filter for specific error types", () => {
+    it("should filter for specific error types", async () => {
       const tools = createMockTools(serverLogs);
       const bindings: Bindings = new Map();
 
       // Grep for errors
-      const grepResult = solve(parse('(grep "ERROR")').term!, tools, bindings);
+      const grepResult = await solve(parse('(grep "ERROR")').term!, tools, bindings);
       bindings.set("RESULTS", grepResult.value);
 
       // Filter for payment errors
-      const filterResult = solve(
+      const filterResult = await solve(
         parse('(filter RESULTS (lambda x (match x "Payment" 0)))').term!,
         tools,
         bindings
@@ -157,14 +157,14 @@ SALES_DATA_CENTRAL: $1,980,000`;
       expect((filterResult.value as unknown[]).length).toBe(1);
     });
 
-    it("should count errors", () => {
+    it("should count errors", async () => {
       const tools = createMockTools(serverLogs);
       const bindings: Bindings = new Map();
 
-      const grepResult = solve(parse('(grep "ERROR")').term!, tools, bindings);
+      const grepResult = await solve(parse('(grep "ERROR")').term!, tools, bindings);
       bindings.set("RESULTS", grepResult.value);
 
-      const countResult = solve(parse('(count RESULTS)').term!, tools, bindings);
+      const countResult = await solve(parse('(count RESULTS)').term!, tools, bindings);
       expect(countResult.success).toBe(true);
       expect(countResult.value).toBe(3);
     });
@@ -177,34 +177,34 @@ TEMP_READING_LAB_003: 21.5°C | Status: NORMAL
 TEMP_READING_COLD_001: -15.2°C | Status: CRITICAL_HIGH
 TEMP_READING_COLD_002: -18.4°C | Status: NORMAL`;
 
-    it("should find critical readings", () => {
+    it("should find critical readings", async () => {
       const tools = createMockTools(sensorData);
       const bindings: Bindings = new Map();
 
-      const result = solve(parse('(grep "CRITICAL")').term!, tools, bindings);
+      const result = await solve(parse('(grep "CRITICAL")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect((result.value as unknown[]).length).toBe(1);
     });
 
-    it("should find warning readings", () => {
+    it("should find warning readings", async () => {
       const tools = createMockTools(sensorData);
       const bindings: Bindings = new Map();
 
-      const result = solve(parse('(grep "WARNING")').term!, tools, bindings);
+      const result = await solve(parse('(grep "WARNING")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect((result.value as unknown[]).length).toBe(1);
     });
 
-    it("should filter lab vs cold readings", () => {
+    it("should filter lab vs cold readings", async () => {
       const tools = createMockTools(sensorData);
       const bindings: Bindings = new Map();
 
       // Grep all temp readings
-      const grepResult = solve(parse('(grep "TEMP_READING")').term!, tools, bindings);
+      const grepResult = await solve(parse('(grep "TEMP_READING")').term!, tools, bindings);
       bindings.set("RESULTS", grepResult.value);
 
       // Filter for LAB readings
-      const filterResult = solve(
+      const filterResult = await solve(
         parse('(filter RESULTS (lambda x (match x "LAB" 0)))').term!,
         tools,
         bindings
@@ -220,34 +220,34 @@ SKU: ELEC-PHONE-002 | Galaxy S24 | PRICE: $849.00 | QTY: 12 | STATUS: LOW_STOCK
 SKU: ELEC-LAPTOP-001 | MacBook Air | PRICE: $1099.00 | QTY: 78 | STATUS: IN_STOCK
 SKU: ELEC-TABLET-001 | iPad Pro | PRICE: $799.00 | QTY: 0 | STATUS: OUT_OF_STOCK`;
 
-    it("should find low stock items", () => {
+    it("should find low stock items", async () => {
       const tools = createMockTools(inventoryData);
       const bindings: Bindings = new Map();
 
-      const result = solve(parse('(grep "LOW_STOCK")').term!, tools, bindings);
+      const result = await solve(parse('(grep "LOW_STOCK")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect((result.value as unknown[]).length).toBe(1);
     });
 
-    it("should find out of stock items", () => {
+    it("should find out of stock items", async () => {
       const tools = createMockTools(inventoryData);
       const bindings: Bindings = new Map();
 
-      const result = solve(parse('(grep "OUT_OF_STOCK")').term!, tools, bindings);
+      const result = await solve(parse('(grep "OUT_OF_STOCK")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect((result.value as unknown[]).length).toBe(1);
     });
 
-    it("should filter by product category", () => {
+    it("should filter by product category", async () => {
       const tools = createMockTools(inventoryData);
       const bindings: Bindings = new Map();
 
       // Grep all items
-      const grepResult = solve(parse('(grep "SKU:")').term!, tools, bindings);
+      const grepResult = await solve(parse('(grep "SKU:")').term!, tools, bindings);
       bindings.set("RESULTS", grepResult.value);
 
       // Filter for phones
-      const filterResult = solve(
+      const filterResult = await solve(
         parse('(filter RESULTS (lambda x (match x "PHONE" 0)))').term!,
         tools,
         bindings
@@ -266,33 +266,33 @@ SALES_TOTAL: $750,000
 INFO: System recovered at 10:30
 SALES_TOTAL: $250,000`;
 
-    it("should complete grep -> filter -> count workflow", () => {
+    it("should complete grep -> filter -> count workflow", async () => {
       const tools = createMockTools(mixedData);
       const bindings: Bindings = new Map();
 
       // Turn 1: Grep
-      const t1 = solve(parse('(grep "ERROR")').term!, tools, bindings);
+      const t1 = await solve(parse('(grep "ERROR")').term!, tools, bindings);
       bindings.set("RESULTS", t1.value);
       bindings.set("_1", t1.value);
       expect((t1.value as unknown[]).length).toBe(2);
 
       // Turn 2: Count
-      const t2 = solve(parse('(count RESULTS)').term!, tools, bindings);
+      const t2 = await solve(parse('(count RESULTS)').term!, tools, bindings);
       expect(t2.value).toBe(2);
     });
 
-    it("should complete grep -> map -> sum workflow", () => {
+    it("should complete grep -> map -> sum workflow", async () => {
       const tools = createMockTools(mixedData);
       const bindings: Bindings = new Map();
 
       // Turn 1: Grep sales
-      const t1 = solve(parse('(grep "SALES_TOTAL")').term!, tools, bindings);
+      const t1 = await solve(parse('(grep "SALES_TOTAL")').term!, tools, bindings);
       bindings.set("RESULTS", t1.value);
       bindings.set("_1", t1.value);
       expect((t1.value as unknown[]).length).toBe(3);
 
       // Turn 2: Map to extract amounts
-      const t2 = solve(
+      const t2 = await solve(
         parse('(map RESULTS (lambda x (match x "[0-9,]+" 0)))').term!,
         tools,
         bindings
@@ -301,50 +301,50 @@ SALES_TOTAL: $250,000`;
       bindings.set("_2", t2.value);
 
       // Turn 3: Sum
-      const t3 = solve(parse('(sum RESULTS)').term!, tools, bindings);
+      const t3 = await solve(parse('(sum RESULTS)').term!, tools, bindings);
       expect(t3.value).toBe(1500000); // 500000 + 750000 + 250000
     });
 
-    it("should allow referencing previous turn results", () => {
+    it("should allow referencing previous turn results", async () => {
       const tools = createMockTools(mixedData);
       const bindings: Bindings = new Map();
 
       // Turn 1: Grep errors
-      const t1 = solve(parse('(grep "ERROR")').term!, tools, bindings);
+      const t1 = await solve(parse('(grep "ERROR")').term!, tools, bindings);
       bindings.set("RESULTS", t1.value);
       bindings.set("_1", t1.value);
 
       // Turn 2: Grep sales (overwrites RESULTS)
-      const t2 = solve(parse('(grep "SALES")').term!, tools, bindings);
+      const t2 = await solve(parse('(grep "SALES")').term!, tools, bindings);
       bindings.set("RESULTS", t2.value);
       bindings.set("_2", t2.value);
 
       // Turn 3: Reference _1 (original error results)
-      const t3 = solve(parse('(count _1)').term!, tools, bindings);
+      const t3 = await solve(parse('(count _1)').term!, tools, bindings);
       expect(t3.value).toBe(2);
 
       // Turn 4: Reference _2 (sales results)
-      const t4 = solve(parse('(count _2)').term!, tools, bindings);
+      const t4 = await solve(parse('(count _2)').term!, tools, bindings);
       expect(t4.value).toBe(3);
     });
   });
 
   describe("Edge Cases", () => {
-    it("should handle empty search results", () => {
+    it("should handle empty search results", async () => {
       const tools = createMockTools("No matching data here");
       const bindings: Bindings = new Map();
 
-      const result = solve(parse('(grep "NONEXISTENT")').term!, tools, bindings);
+      const result = await solve(parse('(grep "NONEXISTENT")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toEqual([]);
     });
 
-    it("should handle filter on empty results", () => {
+    it("should handle filter on empty results", async () => {
       const tools = createMockTools("Some data");
       const bindings: Bindings = new Map();
       bindings.set("RESULTS", []);
 
-      const result = solve(
+      const result = await solve(
         parse('(filter RESULTS (lambda x (match x "test" 0)))').term!,
         tools,
         bindings
@@ -353,26 +353,26 @@ SALES_TOTAL: $250,000`;
       expect(result.value).toEqual([]);
     });
 
-    it("should handle sum of empty array", () => {
+    it("should handle sum of empty array", async () => {
       const tools = createMockTools("Some data");
       const bindings: Bindings = new Map();
       bindings.set("RESULTS", []);
 
-      const result = solve(parse('(sum RESULTS)').term!, tools, bindings);
+      const result = await solve(parse('(sum RESULTS)').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe(0);
     });
 
-    it("should handle mixed valid/null values from map", () => {
+    it("should handle mixed valid/null values from map", async () => {
       const tools = createMockTools("Data: 100\nText only\nData: 200");
       const bindings: Bindings = new Map();
 
       // Grep all lines (use pattern that matches all lines)
-      const grepResult = solve(parse('(grep "Data|Text")').term!, tools, bindings);
+      const grepResult = await solve(parse('(grep "Data|Text")').term!, tools, bindings);
       bindings.set("RESULTS", grepResult.value);
 
       // Map to extract numbers (some will be null)
-      const mapResult = solve(
+      const mapResult = await solve(
         parse('(map RESULTS (lambda x (match x "[0-9]+" 0)))').term!,
         tools,
         bindings
@@ -380,7 +380,7 @@ SALES_TOTAL: $250,000`;
       bindings.set("RESULTS", mapResult.value);
 
       // Sum should handle nulls gracefully
-      const sumResult = solve(parse('(sum RESULTS)').term!, tools, bindings);
+      const sumResult = await solve(parse('(sum RESULTS)').term!, tools, bindings);
       expect(sumResult.success).toBe(true);
       expect(sumResult.value).toBe(300);
     });

--- a/tests/lattice-mcp-handles.test.ts
+++ b/tests/lattice-mcp-handles.test.ts
@@ -52,8 +52,8 @@ describe("Lattice MCP Handle-Based Results", () => {
       await session.loadFile(testFile);
     });
 
-    it("should return handle stub for array results", () => {
-      const result = session.execute('(grep "ERROR")');
+    it("should return handle stub for array results", async () => {
+      const result = await session.execute('(grep "ERROR")');
 
       expect(result.success).toBe(true);
       expect(result.handle).toMatch(/^\$res\d+$/);
@@ -63,26 +63,26 @@ describe("Lattice MCP Handle-Based Results", () => {
       expect(result.value).toBeUndefined();
     });
 
-    it("should include preview in stub for context", () => {
-      const result = session.execute('(grep "ERROR")');
+    it("should include preview in stub for context", async () => {
+      const result = await session.execute('(grep "ERROR")');
 
       // Stub should show preview of first item
       expect(result.stub).toContain("ERROR");
     });
 
-    it("should return scalar values directly", () => {
-      session.execute('(grep "ERROR")');
-      const result = session.execute("(count RESULTS)");
+    it("should return scalar values directly", async () => {
+      await session.execute('(grep "ERROR")');
+      const result = await session.execute("(count RESULTS)");
 
       expect(result.success).toBe(true);
       expect(result.value).toBe(3);
       expect(result.handle).toBeUndefined();
     });
 
-    it("should track multiple handles", () => {
-      session.execute('(grep "ERROR")');
-      session.execute('(grep "INFO")');
-      session.execute('(grep "WARN")');
+    it("should track multiple handles", async () => {
+      await session.execute('(grep "ERROR")');
+      await session.execute('(grep "INFO")');
+      await session.execute('(grep "WARN")');
 
       const bindings = session.getBindings();
 
@@ -97,8 +97,8 @@ describe("Lattice MCP Handle-Based Results", () => {
       await session.loadFile(testFile);
     });
 
-    it("should expand handle to full data", () => {
-      const query = session.execute('(grep "ERROR")');
+    it("should expand handle to full data", async () => {
+      const query = await session.execute('(grep "ERROR")');
       const expanded = session.expand(query.handle!);
 
       expect(expanded.success).toBe(true);
@@ -106,16 +106,16 @@ describe("Lattice MCP Handle-Based Results", () => {
       expect(expanded.total).toBe(3);
     });
 
-    it("should support limit for partial inspection", () => {
-      const query = session.execute('(grep "ERROR")');
+    it("should support limit for partial inspection", async () => {
+      const query = await session.execute('(grep "ERROR")');
       const expanded = session.expand(query.handle!, { limit: 2 });
 
       expect(expanded.data).toHaveLength(2);
       expect(expanded.total).toBe(3);
     });
 
-    it("should support pagination with offset", () => {
-      const query = session.execute('(grep "ERROR")');
+    it("should support pagination with offset", async () => {
+      const query = await session.execute('(grep "ERROR")');
 
       const page1 = session.expand(query.handle!, { offset: 0, limit: 2 });
       const page2 = session.expand(query.handle!, { offset: 2, limit: 2 });
@@ -124,8 +124,8 @@ describe("Lattice MCP Handle-Based Results", () => {
       expect(page2.data).toHaveLength(1);
     });
 
-    it("should format as lines for readable output", () => {
-      const query = session.execute('(grep "ERROR")');
+    it("should format as lines for readable output", async () => {
+      const query = await session.execute('(grep "ERROR")');
       const expanded = session.expand(query.handle!, { format: "lines" });
 
       expect(expanded.data![0]).toMatch(/^\[\d+\]/);
@@ -138,19 +138,19 @@ describe("Lattice MCP Handle-Based Results", () => {
       await session.loadFile(testFile);
     });
 
-    it("should chain operations, getting handles at each step", () => {
+    it("should chain operations, getting handles at each step", async () => {
       // Step 1: grep for errors
-      const step1 = session.execute('(grep "ERROR")');
+      const step1 = await session.execute('(grep "ERROR")');
       expect(step1.handle).toBeDefined();
       expect(step1.stub).toContain("Array(3)");
 
       // Step 2: filter for timeouts
-      const step2 = session.execute('(filter RESULTS (lambda x (match x "timeout" 0)))');
+      const step2 = await session.execute('(filter RESULTS (lambda x (match x "timeout" 0)))');
       expect(step2.handle).toBeDefined();
       expect(step2.stub).toContain("Array(2)"); // "Connection timeout" and "Request timeout"
 
       // Step 3: count results (scalar, no handle)
-      const step3 = session.execute("(count RESULTS)");
+      const step3 = await session.execute("(count RESULTS)");
       expect(step3.value).toBe(2);
       expect(step3.handle).toBeUndefined();
 
@@ -162,9 +162,9 @@ describe("Lattice MCP Handle-Based Results", () => {
       expect(expanded2.total).toBe(2);
     });
 
-    it("should allow inspecting intermediate results when needed", () => {
+    it("should allow inspecting intermediate results when needed", async () => {
       // Initial grep
-      session.execute('(grep "2024")');
+      await session.execute('(grep "2024")');
 
       // Get bindings to see what we have
       const bindings = session.getBindings();
@@ -175,7 +175,7 @@ describe("Lattice MCP Handle-Based Results", () => {
       expect(preview).toHaveLength(3);
 
       // Now filter based on what we saw
-      const filtered = session.execute('(filter RESULTS (lambda x (match x "ERROR" 0)))');
+      const filtered = await session.execute('(filter RESULTS (lambda x (match x "ERROR" 0)))');
 
       // Expand to see full filtered results
       const expanded = session.expand(filtered.handle!);
@@ -197,7 +197,7 @@ describe("Lattice MCP Handle-Based Results", () => {
       await largeSession.loadFile(largeFile);
 
       // Query that returns many results
-      const result = largeSession.execute('(grep "LOG")');
+      const result = await largeSession.execute('(grep "LOG")');
 
       // Handle stub should be compact
       const stubSize = result.stub!.length;
@@ -223,16 +223,16 @@ describe("Lattice MCP Handle-Based Results", () => {
       await session.loadFile(testFile);
     });
 
-    it("should return error for invalid handle expand", () => {
+    it("should return error for invalid handle expand", async () => {
       const result = session.expand("$invalid");
 
       expect(result.success).toBe(false);
       expect(result.error).toContain("Invalid handle");
     });
 
-    it("should return error for query without document", () => {
+    it("should return error for query without document", async () => {
       const emptySession = new HandleSession();
-      const result = emptySession.execute('(grep "test")');
+      const result = await emptySession.execute('(grep "test")');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain("No document loaded");

--- a/tests/logic/bm25-nucleus.test.ts
+++ b/tests/logic/bm25-nucleus.test.ts
@@ -70,7 +70,7 @@ const testContext = `[10:00] INFO: System started
 [10:04] INFO: Connection established`;
 
 describe("BM25 Parser", () => {
-  it("should parse bm25 with query", () => {
+  it("should parse bm25 with query", async () => {
     const result = parse('(bm25 "database error")');
     expect(result.success).toBe(true);
     expect(result.term?.tag).toBe("bm25");
@@ -80,7 +80,7 @@ describe("BM25 Parser", () => {
     }
   });
 
-  it("should parse bm25 with query and limit", () => {
+  it("should parse bm25 with query and limit", async () => {
     const result = parse('(bm25 "database error" 20)');
     expect(result.success).toBe(true);
     expect(result.term?.tag).toBe("bm25");
@@ -90,26 +90,26 @@ describe("BM25 Parser", () => {
     }
   });
 
-  it("should fail on non-string query", () => {
+  it("should fail on non-string query", async () => {
     const result = parse("(bm25 42)");
     expect(result.success).toBe(false);
   });
 
-  it("should fail on empty bm25", () => {
+  it("should fail on empty bm25", async () => {
     const result = parse("(bm25)");
     expect(result.success).toBe(false);
   });
 });
 
 describe("BM25 prettyPrint", () => {
-  it("should round-trip bm25 without limit", () => {
+  it("should round-trip bm25 without limit", async () => {
     const result = parse('(bm25 "database error")');
     expect(result.success).toBe(true);
     const printed = prettyPrint(result.term!);
     expect(printed).toBe('(bm25 "database error")');
   });
 
-  it("should round-trip bm25 with limit", () => {
+  it("should round-trip bm25 with limit", async () => {
     const result = parse('(bm25 "database error" 20)');
     expect(result.success).toBe(true);
     const printed = prettyPrint(result.term!);
@@ -118,7 +118,7 @@ describe("BM25 prettyPrint", () => {
 });
 
 describe("BM25 Type Inference", () => {
-  it("should infer array type for bm25", () => {
+  it("should infer array type for bm25", async () => {
     const result = parse('(bm25 "query")');
     expect(result.success).toBe(true);
     const typeResult = inferType(result.term!);
@@ -128,52 +128,52 @@ describe("BM25 Type Inference", () => {
 });
 
 describe("BM25 Solver", () => {
-  it("should execute bm25 search and return results", () => {
+  it("should execute bm25 search and return results", async () => {
     const tools = createMockTools(testContext);
     const result = parse('(bm25 "error database")');
     expect(result.success).toBe(true);
 
-    const solveResult = solve(result.term!, tools);
+    const solveResult = await solve(result.term!, tools);
     expect(solveResult.success).toBe(true);
     expect(Array.isArray(solveResult.value)).toBe(true);
     const results = solveResult.value as Array<{ line: string; lineNum: number; score: number }>;
     expect(results.length).toBeGreaterThan(0);
   });
 
-  it("should respect limit in bm25 search", () => {
+  it("should respect limit in bm25 search", async () => {
     const tools = createMockTools(testContext);
     const result = parse('(bm25 "error" 1)');
     expect(result.success).toBe(true);
 
-    const solveResult = solve(result.term!, tools);
+    const solveResult = await solve(result.term!, tools);
     expect(solveResult.success).toBe(true);
     const results = solveResult.value as Array<{ line: string }>;
     expect(results.length).toBeLessThanOrEqual(1);
   });
 
-  it("should work with filter on bm25 results", () => {
+  it("should work with filter on bm25 results", async () => {
     const tools = createMockTools(testContext);
     const bindings: Bindings = new Map();
 
     // First: run bm25
     const bm25Result = parse('(bm25 "error connection")');
     expect(bm25Result.success).toBe(true);
-    const bm25SolveResult = solve(bm25Result.term!, tools);
+    const bm25SolveResult = await solve(bm25Result.term!, tools);
     expect(bm25SolveResult.success).toBe(true);
     bindings.set("RESULTS", bm25SolveResult.value);
 
     // Then: filter RESULTS
     const filterResult = parse('(filter RESULTS (lambda line (match line "timeout" 0)))');
     expect(filterResult.success).toBe(true);
-    const filterSolveResult = solve(filterResult.term!, tools, bindings);
+    const filterSolveResult = await solve(filterResult.term!, tools, bindings);
     expect(filterSolveResult.success).toBe(true);
   });
 
-  it("should use default limit when none provided", () => {
+  it("should use default limit when none provided", async () => {
     const tools = createMockTools(testContext);
     const result = parse('(bm25 "error")');
     expect(result.success).toBe(true);
-    const solveResult = solve(result.term!, tools);
+    const solveResult = await solve(result.term!, tools);
     expect(solveResult.success).toBe(true);
     // Default limit is 10, so all matching lines should appear
     const results = solveResult.value as Array<{ line: string }>;

--- a/tests/logic/dampen-nucleus.test.ts
+++ b/tests/logic/dampen-nucleus.test.ts
@@ -68,7 +68,7 @@ const testContext = `[10:00] INFO: System started
 [10:04] INFO: Connection established`;
 
 describe("dampen Parser", () => {
-  it("should parse dampen with collection and query", () => {
+  it("should parse dampen with collection and query", async () => {
     const result = parse('(dampen (bm25 "error") "database error")');
     expect(result.success).toBe(true);
     expect(result.term?.tag).toBe("dampen");
@@ -78,7 +78,7 @@ describe("dampen Parser", () => {
     }
   });
 
-  it("should parse dampen with variable reference", () => {
+  it("should parse dampen with variable reference", async () => {
     const result = parse('(dampen RESULTS "connection timeout")');
     expect(result.success).toBe(true);
     if (result.term?.tag === "dampen") {
@@ -87,26 +87,26 @@ describe("dampen Parser", () => {
     }
   });
 
-  it("should fail without query string", () => {
+  it("should fail without query string", async () => {
     const result = parse("(dampen RESULTS)");
     expect(result.success).toBe(false);
   });
 
-  it("should fail on empty dampen", () => {
+  it("should fail on empty dampen", async () => {
     const result = parse("(dampen)");
     expect(result.success).toBe(false);
   });
 });
 
 describe("dampen prettyPrint", () => {
-  it("should round-trip dampen", () => {
+  it("should round-trip dampen", async () => {
     const result = parse('(dampen RESULTS "database error")');
     expect(result.success).toBe(true);
     const printed = prettyPrint(result.term!);
     expect(printed).toBe('(dampen RESULTS "database error")');
   });
 
-  it("should round-trip dampen with nested expression", () => {
+  it("should round-trip dampen with nested expression", async () => {
     const result = parse('(dampen (bm25 "error") "database error")');
     expect(result.success).toBe(true);
     const printed = prettyPrint(result.term!);
@@ -115,7 +115,7 @@ describe("dampen prettyPrint", () => {
 });
 
 describe("dampen Type Inference", () => {
-  it("should infer array type for dampen", () => {
+  it("should infer array type for dampen", async () => {
     const result = parse('(dampen (bm25 "error") "database")');
     expect(result.success).toBe(true);
     const typeResult = inferType(result.term!);
@@ -125,14 +125,14 @@ describe("dampen Type Inference", () => {
 });
 
 describe("dampen Solver", () => {
-  it("should dampen results that lack query terms", () => {
+  it("should dampen results that lack query terms", async () => {
     const tools = createMockTools(testContext);
 
     // BM25 returns results with scores — dampen ones without "database"
     const result = parse('(dampen (bm25 "error connection database") "database")');
     expect(result.success).toBe(true);
 
-    const solveResult = solve(result.term!, tools);
+    const solveResult = await solve(result.term!, tools);
     expect(solveResult.success).toBe(true);
     expect(Array.isArray(solveResult.value)).toBe(true);
     const results = solveResult.value as DampenableResult[];
@@ -148,44 +148,44 @@ describe("dampen Solver", () => {
     }
   });
 
-  it("should work with bindings", () => {
+  it("should work with bindings", async () => {
     const tools = createMockTools(testContext);
     const bindings: Bindings = new Map();
 
     // Store bm25 results in bindings
     const bm25Parse = parse('(bm25 "error connection")');
-    const bm25Result = solve(bm25Parse.term!, tools);
+    const bm25Result = await solve(bm25Parse.term!, tools);
     bindings.set("RESULTS", bm25Result.value);
 
     // Dampen using bindings
     const dampenParse = parse('(dampen RESULTS "database")');
     expect(dampenParse.success).toBe(true);
-    const dampenResult = solve(dampenParse.term!, tools, bindings);
+    const dampenResult = await solve(dampenParse.term!, tools, bindings);
     expect(dampenResult.success).toBe(true);
     expect(Array.isArray(dampenResult.value)).toBe(true);
   });
 
-  it("should compose with filter after dampening", () => {
+  it("should compose with filter after dampening", async () => {
     const tools = createMockTools(testContext);
     const bindings: Bindings = new Map();
 
     const dampenParse = parse('(dampen (bm25 "error") "error")');
-    const dampenResult = solve(dampenParse.term!, tools);
+    const dampenResult = await solve(dampenParse.term!, tools);
     expect(dampenResult.success).toBe(true);
     bindings.set("RESULTS", dampenResult.value);
 
     const filterParse = parse('(filter RESULTS (lambda x (match x "timeout" 0)))');
     expect(filterParse.success).toBe(true);
-    const filterResult = solve(filterParse.term!, tools, bindings);
+    const filterResult = await solve(filterParse.term!, tools, bindings);
     expect(filterResult.success).toBe(true);
   });
 
-  it("should compose with fuse then dampen", () => {
+  it("should compose with fuse then dampen", async () => {
     const tools = createMockTools(testContext);
 
     const result = parse('(dampen (fuse (grep "ERROR") (bm25 "error")) "error")');
     expect(result.success).toBe(true);
-    const solveResult = solve(result.term!, tools);
+    const solveResult = await solve(result.term!, tools);
     expect(solveResult.success).toBe(true);
     expect(Array.isArray(solveResult.value)).toBe(true);
   });

--- a/tests/logic/fuse-nucleus.test.ts
+++ b/tests/logic/fuse-nucleus.test.ts
@@ -68,7 +68,7 @@ const testContext = `[10:00] INFO: System started
 [10:04] INFO: Connection established`;
 
 describe("fuse Parser", () => {
-  it("should parse fuse with two sub-expressions", () => {
+  it("should parse fuse with two sub-expressions", async () => {
     const result = parse('(fuse (grep "ERROR") (bm25 "error"))');
     expect(result.success).toBe(true);
     expect(result.term?.tag).toBe("fuse");
@@ -79,7 +79,7 @@ describe("fuse Parser", () => {
     }
   });
 
-  it("should parse fuse with three sub-expressions", () => {
+  it("should parse fuse with three sub-expressions", async () => {
     const result = parse('(fuse (grep "ERROR") (bm25 "error") (fuzzy_search "error"))');
     expect(result.success).toBe(true);
     if (result.term?.tag === "fuse") {
@@ -87,7 +87,7 @@ describe("fuse Parser", () => {
     }
   });
 
-  it("should parse fuse with variable references", () => {
+  it("should parse fuse with variable references", async () => {
     const result = parse("(fuse RESULTS _1)");
     expect(result.success).toBe(true);
     if (result.term?.tag === "fuse") {
@@ -97,19 +97,19 @@ describe("fuse Parser", () => {
     }
   });
 
-  it("should fail on fuse with fewer than 2 arguments", () => {
+  it("should fail on fuse with fewer than 2 arguments", async () => {
     const result = parse('(fuse (grep "ERROR"))');
     expect(result.success).toBe(false);
   });
 
-  it("should fail on empty fuse", () => {
+  it("should fail on empty fuse", async () => {
     const result = parse("(fuse)");
     expect(result.success).toBe(false);
   });
 });
 
 describe("fuse prettyPrint", () => {
-  it("should round-trip fuse with two sub-expressions", () => {
+  it("should round-trip fuse with two sub-expressions", async () => {
     const result = parse('(fuse (grep "ERROR") (bm25 "error"))');
     expect(result.success).toBe(true);
     const printed = prettyPrint(result.term!);
@@ -118,7 +118,7 @@ describe("fuse prettyPrint", () => {
 });
 
 describe("fuse Type Inference", () => {
-  it("should infer array type for fuse", () => {
+  it("should infer array type for fuse", async () => {
     const result = parse('(fuse (grep "ERROR") (bm25 "error"))');
     expect(result.success).toBe(true);
     const typeResult = inferType(result.term!);
@@ -128,12 +128,12 @@ describe("fuse Type Inference", () => {
 });
 
 describe("fuse Solver", () => {
-  it("should fuse grep and bm25 results", () => {
+  it("should fuse grep and bm25 results", async () => {
     const tools = createMockTools(testContext);
     const result = parse('(fuse (grep "ERROR") (bm25 "error"))');
     expect(result.success).toBe(true);
 
-    const solveResult = solve(result.term!, tools);
+    const solveResult = await solve(result.term!, tools);
     expect(solveResult.success).toBe(true);
     expect(Array.isArray(solveResult.value)).toBe(true);
     const results = solveResult.value as Array<{ line: string; lineNum: number; score: number }>;
@@ -144,48 +144,48 @@ describe("fuse Solver", () => {
     }
   });
 
-  it("should fuse bindings with fresh results", () => {
+  it("should fuse bindings with fresh results", async () => {
     const tools = createMockTools(testContext);
     const bindings: Bindings = new Map();
 
     // Simulate a previous grep result stored in _1
     const grepParse = parse('(grep "ERROR")');
-    const grepResult = solve(grepParse.term!, tools);
+    const grepResult = await solve(grepParse.term!, tools);
     bindings.set("_1", grepResult.value);
 
     // Fuse _1 with fresh bm25
     const fuseParse = parse('(fuse _1 (bm25 "connection"))');
     expect(fuseParse.success).toBe(true);
-    const fuseResult = solve(fuseParse.term!, tools, bindings);
+    const fuseResult = await solve(fuseParse.term!, tools, bindings);
     expect(fuseResult.success).toBe(true);
     expect(Array.isArray(fuseResult.value)).toBe(true);
   });
 
-  it("should work with filter on fused results", () => {
+  it("should work with filter on fused results", async () => {
     const tools = createMockTools(testContext);
     const bindings: Bindings = new Map();
 
     // Fuse and store
     const fuseParse = parse('(fuse (grep "ERROR") (bm25 "connection"))');
-    const fuseResult = solve(fuseParse.term!, tools);
+    const fuseResult = await solve(fuseParse.term!, tools);
     expect(fuseResult.success).toBe(true);
     bindings.set("RESULTS", fuseResult.value);
 
     // Filter fused results
     const filterParse = parse('(filter RESULTS (lambda x (match x "timeout" 0)))');
     expect(filterParse.success).toBe(true);
-    const filterResult = solve(filterParse.term!, tools, bindings);
+    const filterResult = await solve(filterParse.term!, tools, bindings);
     expect(filterResult.success).toBe(true);
   });
 
-  it("should normalize grep results that lack score field", () => {
+  it("should normalize grep results that lack score field", async () => {
     const tools = createMockTools(testContext);
     // grep results have {match, line, lineNum, index, groups} but NO score
     // fuse must assign default score=1 to them
     const result = parse('(fuse (grep "ERROR") (bm25 "error"))');
     expect(result.success).toBe(true);
 
-    const solveResult = solve(result.term!, tools);
+    const solveResult = await solve(result.term!, tools);
     expect(solveResult.success).toBe(true);
     const results = solveResult.value as Array<{ line: string; lineNum: number; score: number }>;
     // All fused results must have numeric scores
@@ -196,12 +196,12 @@ describe("fuse Solver", () => {
     }
   });
 
-  it("should fuse three signals", () => {
+  it("should fuse three signals", async () => {
     const tools = createMockTools(testContext);
     const result = parse('(fuse (grep "ERROR") (bm25 "error") (fuzzy_search "error"))');
     expect(result.success).toBe(true);
 
-    const solveResult = solve(result.term!, tools);
+    const solveResult = await solve(result.term!, tools);
     expect(solveResult.success).toBe(true);
     expect(Array.isArray(solveResult.value)).toBe(true);
   });

--- a/tests/logic/lc-solver-bindings.test.ts
+++ b/tests/logic/lc-solver-bindings.test.ts
@@ -57,7 +57,7 @@ describe("LC Solver Bindings", () => {
 [10:04] INFO: Connection established`;
 
   describe("basic binding lookup", () => {
-    it("should resolve RESULTS from bindings", () => {
+    it("should resolve RESULTS from bindings", async () => {
       const tools = createMockTools(testContext);
       const bindings: Bindings = new Map();
 
@@ -69,7 +69,7 @@ describe("LC Solver Bindings", () => {
       const parseResult = parse('(filter RESULTS (lambda line (match line "timeout" 0)))');
       expect(parseResult.success).toBe(true);
 
-      const result = solve(parseResult.term!, tools, bindings);
+      const result = await solve(parseResult.term!, tools, bindings);
       console.log("Result error:", result.error);
       console.log("Result logs:", result.logs);
       expect(result.success).toBe(true);
@@ -78,7 +78,7 @@ describe("LC Solver Bindings", () => {
       expect((result.value as Array<{ line: string }>)[0].line).toContain("timeout");
     });
 
-    it("should resolve turn-specific bindings like _1", () => {
+    it("should resolve turn-specific bindings like _1", async () => {
       const tools = createMockTools(testContext);
       const bindings: Bindings = new Map();
 
@@ -90,33 +90,33 @@ describe("LC Solver Bindings", () => {
       const parseResult = parse('(filter _1 (lambda line (match line "started" 0)))');
       expect(parseResult.success).toBe(true);
 
-      const result = solve(parseResult.term!, tools, bindings);
+      const result = await solve(parseResult.term!, tools, bindings);
       expect(result.success).toBe(true);
       expect((result.value as Array<{ line: string }>).length).toBe(1);
     });
 
-    it("should throw error for unbound variable when not in bindings", () => {
+    it("should throw error for unbound variable when not in bindings", async () => {
       const tools = createMockTools(testContext);
       const bindings: Bindings = new Map();
 
       const parseResult = parse('(filter UNKNOWN_VAR (lambda line (match line "test" 0)))');
       expect(parseResult.success).toBe(true);
 
-      const result = solve(parseResult.term!, tools, bindings);
+      const result = await solve(parseResult.term!, tools, bindings);
       expect(result.success).toBe(false);
       expect(result.error).toContain("Unbound variable");
     });
   });
 
   describe("multi-turn workflow simulation", () => {
-    it("should support search → filter → extract workflow", () => {
+    it("should support search → filter → extract workflow", async () => {
       const tools = createMockTools(testContext);
       const bindings: Bindings = new Map();
 
       // Turn 1: Search
       const turn1 = parse('(grep "ERROR")');
       expect(turn1.success).toBe(true);
-      const result1 = solve(turn1.term!, tools, bindings);
+      const result1 = await solve(turn1.term!, tools, bindings);
       expect(result1.success).toBe(true);
       expect((result1.value as Array<unknown>).length).toBe(2);
 
@@ -127,7 +127,7 @@ describe("LC Solver Bindings", () => {
       // Turn 2: Filter
       const turn2 = parse('(filter RESULTS (lambda line (match line "timeout" 0)))');
       expect(turn2.success).toBe(true);
-      const result2 = solve(turn2.term!, tools, bindings);
+      const result2 = await solve(turn2.term!, tools, bindings);
       expect(result2.success).toBe(true);
       expect((result2.value as Array<unknown>).length).toBe(1);
 
@@ -138,12 +138,12 @@ describe("LC Solver Bindings", () => {
       // Turn 3: Can still access _1 (original grep results)
       const turn3 = parse('(filter _1 (lambda line (match line "database" 0)))');
       expect(turn3.success).toBe(true);
-      const result3 = solve(turn3.term!, tools, bindings);
+      const result3 = await solve(turn3.term!, tools, bindings);
       expect(result3.success).toBe(true);
       expect((result3.value as Array<{ line: string }>)[0].line).toContain("database");
     });
 
-    it("should allow chaining map after filter", () => {
+    it("should allow chaining map after filter", async () => {
       const tools = createMockTools(`Total: $100
 Total: $250
 Total: $75`);
@@ -151,24 +151,24 @@ Total: $75`);
 
       // Turn 1: Search for totals
       const turn1 = parse('(grep "Total")');
-      const result1 = solve(turn1.term!, tools, bindings);
+      const result1 = await solve(turn1.term!, tools, bindings);
       bindings.set("RESULTS", result1.value);
 
       // Turn 2: Extract numeric values
       const turn2 = parse('(map RESULTS (lambda line (parseFloat (match line "[0-9]+" 0))))');
-      const result2 = solve(turn2.term!, tools, bindings);
+      const result2 = await solve(turn2.term!, tools, bindings);
       expect(result2.success).toBe(true);
       expect(result2.value).toEqual([100, 250, 75]);
     });
   });
 
   describe("binding log messages", () => {
-    it("should log when resolving from bindings", () => {
+    it("should log when resolving from bindings", async () => {
       const tools = createMockTools(testContext);
       const bindings: Bindings = new Map([["RESULTS", [{ line: "test", lineNum: 1 }]]]);
 
       const parseResult = parse('(filter RESULTS (lambda line (match line "test" 0)))');
-      const result = solve(parseResult.term!, tools, bindings);
+      const result = await solve(parseResult.term!, tools, bindings);
 
       expect(result.logs.some(log => log.includes("Available bindings"))).toBe(true);
       expect(result.logs.some(log => log.includes("Resolved variable RESULTS"))).toBe(true);

--- a/tests/logic/lc-solver-coercion.test.ts
+++ b/tests/logic/lc-solver-coercion.test.ts
@@ -54,150 +54,150 @@ describe("LC Solver Type Coercion", () => {
   const bindings: Bindings = new Map();
 
   describe("parseDate", () => {
-    it("should parse ISO date format", () => {
-      const result = solve(parse('(parseDate "2024-01-15")').term!, tools, bindings);
+    it("should parse ISO date format", async () => {
+      const result = await solve(parse('(parseDate "2024-01-15")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe("2024-01-15");
     });
 
-    it("should parse US date format with hint", () => {
-      const result = solve(parse('(parseDate "01/15/2024" "US")').term!, tools, bindings);
+    it("should parse US date format with hint", async () => {
+      const result = await solve(parse('(parseDate "01/15/2024" "US")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe("2024-01-15");
     });
 
-    it("should parse EU date format with hint", () => {
-      const result = solve(parse('(parseDate "15/01/2024" "EU")').term!, tools, bindings);
+    it("should parse EU date format with hint", async () => {
+      const result = await solve(parse('(parseDate "15/01/2024" "EU")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe("2024-01-15");
     });
 
-    it("should parse natural language date (Month Day, Year)", () => {
-      const result = solve(parse('(parseDate "January 15, 2024")').term!, tools, bindings);
+    it("should parse natural language date (Month Day, Year)", async () => {
+      const result = await solve(parse('(parseDate "January 15, 2024")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe("2024-01-15");
     });
 
-    it("should parse natural language date (Day Month Year)", () => {
-      const result = solve(parse('(parseDate "15 Jan 2024")').term!, tools, bindings);
+    it("should parse natural language date (Day Month Year)", async () => {
+      const result = await solve(parse('(parseDate "15 Jan 2024")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe("2024-01-15");
     });
 
-    it("should return null for invalid date", () => {
-      const result = solve(parse('(parseDate "not a date")').term!, tools, bindings);
+    it("should return null for invalid date", async () => {
+      const result = await solve(parse('(parseDate "not a date")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe(null);
     });
   });
 
   describe("parseCurrency", () => {
-    it("should parse US dollar format", () => {
-      const result = solve(parse('(parseCurrency "$1,234.56")').term!, tools, bindings);
+    it("should parse US dollar format", async () => {
+      const result = await solve(parse('(parseCurrency "$1,234.56")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe(1234.56);
     });
 
-    it("should parse EU format (dot thousands, comma decimal)", () => {
-      const result = solve(parse('(parseCurrency "€1.234,56")').term!, tools, bindings);
+    it("should parse EU format (dot thousands, comma decimal)", async () => {
+      const result = await solve(parse('(parseCurrency "€1.234,56")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe(1234.56);
     });
 
-    it("should parse large currency amounts", () => {
-      const result = solve(parse('(parseCurrency "$2,340,000")').term!, tools, bindings);
+    it("should parse large currency amounts", async () => {
+      const result = await solve(parse('(parseCurrency "$2,340,000")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe(2340000);
     });
 
-    it("should handle negative currency (parentheses)", () => {
-      const result = solve(parse('(parseCurrency "($1,234)")').term!, tools, bindings);
+    it("should handle negative currency (parentheses)", async () => {
+      const result = await solve(parse('(parseCurrency "($1,234)")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe(-1234);
     });
 
-    it("should handle negative currency (minus sign)", () => {
-      const result = solve(parse('(parseCurrency "-$1,234")').term!, tools, bindings);
+    it("should handle negative currency (minus sign)", async () => {
+      const result = await solve(parse('(parseCurrency "-$1,234")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe(-1234);
     });
   });
 
   describe("parseNumber", () => {
-    it("should parse comma-separated number", () => {
-      const result = solve(parse('(parseNumber "1,234,567")').term!, tools, bindings);
+    it("should parse comma-separated number", async () => {
+      const result = await solve(parse('(parseNumber "1,234,567")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe(1234567);
     });
 
-    it("should parse percentage", () => {
-      const result = solve(parse('(parseNumber "50%")').term!, tools, bindings);
+    it("should parse percentage", async () => {
+      const result = await solve(parse('(parseNumber "50%")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe(0.5);
     });
 
-    it("should parse decimal", () => {
-      const result = solve(parse('(parseNumber "3.14159")').term!, tools, bindings);
+    it("should parse decimal", async () => {
+      const result = await solve(parse('(parseNumber "3.14159")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe(3.14159);
     });
 
-    it("should parse scientific notation", () => {
-      const result = solve(parse('(parseNumber "1.5e6")').term!, tools, bindings);
+    it("should parse scientific notation", async () => {
+      const result = await solve(parse('(parseNumber "1.5e6")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe(1500000);
     });
   });
 
   describe("coerce", () => {
-    it("should coerce string to date", () => {
-      const result = solve(parse('(coerce "2024-01-15" "date")').term!, tools, bindings);
+    it("should coerce string to date", async () => {
+      const result = await solve(parse('(coerce "2024-01-15" "date")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe("2024-01-15");
     });
 
-    it("should coerce string to currency", () => {
-      const result = solve(parse('(coerce "$1,234" "currency")').term!, tools, bindings);
+    it("should coerce string to currency", async () => {
+      const result = await solve(parse('(coerce "$1,234" "currency")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe(1234);
     });
 
-    it("should coerce string to number", () => {
-      const result = solve(parse('(coerce "1,234" "number")').term!, tools, bindings);
+    it("should coerce string to number", async () => {
+      const result = await solve(parse('(coerce "1,234" "number")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe(1234);
     });
 
-    it("should coerce to boolean", () => {
-      expect(solve(parse('(coerce "true" "boolean")').term!, tools, bindings).value).toBe(true);
-      expect(solve(parse('(coerce "yes" "boolean")').term!, tools, bindings).value).toBe(true);
-      expect(solve(parse('(coerce "false" "boolean")').term!, tools, bindings).value).toBe(false);
-      expect(solve(parse('(coerce "no" "boolean")').term!, tools, bindings).value).toBe(false);
+    it("should coerce to boolean", async () => {
+      expect((await solve(parse('(coerce "true" "boolean")').term!, tools, bindings)).value).toBe(true);
+      expect((await solve(parse('(coerce "yes" "boolean")').term!, tools, bindings)).value).toBe(true);
+      expect((await solve(parse('(coerce "false" "boolean")').term!, tools, bindings)).value).toBe(false);
+      expect((await solve(parse('(coerce "no" "boolean")').term!, tools, bindings)).value).toBe(false);
     });
   });
 
   describe("extract with type coercion", () => {
-    it("should extract and coerce to currency", () => {
-      const result = solve(parse('(extract "Total: $1,234.56" "\\\\$[\\\\d,.]+" 0 "currency")').term!, tools, bindings);
+    it("should extract and coerce to currency", async () => {
+      const result = await solve(parse('(extract "Total: $1,234.56" "\\\\$[\\\\d,.]+" 0 "currency")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe(1234.56);
     });
 
-    it("should extract and coerce to date", () => {
-      const result = solve(parse('(extract "Date: 2024-01-15" "\\\\d{4}-\\\\d{2}-\\\\d{2}" 0 "date")').term!, tools, bindings);
+    it("should extract and coerce to date", async () => {
+      const result = await solve(parse('(extract "Date: 2024-01-15" "\\\\d{4}-\\\\d{2}-\\\\d{2}" 0 "date")').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe("2024-01-15");
     });
 
-    it("should extract without coercion when type not specified", () => {
-      const result = solve(parse('(extract "Value: 42" "\\\\d+" 0)').term!, tools, bindings);
+    it("should extract without coercion when type not specified", async () => {
+      const result = await solve(parse('(extract "Value: 42" "\\\\d+" 0)').term!, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe("42"); // String, not number
     });
   });
 
   describe("map with type coercion", () => {
-    it("should parse dates in map", () => {
+    it("should parse dates in map", async () => {
       const context = `Event: Jan 15, 2024
 Event: Feb 20, 2024
 Event: Mar 10, 2024`;
@@ -205,11 +205,11 @@ Event: Mar 10, 2024`;
       const mapBindings: Bindings = new Map();
 
       // First grep
-      const grepResult = solve(parse('(grep "Event")').term!, mapTools, mapBindings);
+      const grepResult = await solve(parse('(grep "Event")').term!, mapTools, mapBindings);
       mapBindings.set("RESULTS", grepResult.value);
 
       // Map to extract and parse dates
-      const mapResult = solve(
+      const mapResult = await solve(
         parse('(map RESULTS (lambda x (parseDate (match x "[A-Za-z]+ \\\\d+, \\\\d+" 0))))').term!,
         mapTools,
         mapBindings
@@ -218,7 +218,7 @@ Event: Mar 10, 2024`;
       expect(mapResult.value).toEqual(["2024-01-15", "2024-02-20", "2024-03-10"]);
     });
 
-    it("should parse currencies in map", () => {
+    it("should parse currencies in map", async () => {
       const context = `SALES_NORTH: $2,340,000
 SALES_SOUTH: $3,120,000
 SALES_EAST: $1,890,000`;
@@ -226,11 +226,11 @@ SALES_EAST: $1,890,000`;
       const mapBindings: Bindings = new Map();
 
       // First grep
-      const grepResult = solve(parse('(grep "SALES")').term!, mapTools, mapBindings);
+      const grepResult = await solve(parse('(grep "SALES")').term!, mapTools, mapBindings);
       mapBindings.set("RESULTS", grepResult.value);
 
       // Map to extract and parse currencies
-      const mapResult = solve(
+      const mapResult = await solve(
         parse('(map RESULTS (lambda x (parseCurrency (match x "\\\\$[\\\\d,]+" 0))))').term!,
         mapTools,
         mapBindings
@@ -246,19 +246,19 @@ describe("LC Solver Synthesis", () => {
   const bindings: Bindings = new Map();
 
   describe("synthesize command", () => {
-    it("should parse synthesize with bracket pairs", () => {
+    it("should parse synthesize with bracket pairs", async () => {
       const parseResult = parse('(synthesize ["SALES: $100" 100] ["SALES: $200" 200])');
       expect(parseResult.success).toBe(true);
       expect(parseResult.term?.tag).toBe("synthesize");
     });
 
-    it("should parse synthesize with paren pairs", () => {
+    it("should parse synthesize with paren pairs", async () => {
       const parseResult = parse('(synthesize ("input1" "output1") ("input2" "output2"))');
       expect(parseResult.success).toBe(true);
     });
 
-    it("should synthesize a simple extractor", () => {
-      const result = solve(
+    it("should synthesize a simple extractor", async () => {
+      const result = await solve(
         parse('(synthesize ("$100" 100) ("$200" 200) ("$50" 50))').term!,
         tools,
         bindings
@@ -272,9 +272,9 @@ describe("LC Solver Synthesis", () => {
       expect(fn("$300")).toBe(300);
     });
 
-    it("should synthesize date parser via relational solver", () => {
+    it("should synthesize date parser via relational solver", async () => {
       // This tests the relational solver fallback - unusual date format
-      const result = solve(
+      const result = await solve(
         parse('(synthesize ("Q1-2024" "2024-01") ("Q2-2024" "2024-04") ("Q3-2024" "2024-07") ("Q4-2024" "2024-10"))').term!,
         tools,
         bindings
@@ -286,8 +286,8 @@ describe("LC Solver Synthesis", () => {
       expect(fn("Q1-2025")).toBe("2025-01");
     });
 
-    it("should synthesize number extractor from complex pattern", () => {
-      const result = solve(
+    it("should synthesize number extractor from complex pattern", async () => {
+      const result = await solve(
         parse('(synthesize ("Order #12345 (SHIPPED)" 12345) ("Order #67890 (PENDING)" 67890))').term!,
         tools,
         bindings
@@ -314,8 +314,8 @@ Line 8: Conclusion`;
   const tools = createMockTools(multiLineContext);
   const bindings: Bindings = new Map();
 
-  it("should get specific line range", () => {
-    const result = solve(parse("(lines 3 6)").term!, tools, bindings);
+  it("should get specific line range", async () => {
+    const result = await solve(parse("(lines 3 6)").term!, tools, bindings);
     expect(result.success).toBe(true);
     // lines returns an array of strings for compatibility with filter/map
     expect(result.value).toEqual([
@@ -326,8 +326,8 @@ Line 8: Conclusion`;
     ]);
   });
 
-  it("should handle 1-indexed lines", () => {
-    const result = solve(parse("(lines 1 2)").term!, tools, bindings);
+  it("should handle 1-indexed lines", async () => {
+    const result = await solve(parse("(lines 1 2)").term!, tools, bindings);
     expect(result.success).toBe(true);
     expect(result.value).toEqual([
       "Line 1: Introduction",
@@ -335,8 +335,8 @@ Line 8: Conclusion`;
     ]);
   });
 
-  it("should clamp to valid range", () => {
-    const result = solve(parse("(lines 7 100)").term!, tools, bindings);
+  it("should clamp to valid range", async () => {
+    const result = await solve(parse("(lines 7 100)").term!, tools, bindings);
     expect(result.success).toBe(true);
     expect(result.value).toEqual([
       "Line 7: End of config",
@@ -349,42 +349,42 @@ describe("LC Solver NaN-safe parsing", () => {
   const tools = createMockTools("");
   const bindings: Bindings = new Map();
 
-  it("should return null for parseInt of non-numeric string", () => {
+  it("should return null for parseInt of non-numeric string", async () => {
     const term = {
       tag: "parseInt" as const,
       str: { tag: "lit" as const, value: "not-a-number" },
     };
-    const result = solve(term as any, tools, bindings);
+    const result = await solve(term as any, tools, bindings);
     expect(result.success).toBe(true);
     expect(result.value).toBeNull();
   });
 
-  it("should return null for parseFloat of non-numeric string", () => {
+  it("should return null for parseFloat of non-numeric string", async () => {
     const term = {
       tag: "parseFloat" as const,
       str: { tag: "lit" as const, value: "abc" },
     };
-    const result = solve(term as any, tools, bindings);
+    const result = await solve(term as any, tools, bindings);
     expect(result.success).toBe(true);
     expect(result.value).toBeNull();
   });
 
-  it("should still parse valid integers", () => {
+  it("should still parse valid integers", async () => {
     const term = {
       tag: "parseInt" as const,
       str: { tag: "lit" as const, value: "42" },
     };
-    const result = solve(term as any, tools, bindings);
+    const result = await solve(term as any, tools, bindings);
     expect(result.success).toBe(true);
     expect(result.value).toBe(42);
   });
 
-  it("should still parse valid floats", () => {
+  it("should still parse valid floats", async () => {
     const term = {
       tag: "parseFloat" as const,
       str: { tag: "lit" as const, value: "3.14" },
     };
-    const result = solve(term as any, tools, bindings);
+    const result = await solve(term as any, tools, bindings);
     expect(result.success).toBe(true);
     expect(result.value).toBe(3.14);
   });
@@ -394,26 +394,26 @@ describe("LC Solver parse input length guard", () => {
   const tools = createMockTools("");
   const bindings: Bindings = new Map();
 
-  it("should return null for parseCurrency with oversized input", () => {
+  it("should return null for parseCurrency with oversized input", async () => {
     const longStr = "$" + "1".repeat(200);
     const term = {
       tag: "coerce" as const,
       term: { tag: "lit" as const, value: longStr },
       targetType: "currency",
     };
-    const result = solve(term as any, tools, bindings);
+    const result = await solve(term as any, tools, bindings);
     expect(result.success).toBe(true);
     expect(result.value).toBeNull();
   });
 
-  it("should return null for parseNumber with oversized input", () => {
+  it("should return null for parseNumber with oversized input", async () => {
     const longStr = "1".repeat(200);
     const term = {
       tag: "coerce" as const,
       term: { tag: "lit" as const, value: longStr },
       targetType: "number",
     };
-    const result = solve(term as any, tools, bindings);
+    const result = await solve(term as any, tools, bindings);
     expect(result.success).toBe(true);
     expect(result.value).toBeNull();
   });

--- a/tests/logic/lc-solver-graph.test.ts
+++ b/tests/logic/lc-solver-graph.test.ts
@@ -122,36 +122,36 @@ function createHandler(db: Database): Handler {
   });
 
   describe("callers", () => {
-    it("should return callers of a symbol", () => {
+    it("should return callers of a symbol", async () => {
       const result = parse('(callers "speak")');
       expect(result.success).toBe(true);
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
       const callers = solved.value as Symbol[];
       expect(callers).toHaveLength(1);
       expect(callers[0].name).toBe("bark");
     });
 
-    it("should return empty array for uncalled symbol", () => {
+    it("should return empty array for uncalled symbol", async () => {
       const result = parse('(callers "whimper")');
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
       expect(solved.value).toEqual([]);
     });
 
-    it("should error when no graph is available", () => {
+    it("should error when no graph is available", async () => {
       bindings.delete("_symbolGraph");
       const result = parse('(callers "speak")');
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(false);
       expect(solved.error).toMatch(/graph/i);
     });
   });
 
   describe("callees", () => {
-    it("should return callees of a symbol", () => {
+    it("should return callees of a symbol", async () => {
       const result = parse('(callees "startServer")');
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
       const callees = solved.value as Symbol[];
       expect(callees.map((s) => s.name).sort()).toEqual(["createHandler", "initDb"]);
@@ -159,26 +159,26 @@ function createHandler(db: Database): Handler {
   });
 
   describe("ancestors", () => {
-    it("should return ancestor chain", () => {
+    it("should return ancestor chain", async () => {
       const result = parse('(ancestors "Puppy")');
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
       const ancestors = solved.value as Symbol[];
       expect(ancestors.map((s) => s.name)).toEqual(["Dog", "Animal"]);
     });
 
-    it("should return empty for root class", () => {
+    it("should return empty for root class", async () => {
       const result = parse('(ancestors "Animal")');
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
       expect(solved.value).toEqual([]);
     });
   });
 
   describe("descendants", () => {
-    it("should return all descendants", () => {
+    it("should return all descendants", async () => {
       const result = parse('(descendants "Animal")');
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
       const desc = solved.value as Symbol[];
       expect(desc.map((s) => s.name).sort()).toEqual(["Dog", "Puppy"]);
@@ -186,9 +186,9 @@ function createHandler(db: Database): Handler {
   });
 
   describe("implementations", () => {
-    it("should return all implementations of an interface", () => {
+    it("should return all implementations of an interface", async () => {
       const result = parse('(implementations "IRepo")');
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
       const impls = solved.value as Symbol[];
       expect(impls.map((s) => s.name).sort()).toEqual(["MockRepo", "SqlRepo"]);
@@ -196,18 +196,18 @@ function createHandler(db: Database): Handler {
   });
 
   describe("dependents", () => {
-    it("should return transitive dependents", () => {
+    it("should return transitive dependents", async () => {
       const result = parse('(dependents "createHandler")');
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
       const deps = solved.value as Symbol[];
       expect(deps.map((s) => s.name)).toEqual(["startServer"]);
     });
 
-    it("should respect depth limit", () => {
+    it("should respect depth limit", async () => {
       // initDb is called by startServer only
       const result = parse('(dependents "initDb" 1)');
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
       const deps = solved.value as Symbol[];
       expect(deps.map((s) => s.name)).toEqual(["startServer"]);
@@ -215,9 +215,9 @@ function createHandler(db: Database): Handler {
   });
 
   describe("symbol_graph", () => {
-    it("should return neighborhood subgraph", () => {
+    it("should return neighborhood subgraph", async () => {
       const result = parse('(symbol_graph "Dog" 1)');
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
       const hood = solved.value as { nodes: Symbol[]; edges: Array<{ source: string; target: string; relation: string }> };
       const names = hood.nodes.map((s) => s.name).sort();
@@ -227,9 +227,9 @@ function createHandler(db: Database): Handler {
       expect(names).toContain("Puppy");
     });
 
-    it("should use default depth of 1 when not specified", () => {
+    it("should use default depth of 1 when not specified", async () => {
       const result = parse('(symbol_graph "Dog")');
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
       const hood = solved.value as { nodes: Symbol[]; edges: any[] };
       expect(hood.nodes.length).toBeGreaterThanOrEqual(2);
@@ -237,16 +237,16 @@ function createHandler(db: Database): Handler {
   });
 
   describe("composition with existing operations", () => {
-    it("should count callers", () => {
+    it("should count callers", async () => {
       const result = parse('(count (callers "speak"))');
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
       expect(solved.value).toBe(1);
     });
 
-    it("should filter callees", () => {
+    it("should filter callees", async () => {
       const result = parse('(count (callees "startServer"))');
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
       expect(solved.value).toBe(2);
     });

--- a/tests/logic/lc-solver-symbols.test.ts
+++ b/tests/logic/lc-solver-symbols.test.ts
@@ -143,11 +143,11 @@ type ID = string | number;
   });
 
   describe("list_symbols", () => {
-    it("should return all symbols as array", () => {
+    it("should return all symbols as array", async () => {
       const result = parse("(list_symbols)");
       expect(result.success).toBe(true);
 
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
       expect(Array.isArray(solved.value)).toBe(true);
 
@@ -155,11 +155,11 @@ type ID = string | number;
       expect(symbols.length).toBe(6);
     });
 
-    it("should filter symbols by kind", () => {
+    it("should filter symbols by kind", async () => {
       const result = parse('(list_symbols "function")');
       expect(result.success).toBe(true);
 
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
 
       const symbols = solved.value as Symbol[];
@@ -168,11 +168,11 @@ type ID = string | number;
       expect(symbols[0].kind).toBe("function");
     });
 
-    it("should return methods when filtered", () => {
+    it("should return methods when filtered", async () => {
       const result = parse('(list_symbols "method")');
       expect(result.success).toBe(true);
 
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
 
       const symbols = solved.value as Symbol[];
@@ -182,11 +182,11 @@ type ID = string | number;
       expect(names).toContain("farewell");
     });
 
-    it("should return symbol metadata", () => {
+    it("should return symbol metadata", async () => {
       const result = parse('(list_symbols "class")');
       expect(result.success).toBe(true);
 
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
 
       const symbols = solved.value as Symbol[];
@@ -201,11 +201,11 @@ type ID = string | number;
   });
 
   describe("get_symbol_body", () => {
-    it("should return code body for symbol by name", () => {
+    it("should return code body for symbol by name", async () => {
       const result = parse('(get_symbol_body "hello")');
       expect(result.success).toBe(true);
 
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
 
       const body = solved.value as string;
@@ -213,10 +213,10 @@ type ID = string | number;
       expect(body).toContain('return "Hello, "');
     });
 
-    it("should return code body for symbol from result", () => {
+    it("should return code body for symbol from result", async () => {
       // First get a symbol
       const listResult = parse('(list_symbols "function")');
-      const listSolved = solve(listResult.term!, tools, bindings);
+      const listSolved = await solve(listResult.term!, tools, bindings);
       const symbols = listSolved.value as Symbol[];
 
       // Store in bindings as RESULTS
@@ -225,29 +225,29 @@ type ID = string | number;
       const result = parse("(get_symbol_body RESULTS)");
       expect(result.success).toBe(true);
 
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
 
       const body = solved.value as string;
       expect(body).toContain("function hello");
     });
 
-    it("should return null for non-existent symbol", () => {
+    it("should return null for non-existent symbol", async () => {
       const result = parse('(get_symbol_body "nonExistent")');
       expect(result.success).toBe(true);
 
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
       expect(solved.value).toBeNull();
     });
   });
 
   describe("find_references", () => {
-    it("should find all references to identifier", () => {
+    it("should find all references to identifier", async () => {
       const result = parse('(find_references "hello")');
       expect(result.success).toBe(true);
 
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
 
       const refs = solved.value as Array<{ line: string; lineNum: number }>;
@@ -255,11 +255,11 @@ type ID = string | number;
       expect(refs.length).toBeGreaterThanOrEqual(2); // Declaration + usage in greet()
     });
 
-    it("should find references to class name", () => {
+    it("should find references to class name", async () => {
       const result = parse('(find_references "Greeter")');
       expect(result.success).toBe(true);
 
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
 
       const refs = solved.value as Array<{ line: string; lineNum: number }>;
@@ -267,11 +267,11 @@ type ID = string | number;
       expect(refs.length).toBeGreaterThanOrEqual(1);
     });
 
-    it("should return empty array for unused identifier", () => {
+    it("should return empty array for unused identifier", async () => {
       const result = parse('(find_references "unusedThing")');
       expect(result.success).toBe(true);
 
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
 
       const refs = solved.value as Array<{ line: string; lineNum: number }>;
@@ -279,12 +279,12 @@ type ID = string | number;
       expect(refs.length).toBe(0);
     });
 
-    it("should not throw when name contains regex metacharacters", () => {
+    it("should not throw when name contains regex metacharacters", async () => {
       // Names with regex metacharacters should be escaped, not throw
       const result = parse('(find_references "foo(bar")');
       expect(result.success).toBe(true);
 
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       // Should not throw - metacharacters are escaped
       expect(solved.success).toBe(true);
       const refs = solved.value as Array<{ line: string; lineNum: number }>;
@@ -293,7 +293,7 @@ type ID = string | number;
   });
 
   describe("evaluation depth limit", () => {
-    it("should throw on deeply nested lambda application instead of crashing", () => {
+    it("should throw on deeply nested lambda application instead of crashing", async () => {
       // Build a deeply nested application: (app (app (app ... )))
       // This tests that evaluate() has a depth guard
       // We'll construct a term that causes deep recursion via evaluate
@@ -308,7 +308,7 @@ type ID = string | number;
         return;
       }
 
-      const solved = solve(result.term, tools, bindings);
+      const solved = await solve(result.term, tools, bindings);
       // Either it succeeds (if depth is within limit) or fails with depth error
       // The important thing is it doesn't crash with stack overflow
       if (!solved.success) {
@@ -318,10 +318,10 @@ type ID = string | number;
   });
 
   describe("integration scenarios", () => {
-    it("should support grep + symbols workflow", () => {
+    it("should support grep + symbols workflow", async () => {
       // Find all methods then get their bodies
       const listResult = parse('(list_symbols "method")');
-      const listSolved = solve(listResult.term!, tools, bindings);
+      const listSolved = await solve(listResult.term!, tools, bindings);
       expect(listSolved.success).toBe(true);
 
       const methods = listSolved.value as Symbol[];
@@ -330,23 +330,23 @@ type ID = string | number;
       // Get body of first method
       bindings.set("RESULTS", methods[0]);
       const bodyResult = parse("(get_symbol_body RESULTS)");
-      const bodySolved = solve(bodyResult.term!, tools, bindings);
+      const bodySolved = await solve(bodyResult.term!, tools, bindings);
       expect(bodySolved.success).toBe(true);
       expect(typeof bodySolved.value).toBe("string");
     });
 
-    it("should count symbols by kind", () => {
+    it("should count symbols by kind", async () => {
       const result = parse('(count (list_symbols "method"))');
       expect(result.success).toBe(true);
 
-      const solved = solve(result.term!, tools, bindings);
+      const solved = await solve(result.term!, tools, bindings);
       expect(solved.success).toBe(true);
       expect(solved.value).toBe(2);
     });
   });
 
   describe("regex validation in string operations", () => {
-    it("should reject match with nested-quantifier regex (ReDoS)", () => {
+    it("should reject match with nested-quantifier regex (ReDoS)", async () => {
       // Directly invoke solve with a match term containing a dangerous regex
       const term = {
         tag: "match" as const,
@@ -354,38 +354,38 @@ type ID = string | number;
         pattern: "(a+)+",
         group: 0,
       };
-      const result = solve(term as any, tools, bindings);
+      const result = await solve(term as any, tools, bindings);
       expect(result.success).toBe(false);
       expect(result.error).toMatch(/backtracking|invalid regex|match:/i);
     });
 
-    it("should reject replace with nested-quantifier regex (ReDoS)", () => {
+    it("should reject replace with nested-quantifier regex (ReDoS)", async () => {
       const term = {
         tag: "replace" as const,
         str: { tag: "lit" as const, value: "test string" },
         from: "(a+)+",
         to: "x",
       };
-      const result = solve(term as any, tools, bindings);
+      const result = await solve(term as any, tools, bindings);
       expect(result.success).toBe(false);
       expect(result.error).toMatch(/backtracking|invalid regex|replace:/i);
     });
 
-    it("should reject extract with nested-quantifier regex (ReDoS)", () => {
+    it("should reject extract with nested-quantifier regex (ReDoS)", async () => {
       const term = {
         tag: "extract" as const,
         str: { tag: "lit" as const, value: "test string" },
         pattern: "(a+)+",
         group: 0,
       };
-      const result = solve(term as any, tools, bindings);
+      const result = await solve(term as any, tools, bindings);
       expect(result.success).toBe(false);
       expect(result.error).toMatch(/backtracking|invalid regex|extract:/i);
     });
   });
 
   describe("empty regex validation", () => {
-    it("should reject empty regex pattern", () => {
+    it("should reject empty regex pattern", async () => {
       const result = validateRegex("");
       expect(result.valid).toBe(false);
       expect(result.error).toContain("Empty");
@@ -393,82 +393,82 @@ type ID = string | number;
   });
 
   describe("add type validation", () => {
-    it("should throw when adding non-numeric operands", () => {
+    it("should throw when adding non-numeric operands", async () => {
       const term = {
         tag: "add" as const,
         left: { tag: "lit" as const, value: "hello" },
         right: { tag: "lit" as const, value: 5 },
       };
-      const result = solve(term as any, tools, bindings);
+      const result = await solve(term as any, tools, bindings);
       expect(result.success).toBe(false);
       expect(result.error).toMatch(/expected numbers/i);
     });
 
-    it("should succeed with valid numeric operands", () => {
+    it("should succeed with valid numeric operands", async () => {
       const term = {
         tag: "add" as const,
         left: { tag: "lit" as const, value: 3 },
         right: { tag: "lit" as const, value: 5 },
       };
-      const result = solve(term as any, tools, bindings);
+      const result = await solve(term as any, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBe(8);
     });
   });
 
   describe("negative group index guard", () => {
-    it("should return null for negative group index in match", () => {
+    it("should return null for negative group index in match", async () => {
       const term = {
         tag: "match" as const,
         str: { tag: "lit" as const, value: "hello world" },
         pattern: "(\\w+)",
         group: -1,
       };
-      const result = solve(term as any, tools, bindings);
+      const result = await solve(term as any, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBeNull();
     });
   });
 
   describe("parseDate input length limit", () => {
-    it("should return null for excessively long date string", () => {
+    it("should return null for excessively long date string", async () => {
       const term = {
         tag: "parseDate" as const,
         str: { tag: "lit" as const, value: "A".repeat(500) },
       };
-      const result = solve(term as any, tools, bindings);
+      const result = await solve(term as any, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBeNull();
     });
   });
 
   describe("parseDate month/day validation", () => {
-    it("should reject Feb 31 as invalid date", () => {
+    it("should reject Feb 31 as invalid date", async () => {
       const term = {
         tag: "parseDate" as const,
         str: { tag: "lit" as const, value: "02/31/2024" },
       };
-      const result = solve(term as any, tools, bindings);
+      const result = await solve(term as any, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBeNull();
     });
 
-    it("should reject month 13 as invalid date", () => {
+    it("should reject month 13 as invalid date", async () => {
       const term = {
         tag: "parseDate" as const,
         str: { tag: "lit" as const, value: "2024-13-01" },
       };
-      const result = solve(term as any, tools, bindings);
+      const result = await solve(term as any, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBeNull();
     });
 
-    it("should reject month 0 as invalid date", () => {
+    it("should reject month 0 as invalid date", async () => {
       const term = {
         tag: "parseDate" as const,
         str: { tag: "lit" as const, value: "2024-00-15" },
       };
-      const result = solve(term as any, tools, bindings);
+      const result = await solve(term as any, tools, bindings);
       expect(result.success).toBe(true);
       expect(result.value).toBeNull();
     });

--- a/tests/logic/lc-solver-synthesis.test.ts
+++ b/tests/logic/lc-solver-synthesis.test.ts
@@ -73,7 +73,7 @@ function createMockTools(content: string): SolverTools {
 /**
  * Helper to parse and solve
  */
-function parseAndSolve(query: string, tools: SolverTools, bindings: Bindings = new Map()) {
+async function parseAndSolve(query: string, tools: SolverTools, bindings: Bindings = new Map()) {
   const parseResult = parse(query);
   if (!parseResult.success || !parseResult.term) {
     throw new Error(`Parse failed: ${parseResult.error}`);
@@ -83,12 +83,12 @@ function parseAndSolve(query: string, tools: SolverTools, bindings: Bindings = n
 
 describe("LC Solver with Synthesis Fallback", () => {
   describe("parseCurrency synthesis", () => {
-    it("auto-synthesizes when built-in fails on EU format", () => {
+    it("auto-synthesizes when built-in fails on EU format", async () => {
       const tools = createMockTools("Price: 1.234,56€\nPrice: 500,00€");
 
       // EU format with trailing euro sign - built-in should handle this
       // but with examples, it should use synthesis for complex formats
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(map (grep "Price")
            (lambda x
              (parseCurrency (match x "([0-9.,]+€)" 1)
@@ -100,11 +100,11 @@ describe("LC Solver with Synthesis Fallback", () => {
       expect(result.value).toEqual([1234.56, 500]);
     });
 
-    it("synthesizes currency parser for unfamiliar format", () => {
+    it("synthesizes currency parser for unfamiliar format", async () => {
       const tools = createMockTools("Amount: CHF 1'234.50\nAmount: CHF 500.00");
 
       // Swiss format with apostrophe thousand separator
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(map (grep "Amount")
            (lambda x
              (parseCurrency (match x "CHF ([0-9'.,]+)" 1)
@@ -116,11 +116,11 @@ describe("LC Solver with Synthesis Fallback", () => {
       expect(result.value).toEqual([1234.5, 500]);
     });
 
-    it("uses built-in parser when no examples and format is standard", () => {
+    it("uses built-in parser when no examples and format is standard", async () => {
       const tools = createMockTools("Price: $1,234.56\nPrice: $500.00");
 
       // Standard US format - should work without examples
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(map (grep "Price")
            (lambda x
              (parseCurrency (match x "\\$([0-9,.]+)" 1))))`,
@@ -133,10 +133,10 @@ describe("LC Solver with Synthesis Fallback", () => {
   });
 
   describe("parseDate synthesis", () => {
-    it("synthesizes date parser for DD-Mon-YYYY format", () => {
+    it("synthesizes date parser for DD-Mon-YYYY format", async () => {
       const tools = createMockTools("Date: 15-Jan-2024\nDate: 20-Feb-2024");
 
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(map (grep "Date")
            (lambda x
              (parseDate (match x "Date: (.+)" 1)
@@ -148,10 +148,10 @@ describe("LC Solver with Synthesis Fallback", () => {
       expect(result.value).toEqual(["2024-01-15", "2024-02-20"]);
     });
 
-    it("synthesizes date parser for short year format", () => {
+    it("synthesizes date parser for short year format", async () => {
       const tools = createMockTools("Date: 15/01/24\nDate: 28/02/24");
 
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(map (grep "Date")
            (lambda x
              (parseDate (match x "Date: (.+)" 1)
@@ -165,10 +165,10 @@ describe("LC Solver with Synthesis Fallback", () => {
   });
 
   describe("parseNumber synthesis", () => {
-    it("synthesizes number extractor from text", () => {
+    it("synthesizes number extractor from text", async () => {
       const tools = createMockTools("Total: 1,234 units\nTotal: 500 units");
 
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(map (grep "Total")
            (lambda x
              (parseNumber (match x "Total: ([0-9,]+)" 1)
@@ -180,12 +180,12 @@ describe("LC Solver with Synthesis Fallback", () => {
       expect(result.value).toEqual([1234, 500]);
     });
 
-    it("extracts percentages and handles numeric values", () => {
+    it("extracts percentages and handles numeric values", async () => {
       const tools = createMockTools("Growth: 25.5%\nGrowth: 10%");
 
       // parseNumber with % converts to decimals (0.255, 0.10)
       // To get raw numbers, extract without the % and parse as number
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(map (grep "Growth")
            (lambda x
              (parseNumber (match x "Growth: ([0-9.]+)" 1)
@@ -200,12 +200,12 @@ describe("LC Solver with Synthesis Fallback", () => {
   });
 
   describe("predicate synthesis", () => {
-    it("synthesizes predicate from true/false examples", () => {
+    it("synthesizes predicate from true/false examples", async () => {
       const tools = createMockTools(
         "ERROR: Connection failed\nINFO: Started\nERROR: Timeout\nDEBUG: trace"
       );
 
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(filter (grep "")
            (lambda x
              (predicate x
@@ -225,12 +225,12 @@ describe("LC Solver with Synthesis Fallback", () => {
       expect(lines.every((l) => l.includes("ERROR"))).toBe(true);
     });
 
-    it("synthesizes predicate for log levels (ERROR or WARN)", () => {
+    it("synthesizes predicate for log levels (ERROR or WARN)", async () => {
       const tools = createMockTools(
         "[ERROR] Failed to connect\n[WARN] High memory\n[INFO] Server started\n[DEBUG] Query"
       );
 
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(filter (grep "")
            (lambda x
              (predicate x
@@ -252,13 +252,13 @@ describe("LC Solver with Synthesis Fallback", () => {
   });
 
   describe("extract with examples", () => {
-    it("synthesizes extractor from examples", () => {
+    it("synthesizes extractor from examples", async () => {
       const tools = createMockTools(
         "Order #1234: $500.00\nOrder #5678: $1,200.00"
       );
 
       // Use :type "number" for type coercion
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(map (grep "Order")
            (lambda x
              (extract x "Order #(\\d+)" 1 "number"
@@ -270,12 +270,12 @@ describe("LC Solver with Synthesis Fallback", () => {
       expect(result.value).toEqual([1234, 5678]);
     });
 
-    it("synthesizes extractor with type coercion", () => {
+    it("synthesizes extractor with type coercion", async () => {
       const tools = createMockTools(
         "Revenue: $1,234.56\nRevenue: $500.00"
       );
 
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(map (grep "Revenue")
            (lambda x
              (extract x "\\$([\\d,\\.]+)" 1 "currency"
@@ -289,11 +289,11 @@ describe("LC Solver with Synthesis Fallback", () => {
   });
 
   describe("define-fn and apply-fn", () => {
-    it("defines and applies a synthesized function", () => {
+    it("defines and applies a synthesized function", async () => {
       const tools = createMockTools("€100\n€200\n€300");
 
       // Define the function
-      const defineResult = parseAndSolve(
+      const defineResult = await parseAndSolve(
         `(define-fn "euro-parser" :examples [("€100" 100) ("€200" 200)])`,
         tools
       );
@@ -307,7 +307,7 @@ describe("LC Solver with Synthesis Fallback", () => {
       }
 
       // Apply the function
-      const applyResult = parseAndSolve(
+      const applyResult = await parseAndSolve(
         `(apply-fn "euro-parser" "€300")`,
         tools,
         bindings
@@ -317,12 +317,12 @@ describe("LC Solver with Synthesis Fallback", () => {
       expect(applyResult.value).toBe(300);
     });
 
-    it("applies synthesized function in map", () => {
+    it("applies synthesized function in map", async () => {
       const tools = createMockTools("€100\n€200\n€300");
 
       // Define first
       const bindings: Bindings = new Map();
-      const defineResult = parseAndSolve(
+      const defineResult = await parseAndSolve(
         `(define-fn "euro-parser" :examples [("€100" 100) ("€200" 200)])`,
         tools
       );
@@ -331,7 +331,7 @@ describe("LC Solver with Synthesis Fallback", () => {
       }
 
       // Now map over lines using the defined function
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(map (grep "€")
            (lambda x
              (apply-fn "euro-parser" x)))`,
@@ -345,7 +345,7 @@ describe("LC Solver with Synthesis Fallback", () => {
   });
 
   describe("chained synthesis operations", () => {
-    it("synthesizes multiple extractors in pipeline", () => {
+    it("synthesizes multiple extractors in pipeline", async () => {
       const tools = createMockTools(
         "Order #1234: $1,500.00 - Status: SHIPPED\n" +
         "Order #5678: $250.00 - Status: PENDING\n" +
@@ -353,7 +353,7 @@ describe("LC Solver with Synthesis Fallback", () => {
       );
 
       // Extract order numbers - use :type "number" for coercion
-      const orderNumsResult = parseAndSolve(
+      const orderNumsResult = await parseAndSolve(
         `(map (grep "Order")
            (lambda line
              (extract line "Order #(\\d+)" 1 "number"
@@ -365,7 +365,7 @@ describe("LC Solver with Synthesis Fallback", () => {
       expect(orderNumsResult.value).toEqual([1234, 5678, 9012]);
 
       // Extract amounts
-      const amountsResult = parseAndSolve(
+      const amountsResult = await parseAndSolve(
         `(map (grep "Order")
            (lambda line
              (parseCurrency (match line "\\$([\\d,\\.]+)" 1)
@@ -379,10 +379,10 @@ describe("LC Solver with Synthesis Fallback", () => {
   });
 
   describe("synthesis with constraints", () => {
-    it("respects type constraints during synthesis", () => {
+    it("respects type constraints during synthesis", async () => {
       const tools = createMockTools("Temperature: 72.5°F\nTemperature: 68.0°F");
 
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(map (grep "Temperature")
            (lambda x
              (extract x "([0-9.]+)°F" 1
@@ -398,11 +398,11 @@ describe("LC Solver with Synthesis Fallback", () => {
   });
 
   describe("synthesis caching", () => {
-    it("caches synthesized functions for reuse", () => {
+    it("caches synthesized functions for reuse", async () => {
       const tools = createMockTools("€100\n€200\n€100");
 
       // First call synthesizes
-      const result1 = parseAndSolve(
+      const result1 = await parseAndSolve(
         `(parseCurrency "€100" :examples [("€100" 100) ("€200" 200)])`,
         tools
       );
@@ -410,7 +410,7 @@ describe("LC Solver with Synthesis Fallback", () => {
       expect(result1.value).toBe(100);
 
       // Second call with same pattern should reuse cached function
-      const result2 = parseAndSolve(
+      const result2 = await parseAndSolve(
         `(parseCurrency "€200" :examples [("€100" 100) ("€200" 200)])`,
         tools
       );
@@ -420,7 +420,7 @@ describe("LC Solver with Synthesis Fallback", () => {
   });
 
   describe("classify with miniKanren", () => {
-    it("uses relational solver for pattern discovery", () => {
+    it("uses relational solver for pattern discovery", async () => {
       const tools = createMockTools(
         "2024-01-15 10:30:00 [ERROR] auth.service - Login failed\n" +
         "2024-01-15 10:30:05 [INFO] auth.service - Login successful\n" +
@@ -428,7 +428,7 @@ describe("LC Solver with Synthesis Fallback", () => {
       );
 
       // Use classify with examples
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(classify
            :examples [
              ("2024-01-15 10:30:00 [ERROR] auth.service - Login failed" true)
@@ -448,11 +448,11 @@ describe("LC Solver with Synthesis Fallback", () => {
   });
 
   describe("error handling", () => {
-    it("falls back to built-in when conflicting examples provided", () => {
+    it("falls back to built-in when conflicting examples provided", async () => {
       const tools = createMockTools("random text");
 
       // Conflicting examples cause synthesis to fail, but solver falls back to built-in
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(parseCurrency "test" :examples [("test" 100) ("test" 200)])`,
         tools
       );
@@ -463,10 +463,10 @@ describe("LC Solver with Synthesis Fallback", () => {
       expect(result.value).toBe(null);
     });
 
-    it("falls back to null when no examples and parse fails", () => {
+    it("falls back to null when no examples and parse fails", async () => {
       const tools = createMockTools("gibberish: xyz");
 
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(parseCurrency "xyz")`,
         tools
       );
@@ -477,13 +477,13 @@ describe("LC Solver with Synthesis Fallback", () => {
   });
 
   describe("integration with existing solver features", () => {
-    it("combines synthesis with filter and count", () => {
+    it("combines synthesis with filter and count", async () => {
       const tools = createMockTools(
         "[ERROR] Failed\n[INFO] OK\n[ERROR] Timeout\n[WARN] Slow"
       );
 
       // Count errors using synthesized predicate
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(count
            (filter (grep "")
              (lambda x
@@ -499,13 +499,13 @@ describe("LC Solver with Synthesis Fallback", () => {
       expect(result.value).toBe(2); // Two ERROR lines
     });
 
-    it("combines synthesis with sum", () => {
+    it("combines synthesis with sum", async () => {
       const tools = createMockTools(
         "Sales: 1.234,56€\nSales: 500,00€\nSales: 750,00€"
       );
 
       // Sum EU-formatted currency using synthesis
-      const result = parseAndSolve(
+      const result = await parseAndSolve(
         `(sum
            (map (grep "Sales")
              (lambda x
@@ -522,10 +522,10 @@ describe("LC Solver with Synthesis Fallback", () => {
 });
 
 describe("Solver synthesis integration edge cases", () => {
-  it("handles empty examples array gracefully", () => {
+  it("handles empty examples array gracefully", async () => {
     const tools = createMockTools("$100");
 
-    const result = parseAndSolve(
+    const result = await parseAndSolve(
       `(parseCurrency "$100" :examples [])`,
       tools
     );
@@ -535,10 +535,10 @@ describe("Solver synthesis integration edge cases", () => {
     expect(result.value).toBe(100);
   });
 
-  it("handles single example", () => {
+  it("handles single example", async () => {
     const tools = createMockTools("€50");
 
-    const result = parseAndSolve(
+    const result = await parseAndSolve(
       `(parseCurrency "€50" :examples [("€50" 50)])`,
       tools
     );
@@ -547,11 +547,11 @@ describe("Solver synthesis integration edge cases", () => {
     expect(result.value).toBe(50);
   });
 
-  it("preserves bindings across synthesis operations", () => {
+  it("preserves bindings across synthesis operations", async () => {
     const tools = createMockTools("$100\n$200");
     const bindings: Bindings = new Map([["RESULTS", [{ line: "$100" }, { line: "$200" }]]]);
 
-    const result = parseAndSolve(
+    const result = await parseAndSolve(
       `(map RESULTS
          (lambda x
            (parseCurrency x :examples [("$100" 100)])))`,

--- a/tests/logic/llm-query-nested.test.ts
+++ b/tests/logic/llm-query-nested.test.ts
@@ -52,7 +52,7 @@ function makeTools(opts: {
 }
 
 describe("nested llm_query — async refactor target", () => {
-  it.fails("(map RESULTS (lambda x (llm_query ...))) invokes sub-LLM once per item", async () => {
+  it("(map RESULTS (lambda x (llm_query ...))) invokes sub-LLM once per item", async () => {
     // OOLONG core pattern: per-item semantic classification. For each
     // element in RESULTS, the lambda should call llm_query once. After
     // the refactor, this returns an Array<string> with one response per
@@ -87,7 +87,7 @@ describe("nested llm_query — async refactor target", () => {
     expect(calls[2]).toContain("line three");
   });
 
-  it.fails("map-based llm_query sees each item's actual value under the placeholder", async () => {
+  it("map-based llm_query sees each item's actual value under the placeholder", async () => {
     // Stronger check: the `{item}` placeholder must interpolate the
     // per-iteration value, not the whole RESULTS binding.
     const received: string[] = [];
@@ -112,7 +112,7 @@ describe("nested llm_query — async refactor target", () => {
     expect(received[1]).toBe("Classify beta");
   });
 
-  it.fails("(if cond (llm_query ...) (llm_query ...)) dispatches through the correct branch", async () => {
+  it("(if cond (llm_query ...) (llm_query ...)) dispatches through the correct branch", async () => {
     // `if` branches must be awaitable when they contain llm_query. Only
     // one sub-LLM call should happen (the taken branch).
     const calls: string[] = [];
@@ -135,7 +135,7 @@ describe("nested llm_query — async refactor target", () => {
     expect(calls[0]).toBe("then path");
   });
 
-  it.fails("filter with an llm_query-backed predicate includes only matching items", async () => {
+  it("filter with an llm_query-backed predicate includes only matching items", async () => {
     // Practical OOLONG-Pairs pattern: semantic filtering. The lambda
     // calls llm_query per item and matches its response against a
     // regex; items whose sub-LLM response says "keep" survive.
@@ -159,7 +159,7 @@ describe("nested llm_query — async refactor target", () => {
     expect(result.value).toEqual(["good item", "another good one"]);
   });
 
-  it.fails("chained map → count via RESULTS works after the refactor", async () => {
+  it("chained map → count via RESULTS works after the refactor", async () => {
     // This exercises the full loop: nested llm_query produces an array,
     // RESULTS is re-bound to that array, and a follow-up `(count ...)`
     // over the result still works. The current POC can't reach this

--- a/tests/logic/llm-query-nested.test.ts
+++ b/tests/logic/llm-query-nested.test.ts
@@ -1,0 +1,183 @@
+/**
+ * TDD harness for the nested `(llm_query …)` capability — the full
+ * async refactor that unlocks the paper's OOLONG pattern
+ * `(map RESULTS (lambda x (llm_query "classify: {item}" (item x))))`.
+ *
+ * All tests in this file are currently marked `.fails` because the POC
+ * sync `solve()` rejects nested `llm_query` with a "top level only"
+ * error. As the async refactor lands in subsequent commits, each test
+ * is expected to flip to a positive assertion (drop the `.fails`).
+ *
+ * This file is the empirical contract for the refactor: the moment
+ * every test here is flipped and still green, we know the new
+ * capability actually works end-to-end. Until then, the `.fails` marker
+ * keeps the suite green while documenting the target state.
+ *
+ * Commit history:
+ *   - Chunk 1 (this commit): tests added as `.fails`, all green in
+ *     expected-fail mode.
+ *   - Chunks 2–3: async refactor of evaluate()/solve() and downstream
+ *     callers. These tests remain `.fails` and green.
+ *   - Chunk 4: restriction removed, tests flipped to `it(...)` and
+ *     pass as positive assertions.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parse } from "../../src/logic/lc-parser.js";
+import {
+  solveAsync,
+  type SolverTools,
+  type Bindings,
+} from "../../src/logic/lc-solver.js";
+
+/** Minimal SolverTools stub with a recording llmQuery. */
+function makeTools(opts: {
+  llmQuery?: (prompt: string) => Promise<string>;
+  context?: string;
+} = {}): SolverTools {
+  return {
+    context: opts.context ?? "",
+    lines: (opts.context ?? "").split("\n"),
+    grep: () => [],
+    fuzzy_search: () => [],
+    bm25: () => [],
+    semantic: () => [],
+    text_stats: () => ({
+      length: 0,
+      lineCount: 0,
+      sample: { start: "", middle: "", end: "" },
+    }),
+    llmQuery: opts.llmQuery,
+  };
+}
+
+describe("nested llm_query — async refactor target", () => {
+  it.fails("(map RESULTS (lambda x (llm_query ...))) invokes sub-LLM once per item", async () => {
+    // OOLONG core pattern: per-item semantic classification. For each
+    // element in RESULTS, the lambda should call llm_query once. After
+    // the refactor, this returns an Array<string> with one response per
+    // input item.
+    const calls: string[] = [];
+    const tools = makeTools({
+      llmQuery: async (prompt: string) => {
+        calls.push(prompt);
+        return `classified-${calls.length}`;
+      },
+    });
+
+    const bindings: Bindings = new Map();
+    bindings.set("RESULTS", ["line one", "line two", "line three"]);
+
+    const parsed = parse(
+      '(map RESULTS (lambda x (llm_query "classify: {item}" (item x))))'
+    );
+    expect(parsed.success).toBe(true);
+
+    const result = await solveAsync(parsed.term!, tools, bindings);
+    expect(result.success).toBe(true);
+    expect(Array.isArray(result.value)).toBe(true);
+    expect(result.value).toEqual([
+      "classified-1",
+      "classified-2",
+      "classified-3",
+    ]);
+    expect(calls).toHaveLength(3);
+    expect(calls[0]).toContain("line one");
+    expect(calls[1]).toContain("line two");
+    expect(calls[2]).toContain("line three");
+  });
+
+  it.fails("map-based llm_query sees each item's actual value under the placeholder", async () => {
+    // Stronger check: the `{item}` placeholder must interpolate the
+    // per-iteration value, not the whole RESULTS binding.
+    const received: string[] = [];
+    const tools = makeTools({
+      llmQuery: async (prompt: string) => {
+        received.push(prompt);
+        return "ok";
+      },
+    });
+
+    const bindings: Bindings = new Map();
+    bindings.set("RESULTS", ["alpha", "beta"]);
+
+    const parsed = parse(
+      '(map RESULTS (lambda x (llm_query "Classify {thing}" (thing x))))'
+    );
+    expect(parsed.success).toBe(true);
+
+    await solveAsync(parsed.term!, tools, bindings);
+    expect(received).toHaveLength(2);
+    expect(received[0]).toBe("Classify alpha");
+    expect(received[1]).toBe("Classify beta");
+  });
+
+  it.fails("(if cond (llm_query ...) (llm_query ...)) dispatches through the correct branch", async () => {
+    // `if` branches must be awaitable when they contain llm_query. Only
+    // one sub-LLM call should happen (the taken branch).
+    const calls: string[] = [];
+    const tools = makeTools({
+      llmQuery: async (prompt: string) => {
+        calls.push(prompt);
+        return prompt.includes("then") ? "then-branch" : "else-branch";
+      },
+    });
+
+    const parsed = parse(
+      '(if (lit true) (llm_query "then path") (llm_query "else path"))'
+    );
+    expect(parsed.success).toBe(true);
+
+    const result = await solveAsync(parsed.term!, tools, new Map());
+    expect(result.success).toBe(true);
+    expect(result.value).toBe("then-branch");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe("then path");
+  });
+
+  it.fails("filter with an llm_query-backed predicate includes only matching items", async () => {
+    // Practical OOLONG-Pairs pattern: semantic filtering. The lambda
+    // calls llm_query per item and matches its response against a
+    // regex; items whose sub-LLM response says "keep" survive.
+    const tools = makeTools({
+      llmQuery: async (prompt: string) => {
+        // Accept items whose name contains "good".
+        return prompt.includes("good") ? "keep" : "drop";
+      },
+    });
+
+    const bindings: Bindings = new Map();
+    bindings.set("RESULTS", ["good item", "bad item", "another good one"]);
+
+    const parsed = parse(
+      '(filter RESULTS (lambda x (match (llm_query "judge: {item}" (item x)) "keep" 0)))'
+    );
+    expect(parsed.success).toBe(true);
+
+    const result = await solveAsync(parsed.term!, tools, bindings);
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual(["good item", "another good one"]);
+  });
+
+  it.fails("chained map → count via RESULTS works after the refactor", async () => {
+    // This exercises the full loop: nested llm_query produces an array,
+    // RESULTS is re-bound to that array, and a follow-up `(count ...)`
+    // over the result still works. The current POC can't reach this
+    // state because the first term already trips "top level only".
+    const tools = makeTools({
+      llmQuery: async () => "OK",
+    });
+
+    const bindings: Bindings = new Map();
+    bindings.set("RESULTS", ["a", "b", "c", "d"]);
+
+    const parsed = parse(
+      '(map RESULTS (lambda x (llm_query "score {item}" (item x))))'
+    );
+    expect(parsed.success).toBe(true);
+
+    const mapResult = await solveAsync(parsed.term!, tools, bindings);
+    expect(mapResult.success).toBe(true);
+    expect(mapResult.value).toEqual(["OK", "OK", "OK", "OK"]);
+  });
+});

--- a/tests/logic/llm-query-nested.test.ts
+++ b/tests/logic/llm-query-nested.test.ts
@@ -1,31 +1,24 @@
 /**
- * TDD harness for the nested `(llm_query …)` capability — the full
- * async refactor that unlocks the paper's OOLONG pattern
- * `(map RESULTS (lambda x (llm_query "classify: {item}" (item x))))`.
+ * Positive-assertion tests for the nested `(llm_query …)` capability
+ * — the paper's OOLONG pattern
  *
- * All tests in this file are currently marked `.fails` because the POC
- * sync `solve()` rejects nested `llm_query` with a "top level only"
- * error. As the async refactor lands in subsequent commits, each test
- * is expected to flip to a positive assertion (drop the `.fails`).
+ *   (map RESULTS (lambda x (llm_query "classify: {item}" (item x))))
  *
- * This file is the empirical contract for the refactor: the moment
- * every test here is flipped and still green, we know the new
- * capability actually works end-to-end. Until then, the `.fails` marker
- * keeps the suite green while documenting the target state.
+ * was the target of the full async refactor. This file exercises the
+ * nested capability from several angles (map, filter predicate, if
+ * branches, chained consumption) to prove that the sub-LLM is actually
+ * called at the expected nested sites and that results flow through
+ * downstream terms correctly.
  *
- * Commit history:
- *   - Chunk 1 (this commit): tests added as `.fails`, all green in
- *     expected-fail mode.
- *   - Chunks 2–3: async refactor of evaluate()/solve() and downstream
- *     callers. These tests remain `.fails` and green.
- *   - Chunk 4: restriction removed, tests flipped to `it(...)` and
- *     pass as positive assertions.
+ * Originally introduced as `.fails` TDD tests; flipped to `it(...)`
+ * once the async evaluator landed and the "top-level only" restriction
+ * was removed.
  */
 
 import { describe, it, expect } from "vitest";
 import { parse } from "../../src/logic/lc-parser.js";
 import {
-  solveAsync,
+  solve,
   type SolverTools,
   type Bindings,
 } from "../../src/logic/lc-solver.js";
@@ -73,7 +66,7 @@ describe("nested llm_query — async refactor target", () => {
     );
     expect(parsed.success).toBe(true);
 
-    const result = await solveAsync(parsed.term!, tools, bindings);
+    const result = await solve(parsed.term!, tools, bindings);
     expect(result.success).toBe(true);
     expect(Array.isArray(result.value)).toBe(true);
     expect(result.value).toEqual([
@@ -106,7 +99,7 @@ describe("nested llm_query — async refactor target", () => {
     );
     expect(parsed.success).toBe(true);
 
-    await solveAsync(parsed.term!, tools, bindings);
+    await solve(parsed.term!, tools, bindings);
     expect(received).toHaveLength(2);
     expect(received[0]).toBe("Classify alpha");
     expect(received[1]).toBe("Classify beta");
@@ -128,7 +121,7 @@ describe("nested llm_query — async refactor target", () => {
     );
     expect(parsed.success).toBe(true);
 
-    const result = await solveAsync(parsed.term!, tools, new Map());
+    const result = await solve(parsed.term!, tools, new Map());
     expect(result.success).toBe(true);
     expect(result.value).toBe("then-branch");
     expect(calls).toHaveLength(1);
@@ -154,16 +147,15 @@ describe("nested llm_query — async refactor target", () => {
     );
     expect(parsed.success).toBe(true);
 
-    const result = await solveAsync(parsed.term!, tools, bindings);
+    const result = await solve(parsed.term!, tools, bindings);
     expect(result.success).toBe(true);
     expect(result.value).toEqual(["good item", "another good one"]);
   });
 
   it("chained map → count via RESULTS works after the refactor", async () => {
-    // This exercises the full loop: nested llm_query produces an array,
+    // Exercises the full loop: nested llm_query produces an array,
     // RESULTS is re-bound to that array, and a follow-up `(count ...)`
-    // over the result still works. The current POC can't reach this
-    // state because the first term already trips "top level only".
+    // over the result still works.
     const tools = makeTools({
       llmQuery: async () => "OK",
     });
@@ -176,7 +168,7 @@ describe("nested llm_query — async refactor target", () => {
     );
     expect(parsed.success).toBe(true);
 
-    const mapResult = await solveAsync(parsed.term!, tools, bindings);
+    const mapResult = await solve(parsed.term!, tools, bindings);
     expect(mapResult.success).toBe(true);
     expect(mapResult.value).toEqual(["OK", "OK", "OK", "OK"]);
   });

--- a/tests/logic/llm-query.test.ts
+++ b/tests/logic/llm-query.test.ts
@@ -14,7 +14,7 @@
  *   5. `solveAsync` propagates errors thrown by the underlying
  *      `tools.llmQuery` callback.
  *   6. Nested `(llm_query …)` inside a `filter`/`map`/etc. throws a
- *      clear "top-level only" error via the sync `solve()` path.
+ *      clear "top-level only" error via the sync `await solve()` path.
  *   7. Bindings inside a `(llm_query …)` are evaluated via the sync
  *      solver and respect cross-turn variables (`RESULTS`, `_N`).
  */
@@ -50,7 +50,7 @@ function makeTools(overrides: Partial<SolverTools> = {}): SolverTools {
 }
 
 describe("llm_query parser", () => {
-  it("parses the zero-binding form", () => {
+  it("parses the zero-binding form", async () => {
     const result = parse('(llm_query "summarize the document")');
     expect(result.success).toBe(true);
     expect(result.term?.tag).toBe("llm_query");
@@ -60,7 +60,7 @@ describe("llm_query parser", () => {
     }
   });
 
-  it("parses a single-binding form", () => {
+  it("parses a single-binding form", async () => {
     const result = parse(
       '(llm_query "Classify these errors: {errors}" (errors RESULTS))'
     );
@@ -73,7 +73,7 @@ describe("llm_query parser", () => {
     }
   });
 
-  it("parses a multi-binding form", () => {
+  it("parses a multi-binding form", async () => {
     const result = parse(
       '(llm_query "Apply {rules} to {data}" (rules _1) (data _2))'
     );
@@ -84,21 +84,21 @@ describe("llm_query parser", () => {
     }
   });
 
-  it("rejects a malformed binding that lacks parens", () => {
+  it("rejects a malformed binding that lacks parens", async () => {
     // `(llm_query "prompt" data _1)` is ambiguous — not a (name value)
     // pair. The parser should fail cleanly rather than partially consume.
     const result = parse('(llm_query "prompt" data _1)');
     expect(result.success).toBe(false);
   });
 
-  it("rejects a binding with an unsafe placeholder name", () => {
+  it("rejects a binding with an unsafe placeholder name", async () => {
     const result = parse('(llm_query "prompt" ("bad name" _1))');
     expect(result.success).toBe(false);
   });
 });
 
 describe("llm_query type inference", () => {
-  it("infers string", () => {
+  it("infers string", async () => {
     const result = parse('(llm_query "summarize")');
     expect(result.success).toBe(true);
     const type = inferType(result.term!);
@@ -210,8 +210,8 @@ describe("llm_query solver — error paths", () => {
     expect(result.error).toMatch(/quota exceeded/);
   });
 
-  it("rejects nested llm_query inside a filter lambda (top-level only)", () => {
-    // This is the POC's deliberate limitation — the sync `solve()` path
+  it("rejects nested llm_query inside a filter lambda (top-level only)", async () => {
+    // This is the POC's deliberate limitation — the sync `await solve()` path
     // refuses to dispatch `llm_query` when encountered inside another
     // term. The error message should explicitly say "top level".
     const parsed = parse(
@@ -220,11 +220,11 @@ describe("llm_query solver — error paths", () => {
     expect(parsed.success).toBe(true);
 
     // Feed through the sync solver directly — the FSM's solveAsync
-    // routes to solve() for anything that isn't a top-level llm_query,
+    // routes to await solve() for anything that isn't a top-level llm_query,
     // so nesting trips the sync path's error case.
     const bindings: Bindings = new Map();
     bindings.set("RESULTS", ["a", "b"]);
-    const result = solve(parsed.term!, makeTools({ llmQuery: async () => "x" }), bindings);
+    const result = await solve(parsed.term!, makeTools({ llmQuery: async () => "x" }), bindings);
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/top level/i);
   });

--- a/tests/logic/llm-query.test.ts
+++ b/tests/logic/llm-query.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for the `(llm_query …)` LC primitive — the symbolic-recursion
+ * POC introduced as the paper-review GAP 1 fix.
+ *
+ * Coverage:
+ *   1. Parser accepts the zero-binding and n-binding forms and rejects
+ *      malformed shapes.
+ *   2. Type inference returns `string`.
+ *   3. `solveAsync` dispatches top-level `(llm_query …)` through
+ *      `tools.llmQuery` and interpolates named bindings into the
+ *      prompt.
+ *   4. `solveAsync` surfaces a clean error when `tools.llmQuery` is
+ *      missing.
+ *   5. `solveAsync` propagates errors thrown by the underlying
+ *      `tools.llmQuery` callback.
+ *   6. Nested `(llm_query …)` inside a `filter`/`map`/etc. throws a
+ *      clear "top-level only" error via the sync `solve()` path.
+ *   7. Bindings inside a `(llm_query …)` are evaluated via the sync
+ *      solver and respect cross-turn variables (`RESULTS`, `_N`).
+ */
+
+import { describe, it, expect } from "vitest";
+import { parse } from "../../src/logic/lc-parser.js";
+import { inferType, typeToString } from "../../src/logic/type-inference.js";
+import {
+  solve,
+  solveAsync,
+  type SolverTools,
+  type Bindings,
+} from "../../src/logic/lc-solver.js";
+
+// Minimal SolverTools stub — the `(llm_query …)` path doesn't touch
+// grep/fuzzy/bm25/semantic/text_stats, so all the search callbacks can
+// return empty results. `lines` is required since the 3912e88 refactor.
+function makeTools(overrides: Partial<SolverTools> = {}): SolverTools {
+  return {
+    context: "",
+    lines: [],
+    grep: () => [],
+    fuzzy_search: () => [],
+    bm25: () => [],
+    semantic: () => [],
+    text_stats: () => ({
+      length: 0,
+      lineCount: 0,
+      sample: { start: "", middle: "", end: "" },
+    }),
+    ...overrides,
+  };
+}
+
+describe("llm_query parser", () => {
+  it("parses the zero-binding form", () => {
+    const result = parse('(llm_query "summarize the document")');
+    expect(result.success).toBe(true);
+    expect(result.term?.tag).toBe("llm_query");
+    if (result.term?.tag === "llm_query") {
+      expect(result.term.prompt).toBe("summarize the document");
+      expect(result.term.bindings).toEqual([]);
+    }
+  });
+
+  it("parses a single-binding form", () => {
+    const result = parse(
+      '(llm_query "Classify these errors: {errors}" (errors RESULTS))'
+    );
+    expect(result.success).toBe(true);
+    if (result.term?.tag === "llm_query") {
+      expect(result.term.prompt).toContain("{errors}");
+      expect(result.term.bindings).toHaveLength(1);
+      expect(result.term.bindings[0].name).toBe("errors");
+      expect(result.term.bindings[0].value.tag).toBe("var");
+    }
+  });
+
+  it("parses a multi-binding form", () => {
+    const result = parse(
+      '(llm_query "Apply {rules} to {data}" (rules _1) (data _2))'
+    );
+    expect(result.success).toBe(true);
+    if (result.term?.tag === "llm_query") {
+      expect(result.term.bindings).toHaveLength(2);
+      expect(result.term.bindings.map((b) => b.name)).toEqual(["rules", "data"]);
+    }
+  });
+
+  it("rejects a malformed binding that lacks parens", () => {
+    // `(llm_query "prompt" data _1)` is ambiguous — not a (name value)
+    // pair. The parser should fail cleanly rather than partially consume.
+    const result = parse('(llm_query "prompt" data _1)');
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a binding with an unsafe placeholder name", () => {
+    const result = parse('(llm_query "prompt" ("bad name" _1))');
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("llm_query type inference", () => {
+  it("infers string", () => {
+    const result = parse('(llm_query "summarize")');
+    expect(result.success).toBe(true);
+    const type = inferType(result.term!);
+    expect(type.valid).toBe(true);
+    expect(type.type && typeToString(type.type)).toBe("string");
+  });
+});
+
+describe("llm_query solver — top-level execution", () => {
+  it("delegates to tools.llmQuery and returns its response", async () => {
+    const received: string[] = [];
+    const tools = makeTools({
+      llmQuery: async (prompt: string) => {
+        received.push(prompt);
+        return "MOCKED SUB-LLM RESPONSE";
+      },
+    });
+
+    const parsed = parse('(llm_query "What is this document about?")');
+    expect(parsed.success).toBe(true);
+
+    const result = await solveAsync(parsed.term!, tools, new Map());
+    expect(result.success).toBe(true);
+    expect(result.value).toBe("MOCKED SUB-LLM RESPONSE");
+    expect(received).toHaveLength(1);
+    expect(received[0]).toBe("What is this document about?");
+  });
+
+  it("interpolates a single {name} placeholder from a binding", async () => {
+    const received: string[] = [];
+    const tools = makeTools({
+      llmQuery: async (prompt: string) => {
+        received.push(prompt);
+        return "ok";
+      },
+    });
+
+    const bindings: Bindings = new Map();
+    bindings.set("RESULTS", [
+      { line: "ERROR: disk full" },
+      { line: "ERROR: timeout" },
+    ]);
+
+    const parsed = parse(
+      '(llm_query "Classify these errors: {errors}" (errors RESULTS))'
+    );
+    expect(parsed.success).toBe(true);
+
+    const result = await solveAsync(parsed.term!, tools, bindings);
+    expect(result.success).toBe(true);
+    expect(received[0]).toContain("Classify these errors:");
+    expect(received[0]).toContain("ERROR: disk full");
+    expect(received[0]).toContain("ERROR: timeout");
+    // `{errors}` placeholder must be fully replaced — no stray braces.
+    expect(received[0]).not.toContain("{errors}");
+  });
+
+  it("interpolates multiple named bindings", async () => {
+    let seenPrompt = "";
+    const tools = makeTools({
+      llmQuery: async (prompt: string) => {
+        seenPrompt = prompt;
+        return "done";
+      },
+    });
+
+    const bindings: Bindings = new Map();
+    bindings.set("_1", "rule-set-A");
+    bindings.set("_2", "data-set-B");
+
+    const parsed = parse(
+      '(llm_query "Apply {rules} to {data}" (rules _1) (data _2))'
+    );
+    expect(parsed.success).toBe(true);
+    const result = await solveAsync(parsed.term!, tools, bindings);
+
+    expect(result.success).toBe(true);
+    expect(seenPrompt).toBe("Apply rule-set-A to data-set-B");
+  });
+
+  it("delegates non-llm_query terms to the sync solver", async () => {
+    // `(lit 42)` should round-trip through the sync path unchanged.
+    const parsed = parse("42");
+    expect(parsed.success).toBe(true);
+    const result = await solveAsync(parsed.term!, makeTools(), new Map());
+    expect(result.success).toBe(true);
+    expect(result.value).toBe(42);
+  });
+});
+
+describe("llm_query solver — error paths", () => {
+  it("errors cleanly when tools.llmQuery is missing", async () => {
+    const parsed = parse('(llm_query "summarize")');
+    expect(parsed.success).toBe(true);
+    const result = await solveAsync(parsed.term!, makeTools(), new Map());
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/llm_query is not available/i);
+  });
+
+  it("propagates errors thrown by tools.llmQuery", async () => {
+    const tools = makeTools({
+      llmQuery: async () => {
+        throw new Error("upstream LLM quota exceeded");
+      },
+    });
+    const parsed = parse('(llm_query "summarize")');
+    const result = await solveAsync(parsed.term!, tools, new Map());
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/quota exceeded/);
+  });
+
+  it("rejects nested llm_query inside a filter lambda (top-level only)", () => {
+    // This is the POC's deliberate limitation — the sync `solve()` path
+    // refuses to dispatch `llm_query` when encountered inside another
+    // term. The error message should explicitly say "top level".
+    const parsed = parse(
+      '(filter RESULTS (lambda x (llm_query "classify {x}" (x x))))'
+    );
+    expect(parsed.success).toBe(true);
+
+    // Feed through the sync solver directly — the FSM's solveAsync
+    // routes to solve() for anything that isn't a top-level llm_query,
+    // so nesting trips the sync path's error case.
+    const bindings: Bindings = new Map();
+    bindings.set("RESULTS", ["a", "b"]);
+    const result = solve(parsed.term!, makeTools({ llmQuery: async () => "x" }), bindings);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/top level/i);
+  });
+});

--- a/tests/logic/llm-query.test.ts
+++ b/tests/logic/llm-query.test.ts
@@ -1,22 +1,19 @@
 /**
  * Tests for the `(llm_query …)` LC primitive — the symbolic-recursion
- * POC introduced as the paper-review GAP 1 fix.
+ * paper-review GAP 1 fix.
  *
- * Coverage:
+ * Coverage (top-level shapes — nested cases are in llm-query-nested.test.ts):
  *   1. Parser accepts the zero-binding and n-binding forms and rejects
  *      malformed shapes.
  *   2. Type inference returns `string`.
- *   3. `solveAsync` dispatches top-level `(llm_query …)` through
- *      `tools.llmQuery` and interpolates named bindings into the
- *      prompt.
- *   4. `solveAsync` surfaces a clean error when `tools.llmQuery` is
+ *   3. `solve()` dispatches `(llm_query …)` through `tools.llmQuery`
+ *      and interpolates named bindings into the prompt.
+ *   4. `solve()` surfaces a clean error when `tools.llmQuery` is
  *      missing.
- *   5. `solveAsync` propagates errors thrown by the underlying
+ *   5. `solve()` propagates errors thrown by the underlying
  *      `tools.llmQuery` callback.
- *   6. Nested `(llm_query …)` inside a `filter`/`map`/etc. throws a
- *      clear "top-level only" error via the sync `await solve()` path.
- *   7. Bindings inside a `(llm_query …)` are evaluated via the sync
- *      solver and respect cross-turn variables (`RESULTS`, `_N`).
+ *   6. Bindings inside a `(llm_query …)` are evaluated via the solver
+ *      and respect cross-turn variables (`RESULTS`, `_N`).
  */
 
 import { describe, it, expect } from "vitest";
@@ -24,7 +21,6 @@ import { parse } from "../../src/logic/lc-parser.js";
 import { inferType, typeToString } from "../../src/logic/type-inference.js";
 import {
   solve,
-  solveAsync,
   type SolverTools,
   type Bindings,
 } from "../../src/logic/lc-solver.js";
@@ -120,7 +116,7 @@ describe("llm_query solver — top-level execution", () => {
     const parsed = parse('(llm_query "What is this document about?")');
     expect(parsed.success).toBe(true);
 
-    const result = await solveAsync(parsed.term!, tools, new Map());
+    const result = await solve(parsed.term!, tools, new Map());
     expect(result.success).toBe(true);
     expect(result.value).toBe("MOCKED SUB-LLM RESPONSE");
     expect(received).toHaveLength(1);
@@ -147,7 +143,7 @@ describe("llm_query solver — top-level execution", () => {
     );
     expect(parsed.success).toBe(true);
 
-    const result = await solveAsync(parsed.term!, tools, bindings);
+    const result = await solve(parsed.term!, tools, bindings);
     expect(result.success).toBe(true);
     expect(received[0]).toContain("Classify these errors:");
     expect(received[0]).toContain("ERROR: disk full");
@@ -173,7 +169,7 @@ describe("llm_query solver — top-level execution", () => {
       '(llm_query "Apply {rules} to {data}" (rules _1) (data _2))'
     );
     expect(parsed.success).toBe(true);
-    const result = await solveAsync(parsed.term!, tools, bindings);
+    const result = await solve(parsed.term!, tools, bindings);
 
     expect(result.success).toBe(true);
     expect(seenPrompt).toBe("Apply rule-set-A to data-set-B");
@@ -183,7 +179,7 @@ describe("llm_query solver — top-level execution", () => {
     // `(lit 42)` should round-trip through the sync path unchanged.
     const parsed = parse("42");
     expect(parsed.success).toBe(true);
-    const result = await solveAsync(parsed.term!, makeTools(), new Map());
+    const result = await solve(parsed.term!, makeTools(), new Map());
     expect(result.success).toBe(true);
     expect(result.value).toBe(42);
   });
@@ -193,7 +189,7 @@ describe("llm_query solver — error paths", () => {
   it("errors cleanly when tools.llmQuery is missing", async () => {
     const parsed = parse('(llm_query "summarize")');
     expect(parsed.success).toBe(true);
-    const result = await solveAsync(parsed.term!, makeTools(), new Map());
+    const result = await solve(parsed.term!, makeTools(), new Map());
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/llm_query is not available/i);
   });
@@ -205,13 +201,10 @@ describe("llm_query solver — error paths", () => {
       },
     });
     const parsed = parse('(llm_query "summarize")');
-    const result = await solveAsync(parsed.term!, tools, new Map());
+    const result = await solve(parsed.term!, tools, new Map());
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/quota exceeded/);
   });
 
-  // The "top-level only" restriction was removed in the full async
-  // refactor — nested llm_query inside filter/map/reduce lambdas now
-  // works. See tests/logic/llm-query-nested.test.ts for the positive
-  // assertions that cover the nested capability.
+  // Nested-case coverage lives in tests/logic/llm-query-nested.test.ts.
 });

--- a/tests/logic/llm-query.test.ts
+++ b/tests/logic/llm-query.test.ts
@@ -210,22 +210,8 @@ describe("llm_query solver — error paths", () => {
     expect(result.error).toMatch(/quota exceeded/);
   });
 
-  it("rejects nested llm_query inside a filter lambda (top-level only)", async () => {
-    // This is the POC's deliberate limitation — the sync `await solve()` path
-    // refuses to dispatch `llm_query` when encountered inside another
-    // term. The error message should explicitly say "top level".
-    const parsed = parse(
-      '(filter RESULTS (lambda x (llm_query "classify {x}" (x x))))'
-    );
-    expect(parsed.success).toBe(true);
-
-    // Feed through the sync solver directly — the FSM's solveAsync
-    // routes to await solve() for anything that isn't a top-level llm_query,
-    // so nesting trips the sync path's error case.
-    const bindings: Bindings = new Map();
-    bindings.set("RESULTS", ["a", "b"]);
-    const result = await solve(parsed.term!, makeTools({ llmQuery: async () => "x" }), bindings);
-    expect(result.success).toBe(false);
-    expect(result.error).toMatch(/top level/i);
-  });
+  // The "top-level only" restriction was removed in the full async
+  // refactor — nested llm_query inside filter/map/reduce lambdas now
+  // works. See tests/logic/llm-query-nested.test.ts for the positive
+  // assertions that cover the nested capability.
 });

--- a/tests/logic/rerank-nucleus.test.ts
+++ b/tests/logic/rerank-nucleus.test.ts
@@ -42,7 +42,7 @@ const testContext = `[10:00] INFO: System started
 [10:04] INFO: Connection established`;
 
 describe("rerank Parser", () => {
-  it("should parse rerank with collection", () => {
+  it("should parse rerank with collection", async () => {
     const result = parse('(rerank (bm25 "error"))');
     expect(result.success).toBe(true);
     expect(result.term?.tag).toBe("rerank");
@@ -51,7 +51,7 @@ describe("rerank Parser", () => {
     }
   });
 
-  it("should parse rerank with variable", () => {
+  it("should parse rerank with variable", async () => {
     const result = parse("(rerank RESULTS)");
     expect(result.success).toBe(true);
     if (result.term?.tag === "rerank") {
@@ -59,13 +59,13 @@ describe("rerank Parser", () => {
     }
   });
 
-  it("should fail on empty rerank", () => {
+  it("should fail on empty rerank", async () => {
     expect(parse("(rerank)").success).toBe(false);
   });
 });
 
 describe("rerank prettyPrint", () => {
-  it("should round-trip", () => {
+  it("should round-trip", async () => {
     const result = parse('(rerank (bm25 "error"))');
     expect(result.success).toBe(true);
     expect(prettyPrint(result.term!)).toBe('(rerank (bm25 "error"))');
@@ -73,7 +73,7 @@ describe("rerank prettyPrint", () => {
 });
 
 describe("rerank Type Inference", () => {
-  it("should infer array type", () => {
+  it("should infer array type", async () => {
     const result = parse('(rerank (bm25 "error"))');
     expect(result.success).toBe(true);
     const typeResult = inferType(result.term!);
@@ -83,14 +83,14 @@ describe("rerank Type Inference", () => {
 });
 
 describe("rerank Solver", () => {
-  it("should rerank bm25 results", () => {
+  it("should rerank bm25 results", async () => {
     const tools = createMockTools(testContext);
     const bindings: Bindings = new Map();
     bindings.set("_qstore", new QValueStore());
 
     const result = parse('(rerank (bm25 "error connection"))');
     expect(result.success).toBe(true);
-    const solveResult = solve(result.term!, tools, bindings);
+    const solveResult = await solve(result.term!, tools, bindings);
     expect(solveResult.success).toBe(true);
     expect(Array.isArray(solveResult.value)).toBe(true);
     const results = solveResult.value as Array<{ line: string; score: number }>;
@@ -101,51 +101,51 @@ describe("rerank Solver", () => {
     }
   });
 
-  it("should work without explicit QValueStore (creates one)", () => {
+  it("should work without explicit QValueStore (creates one)", async () => {
     const tools = createMockTools(testContext);
     const result = parse('(rerank (bm25 "error"))');
     expect(result.success).toBe(true);
-    const solveResult = solve(result.term!, tools);
+    const solveResult = await solve(result.term!, tools);
     expect(solveResult.success).toBe(true);
     expect(Array.isArray(solveResult.value)).toBe(true);
   });
 
-  it("should compose with filter", () => {
+  it("should compose with filter", async () => {
     const tools = createMockTools(testContext);
     const bindings: Bindings = new Map();
 
     const rerankParse = parse('(rerank (bm25 "error"))');
-    const rerankResult = solve(rerankParse.term!, tools);
+    const rerankResult = await solve(rerankParse.term!, tools);
     expect(rerankResult.success).toBe(true);
     bindings.set("RESULTS", rerankResult.value);
 
     const filterParse = parse('(filter RESULTS (lambda x (match x "timeout" 0)))');
-    const filterResult = solve(filterParse.term!, tools, bindings);
+    const filterResult = await solve(filterParse.term!, tools, bindings);
     expect(filterResult.success).toBe(true);
   });
 
-  it("should auto-reward previous RESULTS lines", () => {
+  it("should auto-reward previous RESULTS lines", async () => {
     const tools = createMockTools(testContext);
     const bindings: Bindings = new Map();
 
     const bm25Parse = parse('(bm25 "error")');
-    const bm25Result = solve(bm25Parse.term!, tools, bindings);
+    const bm25Result = await solve(bm25Parse.term!, tools, bindings);
     bindings.set("RESULTS", bm25Result.value);
 
     const rerankParse = parse('(rerank (bm25 "error connection"))');
     expect(rerankParse.success).toBe(true);
-    const rerankResult = solve(rerankParse.term!, tools, bindings);
+    const rerankResult = await solve(rerankParse.term!, tools, bindings);
     expect(rerankResult.success).toBe(true);
 
     const reranked = rerankResult.value as Array<{ lineNum: number }>;
     expect(reranked.length).toBeGreaterThan(0);
   });
 
-  it("should compose with fuse then rerank", () => {
+  it("should compose with fuse then rerank", async () => {
     const tools = createMockTools(testContext);
     const result = parse('(rerank (fuse (grep "ERROR") (bm25 "error")))');
     expect(result.success).toBe(true);
-    const solveResult = solve(result.term!, tools);
+    const solveResult = await solve(result.term!, tools);
     expect(solveResult.success).toBe(true);
     expect(Array.isArray(solveResult.value)).toBe(true);
   });

--- a/tests/logic/semantic-nucleus.test.ts
+++ b/tests/logic/semantic-nucleus.test.ts
@@ -49,7 +49,7 @@ const testContext = `[10:00] INFO: System started
 [10:04] INFO: Connection established`;
 
 describe("semantic Parser", () => {
-  it("should parse semantic with query", () => {
+  it("should parse semantic with query", async () => {
     const result = parse('(semantic "database error")');
     expect(result.success).toBe(true);
     expect(result.term?.tag).toBe("semantic");
@@ -59,7 +59,7 @@ describe("semantic Parser", () => {
     }
   });
 
-  it("should parse semantic with query and limit", () => {
+  it("should parse semantic with query and limit", async () => {
     const result = parse('(semantic "database error" 5)');
     expect(result.success).toBe(true);
     if (result.term?.tag === "semantic") {
@@ -68,23 +68,23 @@ describe("semantic Parser", () => {
     }
   });
 
-  it("should fail on empty semantic", () => {
+  it("should fail on empty semantic", async () => {
     expect(parse("(semantic)").success).toBe(false);
   });
 
-  it("should fail on non-string query", () => {
+  it("should fail on non-string query", async () => {
     expect(parse("(semantic 42)").success).toBe(false);
   });
 });
 
 describe("semantic prettyPrint", () => {
-  it("should round-trip without limit", () => {
+  it("should round-trip without limit", async () => {
     const result = parse('(semantic "database error")');
     expect(result.success).toBe(true);
     expect(prettyPrint(result.term!)).toBe('(semantic "database error")');
   });
 
-  it("should round-trip with limit", () => {
+  it("should round-trip with limit", async () => {
     const result = parse('(semantic "database error" 5)');
     expect(result.success).toBe(true);
     expect(prettyPrint(result.term!)).toBe('(semantic "database error" 5)');
@@ -92,7 +92,7 @@ describe("semantic prettyPrint", () => {
 });
 
 describe("semantic Type Inference", () => {
-  it("should infer array type", () => {
+  it("should infer array type", async () => {
     const result = parse('(semantic "database")');
     expect(result.success).toBe(true);
     const typeResult = inferType(result.term!);
@@ -102,34 +102,34 @@ describe("semantic Type Inference", () => {
 });
 
 describe("semantic Solver", () => {
-  it("should return ranked results", () => {
+  it("should return ranked results", async () => {
     const tools = createMockTools(testContext);
     const result = parse('(semantic "database error")');
     expect(result.success).toBe(true);
-    const solveResult = solve(result.term!, tools);
+    const solveResult = await solve(result.term!, tools);
     expect(solveResult.success).toBe(true);
     expect(Array.isArray(solveResult.value)).toBe(true);
     const results = solveResult.value as Array<{ line: string; score: number }>;
     expect(results.length).toBeGreaterThan(0);
   });
 
-  it("should compose with fuse", () => {
+  it("should compose with fuse", async () => {
     const tools = createMockTools(testContext);
     const result = parse('(fuse (semantic "database error") (bm25 "database"))');
     expect(result.success).toBe(true);
-    const solveResult = solve(result.term!, tools);
+    const solveResult = await solve(result.term!, tools);
     expect(solveResult.success).toBe(true);
   });
 
-  it("should compose with filter", () => {
+  it("should compose with filter", async () => {
     const tools = createMockTools(testContext);
     const bindings: Bindings = new Map();
     const semParse = parse('(semantic "error")');
-    const semResult = solve(semParse.term!, tools);
+    const semResult = await solve(semParse.term!, tools);
     bindings.set("RESULTS", semResult.value);
 
     const filterParse = parse('(filter RESULTS (lambda x (match x "timeout" 0)))');
-    const filterResult = solve(filterParse.term!, tools, bindings);
+    const filterResult = await solve(filterParse.term!, tools, bindings);
     expect(filterResult.success).toBe(true);
   });
 });

--- a/tests/memo.test.ts
+++ b/tests/memo.test.ts
@@ -27,7 +27,7 @@ describe("Memory Pad (Memo)", () => {
   });
 
   describe("basic memo storage", () => {
-    it("should store a memo and return a handle stub", () => {
+    it("should store a memo and return a handle stub", async () => {
       const result = session.memo("Hello, world!\nThis is a test.", "greeting");
 
       expect(result.success).toBe(true);
@@ -37,14 +37,14 @@ describe("Memory Pad (Memo)", () => {
       expect(result.stub).toContain("2 lines");
     });
 
-    it("should work without a loaded document", () => {
+    it("should work without a loaded document", async () => {
       // No loadFile/loadContent called
       const result = session.memo("Some context to remember", "context note");
       expect(result.success).toBe(true);
       expect(result.handle).toBe("$memo1");
     });
 
-    it("should assign incrementing memo handles", () => {
+    it("should assign incrementing memo handles", async () => {
       const r1 = session.memo("First memo", "first");
       const r2 = session.memo("Second memo", "second");
       const r3 = session.memo("Third memo", "third");
@@ -54,7 +54,7 @@ describe("Memory Pad (Memo)", () => {
       expect(r3.handle).toBe("$memo3");
     });
 
-    it("should report token savings", () => {
+    it("should report token savings", async () => {
       const longContent = "x".repeat(4000); // ~1000 tokens
       const result = session.memo(longContent, "big memo");
 
@@ -66,7 +66,7 @@ describe("Memory Pad (Memo)", () => {
   });
 
   describe("memo expansion", () => {
-    it("should expand memo content via expand()", () => {
+    it("should expand memo content via expand()", async () => {
       const content = "Line 1\nLine 2\nLine 3";
       session.memo(content, "test memo");
 
@@ -76,7 +76,7 @@ describe("Memory Pad (Memo)", () => {
       expect(expanded.data).toEqual(["Line 1", "Line 2", "Line 3"]);
     });
 
-    it("should support limit and offset on memo expansion", () => {
+    it("should support limit and offset on memo expansion", async () => {
       const content = Array.from({ length: 20 }, (_, i) => `Line ${i + 1}`).join("\n");
       session.memo(content, "numbered lines");
 
@@ -91,7 +91,7 @@ describe("Memory Pad (Memo)", () => {
   });
 
   describe("memo labels in bindings", () => {
-    it("should show memo labels in getBindings()", () => {
+    it("should show memo labels in getBindings()", async () => {
       session.memo("Some architecture notes", "arch overview");
 
       const bindings = session.getBindings();
@@ -105,7 +105,7 @@ describe("Memory Pad (Memo)", () => {
 
       await session.loadFile(testFile);
       session.memo("Analysis summary", "error analysis");
-      session.execute('(grep "ERROR")');
+      await session.execute('(grep "ERROR")');
 
       const bindings = session.getBindings();
       expect(bindings["$memo1"]).toContain("error analysis");
@@ -124,7 +124,7 @@ describe("Memory Pad (Memo)", () => {
       fs.writeFileSync(testFile, "Some document content");
 
       await session.loadFile(testFile);
-      session.execute('(grep "content")');
+      await session.execute('(grep "content")');
 
       // Clear query handles (simulates document reload)
       session.clearQueryHandles();
@@ -148,19 +148,19 @@ describe("Memory Pad (Memo)", () => {
   });
 
   describe("getMemoLabel", () => {
-    it("should return label for memo handles", () => {
+    it("should return label for memo handles", async () => {
       session.memo("Content", "my label");
       expect(session.getMemoLabel("$memo1")).toBe("my label");
     });
 
-    it("should return null for non-memo handles", () => {
+    it("should return null for non-memo handles", async () => {
       expect(session.getMemoLabel("$res1")).toBeNull();
       expect(session.getMemoLabel("$memo999")).toBeNull();
     });
   });
 
   describe("memo deletion", () => {
-    it("should delete a memo by handle", () => {
+    it("should delete a memo by handle", async () => {
       session.memo("Content A", "memo a");
       session.memo("Content B", "memo b");
 
@@ -175,12 +175,12 @@ describe("Memory Pad (Memo)", () => {
       expect(memo2.success).toBe(true);
     });
 
-    it("should return false for non-memo handles", () => {
+    it("should return false for non-memo handles", async () => {
       expect(session.deleteMemo("$res1")).toBe(false);
       expect(session.deleteMemo("$memo999")).toBe(false);
     });
 
-    it("should update byte tracking on delete", () => {
+    it("should update byte tracking on delete", async () => {
       session.memo("x".repeat(1000), "big memo");
       const before = session.getMemoStats();
       expect(before.totalBytes).toBe(1000);
@@ -193,7 +193,7 @@ describe("Memory Pad (Memo)", () => {
   });
 
   describe("memo eviction", () => {
-    it("should evict oldest memo when count limit exceeded", () => {
+    it("should evict oldest memo when count limit exceeded", async () => {
       const limit = HandleSession.MAX_MEMOS;
       // Fill to the limit
       for (let i = 0; i < limit; i++) {
@@ -215,7 +215,7 @@ describe("Memory Pad (Memo)", () => {
       expect(latest.success).toBe(true);
     });
 
-    it("should evict oldest memos when byte budget exceeded", () => {
+    it("should evict oldest memos when byte budget exceeded", async () => {
       const maxBytes = HandleSession.MAX_MEMO_BYTES;
       const chunkSize = Math.floor(maxBytes / 3);
 
@@ -237,7 +237,7 @@ describe("Memory Pad (Memo)", () => {
   });
 
   describe("reset clears memo state", () => {
-    it("should clear memo tracking on reset()", () => {
+    it("should clear memo tracking on reset()", async () => {
       session.memo("x".repeat(500), "memo a");
       session.memo("x".repeat(500), "memo b");
       expect(session.getMemoStats().count).toBe(2);
@@ -257,7 +257,7 @@ describe("Memory Pad (Memo)", () => {
   });
 
   describe("eviction order is numeric not alphabetic", () => {
-    it("should evict $memo2 before $memo10", () => {
+    it("should evict $memo2 before $memo10", async () => {
       // Create 12 memos so we have handles crossing the single/double digit boundary
       for (let i = 0; i < 12; i++) {
         session.memo(`Memo ${i + 1}`, `memo-${i + 1}`);
@@ -284,7 +284,7 @@ describe("Memory Pad (Memo)", () => {
   });
 
   describe("memo stats", () => {
-    it("should track memo count and bytes", () => {
+    it("should track memo count and bytes", async () => {
       const empty = session.getMemoStats();
       expect(empty.count).toBe(0);
       expect(empty.totalBytes).toBe(0);

--- a/tests/persistence/comparison.test.ts
+++ b/tests/persistence/comparison.test.ts
@@ -65,7 +65,7 @@ describe("Data Comparison: Traditional vs Handle-Based", () => {
   });
 
   describe("Document Loading", () => {
-    it("should capture same line count", () => {
+    it("should capture same line count", async () => {
       const tradStats = traditional.getStats();
       const handleStats = db.getLineCount();
 
@@ -74,7 +74,7 @@ describe("Data Comparison: Traditional vs Handle-Based", () => {
       expect(tradStats?.lineCount).toBe(handleStats);
     });
 
-    it("should capture same document length", () => {
+    it("should capture same document length", async () => {
       const tradStats = traditional.getStats();
       const handleStats = {
         length: SAMPLE_DOCUMENT.length,
@@ -86,9 +86,9 @@ describe("Data Comparison: Traditional vs Handle-Based", () => {
   });
 
   describe("Search Operations (grep)", () => {
-    it("should capture comparable grep results", () => {
+    it("should capture comparable grep results", async () => {
       // Traditional grep (case-insensitive by default in Nucleus)
-      const tradResult = traditional.execute('(grep "ERROR")');
+      const tradResult = await traditional.execute('(grep "ERROR")');
       const tradMatches = tradResult.value as Array<{
         match: string;
         line: string;
@@ -111,8 +111,8 @@ describe("Data Comparison: Traditional vs Handle-Based", () => {
       expect(handleHasError1).toBe(true);
     });
 
-    it("should capture same fields in grep results", () => {
-      const tradResult = traditional.execute('(grep "ERROR")');
+    it("should capture same fields in grep results", async () => {
+      const tradResult = await traditional.execute('(grep "ERROR")');
       const tradMatch = (tradResult.value as unknown[])[0] as {
         match: string;
         line: string;
@@ -149,10 +149,10 @@ describe("Data Comparison: Traditional vs Handle-Based", () => {
       // For regex group extraction, use grep() with the handle system
     });
 
-    it("should allow regex grep through traditional engine", () => {
+    it("should allow regex grep through traditional engine", async () => {
       // Handle-based system still supports regex grep through the engine
       // The FTS5 is an optimization for simple keyword searches
-      const tradResult = traditional.execute('(grep "Sales Q[1-4]")');
+      const tradResult = await traditional.execute('(grep "Sales Q[1-4]")');
       const tradCount = (tradResult.value as unknown[]).length;
       expect(tradCount).toBe(4);
 
@@ -165,10 +165,10 @@ describe("Data Comparison: Traditional vs Handle-Based", () => {
   });
 
   describe("Aggregation Operations", () => {
-    it("should produce consistent count behavior", () => {
+    it("should produce consistent count behavior", async () => {
       // Traditional - count specific pattern
-      traditional.execute('(grep "Sales Q")');
-      const tradCount = traditional.execute('(count RESULTS)');
+      await traditional.execute('(grep "Sales Q")');
+      const tradCount = await traditional.execute('(count RESULTS)');
 
       // Handle-based - count same pattern
       const searchResults = search.search("Sales");
@@ -184,13 +184,13 @@ describe("Data Comparison: Traditional vs Handle-Based", () => {
       console.log("Handle-based count:", handleCount);
     });
 
-    it("should produce identical sum results for same data", () => {
+    it("should produce identical sum results for same data", async () => {
       // Traditional - sum sales figures
-      traditional.execute('(grep "revenue")');
-      const tradSum = traditional.execute('(sum RESULTS)');
+      await traditional.execute('(grep "revenue")');
+      const tradSum = await traditional.execute('(sum RESULTS)');
 
       // Handle-based - use same data source (grep results converted to handle)
-      const grepResult = traditional.execute('(grep "revenue")');
+      const grepResult = await traditional.execute('(grep "revenue")');
       const grepData = grepResult.value as Array<{ line: string; lineNum: number }>;
       const handle = registry.store(grepData);
       const handleSum = ops.sumFromLine(handle);
@@ -207,10 +207,10 @@ describe("Data Comparison: Traditional vs Handle-Based", () => {
   });
 
   describe("Filter Operations", () => {
-    it("should produce equivalent filter results", () => {
+    it("should produce equivalent filter results", async () => {
       // Traditional filter
-      traditional.execute('(grep "ERROR")');
-      const tradFiltered = traditional.execute(
+      await traditional.execute('(grep "ERROR")');
+      const tradFiltered = await traditional.execute(
         '(filter RESULTS (lambda x (match x "timeout" 0)))'
       );
       const tradResult = tradFiltered.value as unknown[];
@@ -233,14 +233,14 @@ describe("Data Comparison: Traditional vs Handle-Based", () => {
   });
 
   describe("Map Operations", () => {
-    it("should produce equivalent map results for same data", () => {
+    it("should produce equivalent map results for same data", async () => {
       // Traditional map - extract item numbers from Customer lines
-      traditional.execute('(grep "Customer:")');  // More specific pattern
-      const tradMapped = traditional.execute('(map RESULTS (lambda x (match x "item #(\\\\d+)" 1)))');
+      await traditional.execute('(grep "Customer:")');  // More specific pattern
+      const tradMapped = await traditional.execute('(map RESULTS (lambda x (match x "item #(\\\\d+)" 1)))');
       const tradResult = tradMapped.value as string[];
 
       // Handle-based map - use same grep results
-      const grepResult = traditional.execute('(grep "Customer:")');
+      const grepResult = await traditional.execute('(grep "Customer:")');
       const grepData = grepResult.value as Array<{ line: string; lineNum: number }>;
       const handle = registry.store(grepData);
       const mappedHandle = ops.map(handle, "item.line.match(/item #(\\d+)/)?.[1]");
@@ -253,9 +253,9 @@ describe("Data Comparison: Traditional vs Handle-Based", () => {
   });
 
   describe("Bindings", () => {
-    it("should track bindings with similar information", () => {
+    it("should track bindings with similar information", async () => {
       // Traditional bindings
-      traditional.execute('(grep "ERROR")');
+      await traditional.execute('(grep "ERROR")');
       const tradBindings = traditional.getBindings();
 
       console.log("\n=== TRADITIONAL BINDINGS ===");
@@ -266,7 +266,7 @@ describe("Data Comparison: Traditional vs Handle-Based", () => {
       expect(tradBindings._1).toMatch(/^Array\[\d+\]$/);
 
       // Handle-based bindings - use same grep results for fair comparison
-      const grepResult = traditional.execute('(grep "ERROR")');
+      const grepResult = await traditional.execute('(grep "ERROR")');
       const grepData = grepResult.value as unknown[];
       const handle = registry.store(grepData);
       registry.setResults(handle);
@@ -281,9 +281,9 @@ describe("Data Comparison: Traditional vs Handle-Based", () => {
       expect(handleContext).toMatch(/Array\(\d+\)/);
     });
 
-    it("should provide more information in handle stubs", () => {
+    it("should provide more information in handle stubs", async () => {
       // Use grep results which have 'line' property
-      const grepResult = traditional.execute('(grep "ERROR")');
+      const grepResult = await traditional.execute('(grep "ERROR")');
       const grepData = grepResult.value as unknown[];
       const handle = registry.store(grepData);
       const stub = registry.getStub(handle);
@@ -300,7 +300,7 @@ describe("Data Comparison: Traditional vs Handle-Based", () => {
   });
 
   describe("Token Savings Verification", () => {
-    it("should demonstrate significant token savings", () => {
+    it("should demonstrate significant token savings", async () => {
       // Simulate large result set
       const largeResults = Array.from({ length: 1000 }, (_, i) => ({
         line: `2024-01-15 10:30:${String(i).padStart(2, "0")} ERROR: Some error message with details about failure ${i}`,
@@ -352,7 +352,7 @@ describe("Handle-Based Advantages (New Features)", () => {
   });
 
   describe("FTS5 Full-Text Search (New)", () => {
-    it("should support phrase queries (not in traditional)", () => {
+    it("should support phrase queries (not in traditional)", async () => {
       // FTS5 phrase query - exact phrase match
       const results = search.search('"connection failed"');
 
@@ -364,7 +364,7 @@ describe("Handle-Based Advantages (New Features)", () => {
       console.log("Result:", results[0].content);
     });
 
-    it("should support boolean operators (improved)", () => {
+    it("should support boolean operators (improved)", async () => {
       // FTS5 boolean - ERROR but not timeout
       const results = search.search("ERROR NOT timeout");
 
@@ -375,7 +375,7 @@ describe("Handle-Based Advantages (New Features)", () => {
       console.log("Results:", results.length);
     });
 
-    it("should support OR queries (improved)", () => {
+    it("should support OR queries (improved)", async () => {
       const results = search.search("WARNING OR DEBUG");
 
       expect(results.length).toBe(2);
@@ -385,7 +385,7 @@ describe("Handle-Based Advantages (New Features)", () => {
       console.log("Results:", results.length);
     });
 
-    it("should support prefix matching (new)", () => {
+    it("should support prefix matching (new)", async () => {
       const results = search.search("connect*");
 
       expect(results.length).toBeGreaterThan(1);
@@ -395,7 +395,7 @@ describe("Handle-Based Advantages (New Features)", () => {
       console.log("Results:", results.length);
     });
 
-    it("should provide highlighting (new)", () => {
+    it("should provide highlighting (new)", async () => {
       const results = search.searchWithHighlights("ERROR");
 
       expect(results[0].highlighted).toContain("<mark>ERROR</mark>");
@@ -405,7 +405,7 @@ describe("Handle-Based Advantages (New Features)", () => {
       console.log("Highlighted:", results[0].highlighted);
     });
 
-    it("should support relevance ranking (new)", () => {
+    it("should support relevance ranking (new)", async () => {
       const results = search.searchByRelevance("revenue customers");
 
       // Results should be ordered by relevance (most matches first)
@@ -418,7 +418,7 @@ describe("Handle-Based Advantages (New Features)", () => {
   });
 
   describe("Session Checkpoints (New)", () => {
-    it("should save and restore session state", () => {
+    it("should save and restore session state", async () => {
       // Build up state
       const results1 = search.search("ERROR");
       const h1 = registry.store(results1);
@@ -446,7 +446,7 @@ describe("Handle-Based Advantages (New Features)", () => {
   });
 
   describe("Server-Side Operations (New)", () => {
-    it("should sort without transferring data", () => {
+    it("should sort without transferring data", async () => {
       const results = search.search("Sales");
       const handle = registry.store(
         results.map((r) => ({
@@ -467,7 +467,7 @@ describe("Handle-Based Advantages (New Features)", () => {
       });
     });
 
-    it("should preview/sample without full transfer", () => {
+    it("should preview/sample without full transfer", async () => {
       const results = search.search("Customer");
       const handle = registry.store(results);
 
@@ -482,7 +482,7 @@ describe("Handle-Based Advantages (New Features)", () => {
       expect(sample.length).toBe(2);
     });
 
-    it("should describe data schema without full transfer", () => {
+    it("should describe data schema without full transfer", async () => {
       const results = search.search("Sales");
       const handle = registry.store(
         results.map((r) => ({
@@ -507,7 +507,7 @@ describe("Handle-Based Advantages (New Features)", () => {
 });
 
 describe("Feature Comparison Summary", () => {
-  it("should document feature comparison", () => {
+  it("should document feature comparison", async () => {
     console.log("\n" + "=".repeat(70));
     console.log("FEATURE COMPARISON: TRADITIONAL vs HANDLE-BASED");
     console.log("=".repeat(70));

--- a/tests/repl/lattice-repl.test.ts
+++ b/tests/repl/lattice-repl.test.ts
@@ -5,47 +5,47 @@ import { describe, it, expect } from "vitest";
 import { HandleSession } from "../../src/engine/handle-session.js";
 
 describe("REPL underlying engine", () => {
-  it("should process commands sequentially", () => {
+  it("should process commands sequentially", async () => {
     const engine = new HandleSession();
     // Use unique pattern that won't match INFO, etc
     engine.loadContent("FATAL: test error\nINFO: test info\nFATAL: another error");
 
     // Simulate REPL session
-    const r1 = engine.execute('(grep "FATAL")');
+    const r1 = await engine.execute('(grep "FATAL")');
     expect(r1.success).toBe(true);
     expect(r1.handle).toBeDefined();
     const expanded = engine.expand(r1.handle!);
     expect(expanded.success).toBe(true);
     expect(expanded.data?.length).toBe(2);
 
-    const r2 = engine.execute('(count RESULTS)');
+    const r2 = await engine.execute('(count RESULTS)');
     expect(r2.success).toBe(true);
     expect(r2.value).toBe(2);
   });
 
-  it("should maintain state across commands", () => {
+  it("should maintain state across commands", async () => {
     const engine = new HandleSession();
     engine.loadContent("line1\nline2\nline3");
 
-    engine.execute('(grep "line")');
+    await engine.execute('(grep "line")');
     const bindings = engine.getBindings();
 
     expect(bindings.RESULTS).toBe("-> $res1");
     expect(bindings.$res1).toContain("Array(3)");
   });
 
-  it("should reset state on command", () => {
+  it("should reset state on command", async () => {
     const engine = new HandleSession();
     engine.loadContent("test");
 
-    engine.execute('(grep "test")');
+    await engine.execute('(grep "test")');
     expect(Object.keys(engine.getBindings()).length).toBeGreaterThan(0);
 
     engine.reset();
     expect(Object.keys(engine.getBindings()).length).toBe(0);
   });
 
-  it("should provide command reference", () => {
+  it("should provide command reference", async () => {
     const ref = HandleSession.getCommandReference();
 
     expect(ref).toContain("grep");
@@ -65,7 +65,7 @@ defmodule Greeter do
 end
 `, "test.ex");
 
-    const result = engine.execute('(list_symbols)');
+    const result = await engine.execute('(list_symbols)');
     expect(result.success).toBe(true);
     expect(result.handle).toBeDefined();
     const expanded = engine.expand(result.handle!);
@@ -75,7 +75,7 @@ end
 });
 
 describe("REPL command patterns", () => {
-  it("should handle typical grep -> count workflow", () => {
+  it("should handle typical grep -> count workflow", async () => {
     const engine = new HandleSession();
     engine.loadContent(`
 [2024-01-15 10:30:00] FATAL: Connection timeout
@@ -86,19 +86,19 @@ describe("REPL command patterns", () => {
     `.trim());
 
     // Step 1: Find all fatal errors
-    const grep = engine.execute('(grep "FATAL")');
+    const grep = await engine.execute('(grep "FATAL")');
     expect(grep.success).toBe(true);
     const expanded = engine.expand(grep.handle!);
     expect(expanded.success).toBe(true);
     expect(expanded.data?.length).toBe(3);
 
     // Step 2: Count
-    const count = engine.execute('(count RESULTS)');
+    const count = await engine.execute('(count RESULTS)');
     expect(count.success).toBe(true);
     expect(count.value).toBe(3);
   });
 
-  it("should handle grep -> sum workflow for numeric data", () => {
+  it("should handle grep -> sum workflow for numeric data", async () => {
     const engine = new HandleSession();
     // Use $ prefix so sum can identify currency values
     engine.loadContent(`
@@ -109,14 +109,14 @@ Sales: $175,000
     `.trim());
 
     // Find sales lines
-    const grep = engine.execute('(grep "Sales")');
+    const grep = await engine.execute('(grep "Sales")');
     expect(grep.success).toBe(true);
     const expanded = engine.expand(grep.handle!);
     expect(expanded.success).toBe(true);
     expect(expanded.data?.length).toBe(4);
 
     // Sum them - sum extracts $ amounts from line content
-    const sum = engine.execute('(sum RESULTS)');
+    const sum = await engine.execute('(sum RESULTS)');
     expect(sum.success).toBe(true);
     expect(sum.value).toBe(550000);
   });

--- a/tests/skip-cwd-checking.test.ts
+++ b/tests/skip-cwd-checking.test.ts
@@ -88,7 +88,7 @@ describe("--dangerously-skip-cwd-checking", () => {
         const tool = new LatticeTool({ skipCwdChecking: true });
         await tool.loadAsync(outsideFile);
 
-        const result = tool.execute({ type: "query", command: '(grep "ERROR")' });
+        const result = await tool.execute({ type: "query", command: '(grep "ERROR")' });
 
         expect(result.success).toBe(true);
         expect(result.message).toContain("Found 1 result");
@@ -207,25 +207,25 @@ describe("--dangerously-skip-cwd-checking", () => {
       "utf-8"
     );
 
-    it("should parse --dangerously-skip-cwd-checking from process.argv", () => {
+    it("should parse --dangerously-skip-cwd-checking from process.argv", async () => {
       expect(serverSource).toContain('process.argv.includes("--dangerously-skip-cwd-checking")');
     });
 
-    it("should wrap CWD check in skipCwdChecking conditional", () => {
+    it("should wrap CWD check in skipCwdChecking conditional", async () => {
       // The path validation block should be inside an if (!skipCwdChecking) guard
       expect(serverSource).toMatch(/if\s*\(\s*!skipCwdChecking\s*\)/);
     });
 
-    it("should still contain the original path-outside-CWD error message", () => {
+    it("should still contain the original path-outside-CWD error message", async () => {
       // The error message should still exist (just conditionally reached)
       expect(serverSource).toContain("Path outside working directory is not allowed");
     });
 
-    it("should still contain the path traversal error message", () => {
+    it("should still contain the path traversal error message", async () => {
       expect(serverSource).toContain("Path traversal (..) is not allowed");
     });
 
-    it("should log a warning when CWD checking is disabled", () => {
+    it("should log a warning when CWD checking is disabled", async () => {
       expect(serverSource).toMatch(/WARNING.*CWD.*checking.*DISABLED|CWD.*path.*checking.*DISABLED/i);
     });
   });

--- a/tests/token-metadata.test.ts
+++ b/tests/token-metadata.test.ts
@@ -36,8 +36,8 @@ describe("Token metadata on results", () => {
       await session.loadFile(testFile);
     });
 
-    it("should include estimatedTokens on array results", () => {
-      const result = session.execute('(grep "LOG")');
+    it("should include estimatedTokens on array results", async () => {
+      const result = await session.execute('(grep "LOG")');
 
       expect(result.success).toBe(true);
       expect(result.tokenMetadata).toBeDefined();
@@ -45,24 +45,24 @@ describe("Token metadata on results", () => {
       expect(result.tokenMetadata!.stubTokens).toBeGreaterThan(0);
     });
 
-    it("should show significant savings ratio for large results", () => {
-      const result = session.execute('(grep "LOG")');
+    it("should show significant savings ratio for large results", async () => {
+      const result = await session.execute('(grep "LOG")');
 
       const meta = result.tokenMetadata!;
       expect(meta.estimatedFullTokens).toBeGreaterThan(meta.stubTokens);
       expect(meta.savingsPercent).toBeGreaterThan(90);
     });
 
-    it("should not include tokenMetadata for scalar results", () => {
-      session.execute('(grep "LOG")');
-      const result = session.execute("(count RESULTS)");
+    it("should not include tokenMetadata for scalar results", async () => {
+      await session.execute('(grep "LOG")');
+      const result = await session.execute("(count RESULTS)");
 
       expect(result.success).toBe(true);
       expect(result.tokenMetadata).toBeUndefined();
     });
 
-    it("should estimate tokens using ~4 chars per token heuristic", () => {
-      const result = session.execute('(grep "LOG")');
+    it("should estimate tokens using ~4 chars per token heuristic", async () => {
+      const result = await session.execute('(grep "LOG")');
 
       const meta = result.tokenMetadata!;
       // Stub is small, full data is much larger
@@ -76,8 +76,8 @@ describe("Token metadata on results", () => {
       await session.loadFile(testFile);
     });
 
-    it("should include token cost on expanded results", () => {
-      const query = session.execute('(grep "LOG")');
+    it("should include token cost on expanded results", async () => {
+      const query = await session.execute('(grep "LOG")');
       const expanded = session.expand(query.handle!, { limit: 10 });
 
       expect(expanded.success).toBe(true);
@@ -86,8 +86,8 @@ describe("Token metadata on results", () => {
       expect(expanded.tokenMetadata!.totalTokens).toBeGreaterThan(0);
     });
 
-    it("should show partial vs total tokens when using limit", () => {
-      const query = session.execute('(grep "LOG")');
+    it("should show partial vs total tokens when using limit", async () => {
+      const query = await session.execute('(grep "LOG")');
       const expanded = session.expand(query.handle!, { limit: 5 });
 
       const meta = expanded.tokenMetadata!;

--- a/tests/tool/lattice-tool.test.ts
+++ b/tests/tool/lattice-tool.test.ts
@@ -7,9 +7,9 @@ import {
 
 describe("LatticeTool", () => {
   describe("loadContent", () => {
-    it("should load content from string", () => {
+    it("should load content from string", async () => {
       const tool = new LatticeTool();
-      const result = tool.execute({
+      const result = await tool.execute({
         type: "loadContent",
         content: "line1\nline2\nline3",
         name: "test-doc",
@@ -20,9 +20,9 @@ describe("LatticeTool", () => {
       expect(result.message).toContain("3 lines");
     });
 
-    it("should use default name for inline document", () => {
+    it("should use default name for inline document", async () => {
       const tool = new LatticeTool();
-      const result = tool.execute({
+      const result = await tool.execute({
         type: "loadContent",
         content: "test data",
       });
@@ -33,30 +33,30 @@ describe("LatticeTool", () => {
   });
 
   describe("query", () => {
-    it("should execute grep command", () => {
+    it("should execute grep command", async () => {
       const tool = new LatticeTool();
-      tool.execute({ type: "loadContent", content: "error line\nok line\nerror again" });
+      await tool.execute({ type: "loadContent", content: "error line\nok line\nerror again" });
 
-      const result = tool.execute({ type: "query", command: '(grep "error")' });
+      const result = await tool.execute({ type: "query", command: '(grep "error")' });
 
       expect(result.success).toBe(true);
       expect(result.message).toContain("Found 2 results");
     });
 
-    it("should return error when no document loaded", () => {
+    it("should return error when no document loaded", async () => {
       const tool = new LatticeTool();
-      const result = tool.execute({ type: "query", command: '(grep "test")' });
+      const result = await tool.execute({ type: "query", command: '(grep "test")' });
 
       expect(result.success).toBe(false);
       expect(result.error).toContain("No document loaded");
     });
 
-    it("should maintain bindings across queries", () => {
+    it("should maintain bindings across queries", async () => {
       const tool = new LatticeTool();
-      tool.execute({ type: "loadContent", content: "a\nb\nc\nd\ne" });
-      tool.execute({ type: "query", command: '(grep "[a-z]")' }); // match all lines
+      await tool.execute({ type: "loadContent", content: "a\nb\nc\nd\ne" });
+      await tool.execute({ type: "query", command: '(grep "[a-z]")' }); // match all lines
 
-      const result = tool.execute({ type: "query", command: "(count RESULTS)" });
+      const result = await tool.execute({ type: "query", command: "(count RESULTS)" });
 
       expect(result.success).toBe(true);
       expect(result.data).toBe(5);
@@ -64,20 +64,20 @@ describe("LatticeTool", () => {
   });
 
   describe("bindings", () => {
-    it("should return current bindings", () => {
+    it("should return current bindings", async () => {
       const tool = new LatticeTool();
-      tool.execute({ type: "loadContent", content: "test" });
-      tool.execute({ type: "query", command: '(grep "test")' });
+      await tool.execute({ type: "loadContent", content: "test" });
+      await tool.execute({ type: "query", command: '(grep "test")' });
 
-      const result = tool.execute({ type: "bindings" });
+      const result = await tool.execute({ type: "bindings" });
 
       expect(result.success).toBe(true);
       expect(result.message).toContain("RESULTS");
     });
 
-    it("should report no bindings when empty", () => {
+    it("should report no bindings when empty", async () => {
       const tool = new LatticeTool();
-      const result = tool.execute({ type: "bindings" });
+      const result = await tool.execute({ type: "bindings" });
 
       expect(result.success).toBe(true);
       expect(result.message).toBe("No bindings");
@@ -85,13 +85,13 @@ describe("LatticeTool", () => {
   });
 
   describe("reset", () => {
-    it("should clear bindings", () => {
+    it("should clear bindings", async () => {
       const tool = new LatticeTool();
-      tool.execute({ type: "loadContent", content: "test" });
-      tool.execute({ type: "query", command: '(grep "test")' });
-      tool.execute({ type: "reset" });
+      await tool.execute({ type: "loadContent", content: "test" });
+      await tool.execute({ type: "query", command: '(grep "test")' });
+      await tool.execute({ type: "reset" });
 
-      const result = tool.execute({ type: "bindings" });
+      const result = await tool.execute({ type: "bindings" });
 
       expect(result.success).toBe(true);
       expect(result.message).toBe("No bindings");
@@ -99,20 +99,20 @@ describe("LatticeTool", () => {
   });
 
   describe("stats", () => {
-    it("should return document statistics", () => {
+    it("should return document statistics", async () => {
       const tool = new LatticeTool();
-      tool.execute({ type: "loadContent", content: "line1\nline2\nline3", name: "stats-test" });
+      await tool.execute({ type: "loadContent", content: "line1\nline2\nline3", name: "stats-test" });
 
-      const result = tool.execute({ type: "stats" });
+      const result = await tool.execute({ type: "stats" });
 
       expect(result.success).toBe(true);
       expect(result.message).toContain("stats-test");
       expect(result.message).toContain("3 lines");
     });
 
-    it("should return error when no document loaded", () => {
+    it("should return error when no document loaded", async () => {
       const tool = new LatticeTool();
-      const result = tool.execute({ type: "stats" });
+      const result = await tool.execute({ type: "stats" });
 
       expect(result.success).toBe(false);
       expect(result.error).toContain("No document loaded");
@@ -120,9 +120,9 @@ describe("LatticeTool", () => {
   });
 
   describe("help", () => {
-    it("should return help text", () => {
+    it("should return help text", async () => {
       const tool = new LatticeTool();
-      const result = tool.execute({ type: "help" });
+      const result = await tool.execute({ type: "help" });
 
       expect(result.success).toBe(true);
       expect(result.message).toContain("grep");
@@ -131,65 +131,65 @@ describe("LatticeTool", () => {
   });
 
   describe("isLoaded", () => {
-    it("should return false initially", () => {
+    it("should return false initially", async () => {
       const tool = new LatticeTool();
       expect(tool.isLoaded()).toBe(false);
     });
 
-    it("should return true after loading", () => {
+    it("should return true after loading", async () => {
       const tool = new LatticeTool();
-      tool.execute({ type: "loadContent", content: "test" });
+      await tool.execute({ type: "loadContent", content: "test" });
       expect(tool.isLoaded()).toBe(true);
     });
   });
 
   describe("getDocumentName", () => {
-    it("should return null initially", () => {
+    it("should return null initially", async () => {
       const tool = new LatticeTool();
       expect(tool.getDocumentName()).toBeNull();
     });
 
-    it("should return document name after loading", () => {
+    it("should return document name after loading", async () => {
       const tool = new LatticeTool();
-      tool.execute({ type: "loadContent", content: "test", name: "my-doc" });
+      await tool.execute({ type: "loadContent", content: "test", name: "my-doc" });
       expect(tool.getDocumentName()).toBe("my-doc");
     });
   });
 });
 
 describe("parseCommand", () => {
-  it("should parse :load command", () => {
+  it("should parse :load command", async () => {
     const cmd = parseCommand(":load ./file.txt");
     expect(cmd).toEqual({ type: "load", filePath: "./file.txt" });
   });
 
-  it("should parse :bindings command", () => {
+  it("should parse :bindings command", async () => {
     expect(parseCommand(":bindings")).toEqual({ type: "bindings" });
     expect(parseCommand(":vars")).toEqual({ type: "bindings" });
   });
 
-  it("should parse :reset command", () => {
+  it("should parse :reset command", async () => {
     expect(parseCommand(":reset")).toEqual({ type: "reset" });
     expect(parseCommand(":clear")).toEqual({ type: "reset" });
   });
 
-  it("should parse :stats command", () => {
+  it("should parse :stats command", async () => {
     expect(parseCommand(":stats")).toEqual({ type: "stats" });
     expect(parseCommand(":info")).toEqual({ type: "stats" });
   });
 
-  it("should parse :help command", () => {
+  it("should parse :help command", async () => {
     expect(parseCommand(":help")).toEqual({ type: "help" });
     expect(parseCommand(":h")).toEqual({ type: "help" });
     expect(parseCommand(":?")).toEqual({ type: "help" });
   });
 
-  it("should parse S-expression queries", () => {
+  it("should parse S-expression queries", async () => {
     const cmd = parseCommand('(grep "error")');
     expect(cmd).toEqual({ type: "query", command: '(grep "error")' });
   });
 
-  it("should return null for invalid commands", () => {
+  it("should return null for invalid commands", async () => {
     expect(parseCommand("")).toBeNull();
     expect(parseCommand("   ")).toBeNull();
     expect(parseCommand("invalid")).toBeNull();
@@ -199,17 +199,17 @@ describe("parseCommand", () => {
 });
 
 describe("formatResponse", () => {
-  it("should format success message", () => {
+  it("should format success message", async () => {
     const output = formatResponse({ success: true, message: "Test message" });
     expect(output).toBe("Test message");
   });
 
-  it("should format error", () => {
+  it("should format error", async () => {
     const output = formatResponse({ success: false, error: "Something failed" });
     expect(output).toBe("Error: Something failed");
   });
 
-  it("should format array results", () => {
+  it("should format array results", async () => {
     const output = formatResponse({
       success: true,
       message: "Found 2 results",
@@ -224,7 +224,7 @@ describe("formatResponse", () => {
     expect(output).toContain("[5]");
   });
 
-  it("should truncate long arrays", () => {
+  it("should truncate long arrays", async () => {
     const items = Array.from({ length: 20 }, (_, i) => ({
       line: `line ${i}`,
       lineNum: i,

--- a/tests/treesitter/integration.test.ts
+++ b/tests/treesitter/integration.test.ts
@@ -69,7 +69,7 @@ end
     it("should auto-index symbols on TypeScript file load", async () => {
       await session.loadContentWithSymbols(sampleTypeScript, "test.ts");
 
-      const result = session.execute('(list_symbols)');
+      const result = await session.execute('(list_symbols)');
       expect(result.success).toBe(true);
       expect(result.handle).toBeDefined();
 
@@ -87,7 +87,7 @@ end
     it("should auto-index symbols on Python file load", async () => {
       await session.loadContentWithSymbols(samplePython, "test.py");
 
-      const result = session.execute('(list_symbols)');
+      const result = await session.execute('(list_symbols)');
       expect(result.success).toBe(true);
 
       const expanded = session.expand(result.handle!);
@@ -100,7 +100,7 @@ end
     it("should auto-index symbols on Elixir file load", async () => {
       await session.loadContentWithSymbols(sampleElixir, "test.ex");
 
-      const result = session.execute('(list_symbols)');
+      const result = await session.execute('(list_symbols)');
       expect(result.success).toBe(true);
 
       const expanded = session.expand(result.handle!);
@@ -116,7 +116,7 @@ end
       await session.loadContentWithSymbols(plainText, "readme.txt");
 
       // list_symbols should return empty array, not fail
-      const result = session.execute('(list_symbols)');
+      const result = await session.execute('(list_symbols)');
       expect(result.success).toBe(true);
 
       // Either handle is empty or returns empty array
@@ -132,7 +132,7 @@ end
     it("should update symbols on document reload", async () => {
       // Load initial content
       await session.loadContentWithSymbols(sampleTypeScript, "test.ts");
-      let result = session.execute('(list_symbols "function")');
+      let result = await session.execute('(list_symbols "function")');
       expect(result.success).toBe(true);
       let expanded = session.expand(result.handle!);
 
@@ -144,7 +144,7 @@ function baz() { return 3; }
 `.trim();
 
       await session.loadContentWithSymbols(newCode, "test.ts");
-      result = session.execute('(list_symbols "function")');
+      result = await session.execute('(list_symbols "function")');
       expect(result.success).toBe(true);
       expanded = session.expand(result.handle!);
 
@@ -163,15 +163,15 @@ function baz() { return 3; }
       await session.loadContentWithSymbols(sampleTypeScript, "test.ts");
     });
 
-    it("should return handle for (list_symbols)", () => {
-      const result = session.execute('(list_symbols)');
+    it("should return handle for (list_symbols)", async () => {
+      const result = await session.execute('(list_symbols)');
       expect(result.success).toBe(true);
       expect(result.handle).toMatch(/^\$res\d+$/);
       expect(result.stub).toBeDefined();
     });
 
-    it("should allow expanding symbol handle", () => {
-      const result = session.execute('(list_symbols "method")');
+    it("should allow expanding symbol handle", async () => {
+      const result = await session.execute('(list_symbols "method")');
       expect(result.success).toBe(true);
 
       const expanded = session.expand(result.handle!, { limit: 2 });
@@ -186,8 +186,8 @@ function baz() { return 3; }
       });
     });
 
-    it("should support get_symbol_body by name", () => {
-      const result = session.execute('(get_symbol_body "hello")');
+    it("should support get_symbol_body by name", async () => {
+      const result = await session.execute('(get_symbol_body "hello")');
       expect(result.success).toBe(true);
 
       const body = result.value as string;
@@ -195,8 +195,8 @@ function baz() { return 3; }
       expect(body).toContain('return "Hello, "');
     });
 
-    it("should support find_references", () => {
-      const result = session.execute('(find_references "hello")');
+    it("should support find_references", async () => {
+      const result = await session.execute('(find_references "hello")');
       expect(result.success).toBe(true);
       expect(result.handle).toBeDefined();
 
@@ -210,8 +210,8 @@ function baz() { return 3; }
       await session.loadContentWithSymbols(sampleElixir, "test.ex");
     });
 
-    it("should return protocol symbols with interface kind", () => {
-      const result = session.execute('(list_symbols "interface")');
+    it("should return protocol symbols with interface kind", async () => {
+      const result = await session.execute('(list_symbols "interface")');
       expect(result.success).toBe(true);
 
       const expanded = session.expand(result.handle!);
@@ -219,8 +219,8 @@ function baz() { return 3; }
       expect(symbols.some(s => s.kind === "interface" && s.name === "String.Chars")).toBe(true);
     });
 
-    it("should support get_symbol_body for Elixir functions", () => {
-      const result = session.execute('(get_symbol_body "hello")');
+    it("should support get_symbol_body for Elixir functions", async () => {
+      const result = await session.execute('(get_symbol_body "hello")');
       expect(result.success).toBe(true);
 
       const body = result.value as string;
@@ -234,20 +234,20 @@ function baz() { return 3; }
       await session.loadContentWithSymbols(sampleTypeScript, "test.ts");
     });
 
-    it("should support counting symbols", () => {
-      const result = session.execute('(count (list_symbols "method"))');
+    it("should support counting symbols", async () => {
+      const result = await session.execute('(count (list_symbols "method"))');
       expect(result.success).toBe(true);
       expect(typeof result.value).toBe("number");
       expect(result.value).toBeGreaterThanOrEqual(2); // greet and farewell
     });
 
-    it("should work with grep alongside symbols", () => {
+    it("should work with grep alongside symbols", async () => {
       // Find all lines with "return"
-      const grepResult = session.execute('(grep "return")');
+      const grepResult = await session.execute('(grep "return")');
       expect(grepResult.success).toBe(true);
 
       // Also list functions
-      const symbolResult = session.execute('(list_symbols "function")');
+      const symbolResult = await session.execute('(list_symbols "function")');
       expect(symbolResult.success).toBe(true);
 
       // Both should work independently
@@ -258,9 +258,9 @@ function baz() { return 3; }
       expect(symbolExpanded.data?.length).toBeGreaterThan(0);
     });
 
-    it("should support mapping symbol names", () => {
+    it("should support mapping symbol names", async () => {
       // List all symbols
-      const listResult = session.execute('(list_symbols)');
+      const listResult = await session.execute('(list_symbols)');
       expect(listResult.success).toBe(true);
 
       // Verify RESULTS contains symbols with name property


### PR DESCRIPTION
## Summary

Implements **GAP 1** from the Zhang/Kraska/Khattab RLM paper (arXiv 2512.24601v2): a user-reachable **symbolic-recursion primitive** in Matryoshka's Lambda Calculus DSL. The LLM can now spawn sub-LLM calls from inside a Nucleus program — both at the top level and inside `map`/`filter`/`reduce` lambdas (the paper's OOLONG pattern).

Before this PR, the solver had no way to invoke a sub-LLM from LC terms at all. After this PR:

```scheme
;; Top-level
(llm_query "Summarize the data: {items}" (items RESULTS))

;; OOLONG pattern — one sub-LLM call per item
(map RESULTS (lambda x (llm_query "classify: {item}" (item x))))

;; Semantic filter predicate
(filter RESULTS (lambda x (match (llm_query "keep?: {item}" (item x)) "keep" 0)))
```

## Approach — TDD in two phases

**Phase 1 — Proof of concept** (commit 6167e4b): added `(llm_query …)` as a top-level-only primitive with a fast-path in `solve()`. Nested use was rejected with a loud error, documented as an intentional POC limitation. This proved the design was worth the full async refactor before taking on the tree-walker rewrite.

**Phase 2 — Full async refactor** (commits a4195dd, 21dd396, 0f6faa0, 1d33d42): made the entire solver async so `(llm_query …)` works in any position the grammar allows.

- **Chunk 1 (a4195dd)** — 5 nested-llm_query tests added as `it.fails(...)` TDD red markers documenting the target state.
- **Chunk 2 (21dd396)** — `solve()` promisified, `await` propagated through 28+ test files and all downstream callers (NucleusEngine, HandleSession, LatticeTool, HTTP/pipe/claude-code adapters).
- **Chunk 4 (0f6faa0)** — `evaluate()` / `evaluateWithBinding()` / `evaluatePredicate()` / `evaluateTransform()` / `evaluateReduceFn()` all async. `evaluate()` gains a `case \"llm_query\":` that dispatches through `tools.llmQuery` in any nested position. All 5 `.fails` tests flipped to positive assertions, green.
- **Chunk 5 (1d33d42, this PR's final cleanup)** — removed the now-duplicate top-level fast-path from `solve()`, dropped the deprecated `solveAsync` alias, refreshed stale doc comments, expanded the nucleus adapter system prompt to teach the nested patterns.

Each chunk left the full suite green. The TDD `.fails` marker guaranteed each subsequent chunk was empirically moving toward the target rather than drifting.

## What the LLM sees

Every turn's feedback now includes a **Bindings available for next turn** section with provenance so `_N` variables are self-documenting across roundtrips. That's the critical bit for keeping the LLM on-track — the variable is the only thing the LLM has to go on after a multi-turn run.

```
Bindings available for next turn:
  _1 ← (grep \"ERROR\") → 54 items
  _2 ← (map _1 (lambda x (llm_query \"classify: {item}\" (item x)))) → 54 strings
  RESULTS → same as _2
```

## Verification

**Full suite**: 192 files, 2908 passed, 3 skipped, **0 failures**.

**Live exercise** — 6 scenarios covered by a scripted end-to-end demo:

| # | Scenario | Result |
|---|----------|--------|
| 1 | Top-level `(llm_query \"prompt\")` | 1 sub-LLM call, PASS |
| 2 | Top-level with `{name}` interpolation from binding | 1 sub-LLM call, prompt contains RESULTS values, PASS |
| 3 | Nested `(map RESULTS (lambda x (llm_query ...)))` — OOLONG | 54 sub-LLM calls (one per log line), PASS |
| 4 | Nested `(filter RESULTS (lambda x (match (llm_query ...) \"keep\" 0)))` | 54 sub-LLM calls, filtered correctly, PASS |
| 5 | NucleusEngine standalone (no `llmClient`) rejects `llm_query` cleanly | error message names `llm_query` as unavailable, PASS |
| 6 | Error propagation — `tools.llmQuery` throws | FSM recovers to final answer, no crash, PASS |

**Timing**: 111 sub-LLM calls across 6 runs in 28ms internal / 668ms wall. Process exits promptly — no dangling timers from the async work.

## Files touched

- **Primitive implementation**: `src/logic/lc-parser.ts`, `src/logic/types.ts`, `src/logic/type-inference.ts`, `src/logic/lc-solver.ts`
- **Async ripple**: `src/engine/nucleus-engine.ts`, `src/engine/handle-session.ts`, `src/tool/lattice-tool.ts`, `src/tool/adapters/http.ts`, `src/tool/adapters/claude-code.ts`, `src/fsm/rlm-states.ts`, `src/rlm.ts`
- **LLM-facing**: `src/adapters/nucleus.ts` (system prompt teaches the primitive, `llm_query` added to `KNOWN_COMMANDS`)
- **Tests**: `tests/logic/llm-query.test.ts` (13 tests — parser, type inference, solver, error paths), `tests/logic/llm-query-nested.test.ts` (5 tests — map/filter/if/chained patterns), plus async-await propagation fixes across ~30 existing test files

## Test plan

- [x] `npx vitest run` — 2908 passed / 0 failed
- [x] 6-scenario live exercise with dual-scripted LLM stub
- [x] `chiasmus_graph` dead-code + cycles pass (all hits false positives — FSM dynamic dispatch + expected mutual recursion in evaluator)
- [x] Process exits promptly (no dangling timers)
- [ ] Real-model smoke test post-merge with an actual LLM client

Paper: *Recursive Language Models*, Zhang/Kraska/Khattab (MIT CSAIL, arXiv 2512.24601v2) — GAP 1.