### PR TITLE
feat: P0-followup + P1 + P2 + P3 paper-vs-project RLM gap closure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matryoshka-rlm",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matryoshka-rlm",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matryoshka-rlm",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "type": "module",
   "description": "Recursive Language Model - Process documents larger than LLM context windows",
   "main": "dist/lib.js",

--- a/src/adapters/nucleus.ts
+++ b/src/adapters/nucleus.ts
@@ -31,6 +31,13 @@ SEARCH:
 (grep "pattern")              → matching lines w/ line numbers
 (lines START END)             → get line range (1-indexed)
 
+CHUNK (slice document before mapping over it — for too-large docs):
+(chunk_by_size N)             → N-char slices
+(chunk_by_lines N)            → N-line slices
+(chunk_by_regex "pat")        → slices split on regex (e.g. "\\n\\n")
+  — feed to (map … (lambda c (llm_query "summarize: {chunk}" (chunk c))))
+    to fire a sub-LLM per chunk of a document too big for the root window
+
 TRANSFORM:
 (filter RESULTS (lambda x (match x "pat" 0)))
 (map RESULTS (lambda x (match x "pat" 1)))
@@ -215,7 +222,7 @@ function extractCode(response: string): string | null {
 
   // Check for plain S-expression in raw text
   // Find opening paren and balance to closing
-  const KNOWN_COMMANDS = ["grep", "filter", "map", "reduce", "count", "sum", "lines", "fuzzy_search", "bm25", "semantic", "fuse", "dampen", "rerank", "text_stats", "match", "replace", "split", "parseInt", "parseFloat", "parseDate", "parseCurrency", "parseNumber", "coerce", "extract", "synthesize", "lambda", "if", "classify", "predicate", "define-fn", "apply-fn", "list_symbols", "get_symbol_body", "find_references", "callers", "callees", "ancestors", "descendants", "implementations", "dependents", "symbol_graph", "llm_query"];
+  const KNOWN_COMMANDS = ["grep", "filter", "map", "reduce", "count", "sum", "lines", "fuzzy_search", "bm25", "semantic", "fuse", "dampen", "rerank", "text_stats", "match", "replace", "split", "parseInt", "parseFloat", "parseDate", "parseCurrency", "parseNumber", "coerce", "extract", "synthesize", "lambda", "if", "classify", "predicate", "define-fn", "apply-fn", "list_symbols", "get_symbol_body", "find_references", "callers", "callees", "ancestors", "descendants", "implementations", "dependents", "symbol_graph", "llm_query", "chunk_by_size", "chunk_by_lines", "chunk_by_regex"];
 
   const MAX_SEXP_ITERATIONS = 200;
   let sexpIterations = 0;

--- a/src/adapters/nucleus.ts
+++ b/src/adapters/nucleus.ts
@@ -60,6 +60,10 @@ CODE (when analyzing code):
 MULTI-LINE: grep keyword → get lineNum → (lines N M)
 QUERY MAP: count→count, total/sum→sum, list→grep+FINAL
 ANSWER: <<<FINAL>>>answer<<<END>>>
+  — for large answers, use FINAL_VAR(name) to reference a binding:
+    <<<FINAL>>>FINAL_VAR(_2)<<<END>>>      — substitutes _2's full value
+    <<<FINAL>>>The matches: FINAL_VAR(RESULTS)<<<END>>>
+  — use this when inlining a large result would blow the context window
 
 ${hints?.hintsText || ""}${hints?.selfCorrectionText || ""}`;
 }

--- a/src/engine/handle-session.ts
+++ b/src/engine/handle-session.ts
@@ -106,6 +106,20 @@ export interface ExpandResult {
 export interface HandleSessionOptions {
   /** Enable verbose logging on the underlying NucleusEngine */
   verbose?: boolean;
+  /**
+   * Optional sub-LLM bridge for the `(llm_query ...)` primitive.
+   *
+   * When present, the HandleSession forwards this callback to its
+   * underlying `NucleusEngine`, enabling every `(llm_query ...)` term
+   * (top-level and nested) to delegate to the caller-provided model.
+   *
+   * The primary consumer is `lattice-mcp-server.ts`, which wraps
+   * `server.createMessage(...)` so that lattice_query's `(llm_query ...)`
+   * calls are routed back to the MCP client's LLM via the standard
+   * MCP `sampling/createMessage` protocol. When omitted, `(llm_query ...)`
+   * throws a clear "not available" error.
+   */
+  llmQuery?: (prompt: string) => Promise<string>;
 }
 
 export class HandleSession {
@@ -145,7 +159,10 @@ export class HandleSession {
   }
 
   constructor(options: HandleSessionOptions = {}) {
-    this.engine = new NucleusEngine({ verbose: options.verbose });
+    this.engine = new NucleusEngine({
+      verbose: options.verbose,
+      llmQuery: options.llmQuery,
+    });
     this.db = new SessionDB();
     this.registry = new HandleRegistry(this.db);
     this.ops = new HandleOps(this.db, this.registry);

--- a/src/engine/nucleus-engine.ts
+++ b/src/engine/nucleus-engine.ts
@@ -32,12 +32,34 @@ export interface ExecutionResult {
 export interface NucleusEngineOptions {
   /** Enable verbose logging */
   verbose?: boolean;
+  /**
+   * Optional sub-LLM bridge for the `(llm_query ...)` primitive.
+   *
+   * When present, the engine threads this callback through to `createSolverTools`
+   * every time a document is loaded, so the solver can dispatch `(llm_query ...)`
+   * terms through it. The main consumer is the MCP sampling bridge in
+   * `lattice-mcp-server.ts`, which wraps `server.createMessage(...)` so that
+   * sub-LLM calls are routed back to the MCP client's model.
+   *
+   * When omitted, `(llm_query ...)` throws a clear "not available" error.
+   */
+  llmQuery?: (prompt: string) => Promise<string>;
 }
 
 /**
  * Create SolverTools from document content
+ *
+ * @param context - Document content to expose via grep/fuzzy/bm25/etc.
+ * @param llmQuery - Optional sub-LLM bridge for the `(llm_query ...)` primitive.
+ *   When passed through (e.g. by the MCP sampling bridge in lattice-mcp-server),
+ *   the solver dispatches every `(llm_query ...)` term through this callback,
+ *   both top-level and nested inside map/filter/reduce lambdas. When omitted,
+ *   `(llm_query ...)` throws a clear "not available" error from the solver.
  */
-function createSolverTools(context: string): SolverTools {
+function createSolverTools(
+  context: string,
+  llmQuery?: (prompt: string) => Promise<string>
+): SolverTools {
   const lines = context.split("\n");
 
   // Build newline offset index for O(log N) line-number lookup from byte offset
@@ -190,6 +212,10 @@ function createSolverTools(context: string): SolverTools {
     })(),
 
     text_stats: () => ({ ...textStats }),
+
+    // Symbolic-recursion hook — only present if the caller threaded one in
+    // (e.g. the MCP sampling bridge). Omitted means `(llm_query ...)` throws.
+    llmQuery,
   };
 }
 
@@ -215,9 +241,11 @@ export class NucleusEngine {
   private solverTools: SolverTools | null = null;
   private verbose: boolean;
   private turnCounter: number = 0;
+  private llmQuery?: (prompt: string) => Promise<string>;
 
   constructor(options: NucleusEngineOptions = {}) {
     this.verbose = options.verbose ?? false;
+    this.llmQuery = options.llmQuery;
   }
 
   /**
@@ -234,7 +262,7 @@ export class NucleusEngine {
   loadContent(content: string): void {
     const trimmed = content.trim();
     this.context = trimmed.length > 0 ? content : "";
-    this.solverTools = trimmed.length > 0 ? createSolverTools(content) : null;
+    this.solverTools = trimmed.length > 0 ? createSolverTools(content, this.llmQuery) : null;
     this.bindings.clear();
     this.turnCounter = 0;
 

--- a/src/fsm/rlm-states.ts
+++ b/src/fsm/rlm-states.ts
@@ -97,6 +97,69 @@ function truncate(s: string, max: number = 4000): string {
   return s.slice(0, half) + `\n... [${s.length - max} chars truncated] ...\n` + s.slice(-half);
 }
 
+/**
+ * Expand `FINAL_VAR(name)` markers in a final-answer string by looking up
+ * `name` in the solver bindings and substituting in the serialized value.
+ *
+ * This lets the LLM close the loop without inlining a large binding into
+ * its <<<FINAL>>> payload:
+ *
+ *   <<<FINAL>>>FINAL_VAR(_2)<<<END>>>
+ *   <<<FINAL>>>Here are the results: FINAL_VAR(RESULTS) — done<<<END>>>
+ *
+ * Design choices:
+ *   - Unknown bindings are left in place. Silent stripping would hide a
+ *     real mistake (references to a binding that never existed); leaving
+ *     the marker makes the error obvious to the user without crashing.
+ *   - Arrays / objects are JSON.stringified; strings pass through
+ *     unchanged; numbers and booleans are coerced via String().
+ *   - Each expansion is capped at MAX_FINAL_VAR_EXPANSION bytes to
+ *     protect downstream consumers from pathological payloads. A cap
+ *     here is safer than removing it — the whole point of the feature
+ *     is to let the LLM reference large data, but "large" should not
+ *     mean unbounded.
+ *   - The regex only accepts identifier-shaped names, rejecting weird
+ *     cases like `FINAL_VAR(../../etc/passwd)` before they hit the
+ *     binding lookup.
+ */
+const FINAL_VAR_REGEX = /FINAL_VAR\(([A-Za-z_]\w*)\)/g;
+const MAX_FINAL_VAR_EXPANSION = 500_000;
+
+function expandFinalVar(answer: string, bindings: Bindings): string {
+  // Fast-path: no marker → return original string untouched, avoiding
+  // a regex allocation on the hot path where every final answer flows
+  // through this helper.
+  if (!answer.includes("FINAL_VAR(")) return answer;
+
+  return answer.replace(FINAL_VAR_REGEX, (match, name: string) => {
+    if (!bindings.has(name)) {
+      // Unknown binding: pass through so the error is visible.
+      return match;
+    }
+    const value = bindings.get(name);
+    let serialized: string;
+    if (typeof value === "string") {
+      serialized = value;
+    } else if (value === null || value === undefined) {
+      serialized = String(value);
+    } else if (typeof value === "number" || typeof value === "boolean") {
+      serialized = String(value);
+    } else {
+      try {
+        serialized = JSON.stringify(value, null, 2);
+      } catch {
+        serialized = String(value);
+      }
+    }
+    if (serialized.length > MAX_FINAL_VAR_EXPANSION) {
+      serialized =
+        serialized.slice(0, MAX_FINAL_VAR_EXPANSION) +
+        `\n…[truncated ${serialized.length - MAX_FINAL_VAR_EXPANSION} chars]`;
+    }
+    return serialized;
+  });
+}
+
 interface VerificationResult {
   valid: boolean;
   result: string;
@@ -527,8 +590,12 @@ function handleAnalyze(ctx: RLMContext): RLMContext {
 function handleCheckFinalAnswer(ctx: RLMContext): RLMContext {
   // After code execution: check for final answer in the same response
   if (ctx.solverResult && !ctx.solverResult.error && !ctx.lastOutputWasUnhelpful && !Array.isArray(ctx.solverResult.value)) {
-    const finalAnswer = ctx.adapter.extractFinalAnswer(ctx.response);
-    if (finalAnswer !== null) {
+    const rawAnswer = ctx.adapter.extractFinalAnswer(ctx.response);
+    if (rawAnswer !== null) {
+      // Expand any FINAL_VAR(name) markers against the live solver bindings.
+      // Lets the LLM close the loop by pointing at a handle rather than
+      // inlining a potentially huge value into the final answer string.
+      const finalAnswer = expandFinalVar(rawAnswer, ctx.solverBindings);
       ctx.log(`[Turn ${ctx.turn}] Final answer found after code execution`);
       const verification = verifyAndReturnResult(finalAnswer, ctx.constraint, ctx.log);
       if (verification.valid) {
@@ -560,8 +627,8 @@ function handleCheckFinalAnswer(ctx: RLMContext): RLMContext {
       return ctx;
     }
 
-    const finalAnswer = ctx.adapter.extractFinalAnswer(ctx.response);
-    if (finalAnswer !== null) {
+    const rawAnswer = ctx.adapter.extractFinalAnswer(ctx.response);
+    if (rawAnswer !== null) {
       if (!ctx.codeExecuted) {
         ctx.log(`[Turn ${ctx.turn}] Rejecting final answer - no code executed yet`);
         ctx.history.push({
@@ -576,6 +643,8 @@ function handleCheckFinalAnswer(ctx: RLMContext): RLMContext {
         return ctx;
       }
 
+      // Expand FINAL_VAR(name) markers — see rationale in the first branch.
+      const finalAnswer = expandFinalVar(rawAnswer, ctx.solverBindings);
       ctx.log(`[Turn ${ctx.turn}] Final answer received`);
       const verification = verifyAndReturnResult(finalAnswer, ctx.constraint, ctx.log);
       if (verification.valid) {

--- a/src/lattice-mcp-server.ts
+++ b/src/lattice-mcp-server.ts
@@ -35,11 +35,14 @@ import { HandleSession } from "./engine/handle-session.js";
 import { getVersion } from "./version.js";
 import { hasTraversalSegment } from "./utils/path-safety.js";
 
-// Sub-LLM bridge — populated in main() once the server has connected and we
-// know whether the client supports `sampling/createMessage`. When set, every
-// new HandleSession created by lattice_load / lattice_memo will receive this
-// callback and `(llm_query ...)` inside a lattice_query will be routed back
-// to the MCP client's LLM via the standard sampling protocol.
+// Sub-LLM bridge — installed in main() before `server.connect()` so that the
+// first HandleSession (which may be created before the MCP initialize
+// handshake completes) still gets it. The bridge itself is lazy: every call
+// re-reads `server.getClientCapabilities()` at invocation time. If the
+// client didn't advertise `sampling`, the bridge throws a clear error that
+// propagates up through the solver's llm_query path. If it did, the call
+// is forwarded to `server.createMessage(...)` and the sub-LLM response is
+// returned as a plain string.
 let samplingBridge: ((prompt: string) => Promise<string>) | null = null;
 
 // Default cap for sub-LLM responses. The MCP sampling protocol requires a
@@ -777,34 +780,49 @@ async function main() {
   });
 
   const transport = new StdioServerTransport();
+  // Install the sampling bridge BEFORE awaiting `server.connect()`.
+  //
+  // Subtle race: `server.connect(transport)` returns after the transport
+  // handshake, but `_clientCapabilities` is populated only when the
+  // server's `_oninitialize()` handler runs in response to the client's
+  // first `initialize` request — which happens *after* connect() returns,
+  // on a subsequent event-loop tick. So reading `getClientCapabilities()`
+  // synchronously after `connect()` always returns undefined (the bridge
+  // never gets installed under that design). The lazy-check pattern here
+  // sidesteps that race entirely: we always install the bridge, and each
+  // call re-reads capabilities at invocation time. By the time the first
+  // tool call arrives the client has already initialized, so the lazy
+  // check sees the right capabilities.
+  samplingBridge = async (prompt: string): Promise<string> => {
+    const caps = server.getClientCapabilities();
+    if (!caps?.sampling) {
+      throw new Error(
+        "llm_query is not available: the connected MCP client did not " +
+        "advertise `sampling` capability. Clients that support sampling " +
+        "(e.g. Claude Desktop, Claude Code) will route the sub-LLM call " +
+        "back to their own model; other clients must pre-compute the " +
+        "result or disable the primitive."
+      );
+    }
+    const result = await server.createMessage({
+      messages: [{ role: "user", content: { type: "text", text: prompt } }],
+      maxTokens: SAMPLING_MAX_TOKENS,
+      // `none` keeps the sub-LLM isolated from the parent conversation —
+      // the paper's sub-RLM model spins up a fresh context per sub-call.
+      includeContext: "none",
+    });
+    // CreateMessageResult.content is a single block for the no-tools path.
+    if (result.content?.type === "text") {
+      return result.content.text;
+    }
+    // Image / audio content blocks are not useful for string interpolation;
+    // return a visible placeholder so the solver doesn't crash.
+    return `[sub-LLM returned non-text content: ${result.content?.type ?? "unknown"}]`;
+  };
+
   await server.connect(transport);
 
-  // Wire the sampling bridge once the client has completed the handshake.
-  // Only install it if the client advertised `sampling` support — otherwise
-  // `(llm_query ...)` inside lattice_query should fail loudly rather than
-  // hitting a protocol error when we call server.createMessage.
-  const clientCaps = server.getClientCapabilities();
-  if (clientCaps?.sampling) {
-    samplingBridge = async (prompt: string): Promise<string> => {
-      const result = await server.createMessage({
-        messages: [{ role: "user", content: { type: "text", text: prompt } }],
-        maxTokens: SAMPLING_MAX_TOKENS,
-        // `none` keeps the sub-LLM isolated from the parent conversation —
-        // the paper's sub-RLM model spins up a fresh context per sub-call.
-        includeContext: "none",
-      });
-      // CreateMessageResult.content is a single block for the no-tools path.
-      if (result.content?.type === "text") {
-        return result.content.text;
-      }
-      // Image / audio content blocks are not useful for string interpolation;
-      // return a visible placeholder so the solver doesn't crash.
-      return `[sub-LLM returned non-text content: ${result.content?.type ?? "unknown"}]`;
-    };
-    console.error("[Lattice] Sampling bridge enabled — (llm_query ...) will delegate to client LLM");
-  } else {
-    console.error("[Lattice] Client did not advertise sampling support — (llm_query ...) will be unavailable");
-  }
+  console.error("[Lattice] Sampling bridge installed — (llm_query ...) will route via MCP sampling when client supports it");
 
   console.error("[Lattice] MCP server started (handle-based mode)");
   console.error(`[Lattice] Session timeout: ${SESSION_TIMEOUT_MS / 1000}s`);

--- a/src/lattice-mcp-server.ts
+++ b/src/lattice-mcp-server.ts
@@ -35,6 +35,18 @@ import { HandleSession } from "./engine/handle-session.js";
 import { getVersion } from "./version.js";
 import { hasTraversalSegment } from "./utils/path-safety.js";
 
+// Sub-LLM bridge — populated in main() once the server has connected and we
+// know whether the client supports `sampling/createMessage`. When set, every
+// new HandleSession created by lattice_load / lattice_memo will receive this
+// callback and `(llm_query ...)` inside a lattice_query will be routed back
+// to the MCP client's LLM via the standard sampling protocol.
+let samplingBridge: ((prompt: string) => Promise<string>) | null = null;
+
+// Default cap for sub-LLM responses. The MCP sampling protocol requires a
+// maxTokens value; we keep it modest so sub-LLM calls stay cheap and the
+// paper's OOLONG pattern remains affordable at scale.
+const SAMPLING_MAX_TOKENS = 1024;
+
 // Configuration — timeout is configurable via env var for long sessions
 const SESSION_TIMEOUT_MS = parseInt(process.env.LATTICE_TIMEOUT_MS || "") || 10 * 60 * 1000;
 const MAX_DOCUMENT_SIZE = 50 * 1024 * 1024; // 50MB limit
@@ -513,7 +525,12 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
         } else {
           // Create new session — use temp variable so `session` isn't
           // left pointing at a half-initialised object if loadFile throws.
-          const newSession = new HandleSession();
+          // Thread the sampling bridge through so `(llm_query ...)` inside
+          // lattice_query can delegate to the MCP client's LLM when the
+          // client advertises sampling support.
+          const newSession = new HandleSession({
+            llmQuery: samplingBridge ?? undefined,
+          });
           try {
             stats = await newSession.loadFile(filePath);
           } catch (loadErr) {
@@ -651,9 +668,12 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
           return { content: [{ type: "text", text: "Error: label is required" }] };
         }
 
-        // Auto-create session if none exists (memos don't require a loaded document)
+        // Auto-create session if none exists (memos don't require a loaded document).
+        // Thread sampling bridge so memos-first sessions still get llm_query support.
         if (!session) {
-          session = new HandleSession();
+          session = new HandleSession({
+            llmQuery: samplingBridge ?? undefined,
+          });
           console.error("[Lattice] Auto-created session for memo storage");
         }
 
@@ -758,6 +778,33 @@ async function main() {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
+
+  // Wire the sampling bridge once the client has completed the handshake.
+  // Only install it if the client advertised `sampling` support — otherwise
+  // `(llm_query ...)` inside lattice_query should fail loudly rather than
+  // hitting a protocol error when we call server.createMessage.
+  const clientCaps = server.getClientCapabilities();
+  if (clientCaps?.sampling) {
+    samplingBridge = async (prompt: string): Promise<string> => {
+      const result = await server.createMessage({
+        messages: [{ role: "user", content: { type: "text", text: prompt } }],
+        maxTokens: SAMPLING_MAX_TOKENS,
+        // `none` keeps the sub-LLM isolated from the parent conversation —
+        // the paper's sub-RLM model spins up a fresh context per sub-call.
+        includeContext: "none",
+      });
+      // CreateMessageResult.content is a single block for the no-tools path.
+      if (result.content?.type === "text") {
+        return result.content.text;
+      }
+      // Image / audio content blocks are not useful for string interpolation;
+      // return a visible placeholder so the solver doesn't crash.
+      return `[sub-LLM returned non-text content: ${result.content?.type ?? "unknown"}]`;
+    };
+    console.error("[Lattice] Sampling bridge enabled — (llm_query ...) will delegate to client LLM");
+  } else {
+    console.error("[Lattice] Client did not advertise sampling support — (llm_query ...) will be unavailable");
+  }
 
   console.error("[Lattice] MCP server started (handle-based mode)");
   console.error(`[Lattice] Session timeout: ${SESSION_TIMEOUT_MS / 1000}s`);

--- a/src/logic/constraint-resolver.ts
+++ b/src/logic/constraint-resolver.ts
@@ -127,6 +127,9 @@ export function resolveConstraints(term: LCTerm): ResolvedTerm {
       case "synthesize":
       case "define-fn":
       case "lines":
+      case "chunk_by_size":
+      case "chunk_by_lines":
+      case "chunk_by_regex":
       case "fuzzy_search":
       case "text_stats":
       case "find_references":

--- a/src/logic/lc-parser.ts
+++ b/src/logic/lc-parser.ts
@@ -543,6 +543,30 @@ function parseList(state: ParserState, depth: number = 0): LCTerm | null {
       return { tag: "lines", start: startTerm.value, end: endTerm.value };
     }
 
+    case "chunk_by_size": {
+      const sizeTerm = parseTerm(state, d);
+      if (!sizeTerm || sizeTerm.tag !== "lit" || typeof sizeTerm.value !== "number") {
+        return null;
+      }
+      return { tag: "chunk_by_size", size: sizeTerm.value };
+    }
+
+    case "chunk_by_lines": {
+      const nTerm = parseTerm(state, d);
+      if (!nTerm || nTerm.tag !== "lit" || typeof nTerm.value !== "number") {
+        return null;
+      }
+      return { tag: "chunk_by_lines", lineCount: nTerm.value };
+    }
+
+    case "chunk_by_regex": {
+      const patTerm = parseTerm(state, d);
+      if (!patTerm || patTerm.tag !== "lit" || typeof patTerm.value !== "string") {
+        return null;
+      }
+      return { tag: "chunk_by_regex", pattern: patTerm.value };
+    }
+
     case "filter": {
       const collection = parseTerm(state, d);
       if (!collection) return null;
@@ -1094,6 +1118,12 @@ export function prettyPrint(term: LCTerm): string {
       return "(text_stats)";
     case "lines":
       return `(lines ${term.start} ${term.end})`;
+    case "chunk_by_size":
+      return `(chunk_by_size ${term.size})`;
+    case "chunk_by_lines":
+      return `(chunk_by_lines ${term.lineCount})`;
+    case "chunk_by_regex":
+      return `(chunk_by_regex "${escapeForPrint(term.pattern)}")`;
     case "filter":
       return `(filter ${prettyPrint(term.collection)} ${prettyPrint(term.predicate)})`;
     case "map":

--- a/src/logic/lc-solver.ts
+++ b/src/logic/lc-solver.ts
@@ -403,28 +403,62 @@ async function evaluate(
       // produced by adjacent delimiters are dropped — the paper's OOLONG
       // pattern wants "substantive" chunks to feed to sub-LLMs, not empty
       // strings between `\n\n\n\n` sequences.
+      //
+      // We deliberately DO NOT use `String.prototype.split(regex)` here:
+      // when the user's pattern contains capturing groups, `split`
+      // interleaves the captured text into the output array, producing
+      // surprising chunks that include delimiter characters. Instead we
+      // manually walk matches via matchAll() and extract the text
+      // between them, which treats captures as a no-op.
       const pat = term.pattern;
       if (typeof pat !== "string" || pat.length === 0) {
         throw new Error("chunk_by_regex: pattern must be a non-empty string");
       }
-      // Route through the shared regex validator so a bad pattern errors
-      // cleanly rather than throwing from deep inside String.prototype.split.
       const validation = validateRegex(pat);
       if (!validation.valid) {
         throw new Error(`chunk_by_regex: invalid pattern "${pat}" — ${validation.error}`);
       }
-      const regex = new RegExp(pat);
+      // Force the global flag so matchAll() can iterate all matches.
+      // new RegExp(pat, "g") is safe even when the user's pattern
+      // already implies global — JS accepts duplicate-meaning flags
+      // via the string form as long as each character appears once.
+      const regex = new RegExp(pat, "g");
       const ctx = tools.context;
       if (ctx.length === 0) return [];
       const MAX_CHUNKS = 100_000;
-      const rawChunks = ctx.split(regex);
+
       const chunks: string[] = [];
-      for (const c of rawChunks) {
-        if (c.length > 0) chunks.push(c);
+      let cursor = 0;
+      let matches = 0;
+      // Cap match iteration independently so a pathological regex that
+      // matches millions of zero-width positions (which would be blocked
+      // by the infinite-loop guard below anyway) doesn't burn CPU
+      // building an intermediate array via [...matchAll()].
+      const MAX_MATCH_ITERATIONS = MAX_CHUNKS + 1;
+      for (const m of ctx.matchAll(regex)) {
+        if (matches++ >= MAX_MATCH_ITERATIONS) break;
+        const start = m.index ?? cursor;
+        // Slice content between the previous match end and this match.
+        if (start > cursor) {
+          chunks.push(ctx.slice(cursor, start));
+        }
+        // Advance past this match. Zero-width matches would loop
+        // forever otherwise, so we force forward progress by at least
+        // one char.
+        const matchLen = m[0].length;
+        cursor = start + (matchLen === 0 ? 1 : matchLen);
         if (chunks.length >= MAX_CHUNKS) break;
       }
-      log(`[Solver] chunk_by_regex(/${pat}/): produced ${chunks.length} chunks from ${rawChunks.length} raw pieces`);
-      return chunks;
+      // Trailing content after the last match.
+      if (cursor < ctx.length && chunks.length < MAX_CHUNKS) {
+        chunks.push(ctx.slice(cursor));
+      }
+
+      // Drop empty chunks from adjacent delimiters (e.g. "\n\n\n\n"
+      // matched by "\n\n" yields one empty middle piece).
+      const nonEmpty = chunks.filter((c) => c.length > 0);
+      log(`[Solver] chunk_by_regex(/${pat}/): produced ${nonEmpty.length} chunks from ${matches} matches`);
+      return nonEmpty;
     }
 
     // ==========================

--- a/src/logic/lc-solver.ts
+++ b/src/logic/lc-solver.ts
@@ -355,6 +355,78 @@ async function evaluate(
       return selectedLines;
     }
 
+    case "chunk_by_size": {
+      // Split the document context into fixed-size character chunks. The
+      // last chunk may be shorter than `size`. The primary use-case is
+      // feeding each chunk into a per-chunk sub-LLM call via a map lambda.
+      const size = term.size;
+      if (!Number.isFinite(size) || size <= 0) {
+        throw new Error(`chunk_by_size: size must be a positive finite number, got ${size}`);
+      }
+      const intSize = Math.floor(size);
+      // Cap at MAX_CHUNKS to prevent an adversarial `(chunk_by_size 1)` over
+      // a 10MB document from producing a 10M-element array that blows up
+      // downstream handle storage. This is large enough that real use-cases
+      // (2KB chunks of a 50MB file = 25_000 chunks) stay well under it.
+      const MAX_CHUNKS = 100_000;
+      const ctx = tools.context;
+      if (ctx.length === 0) return [];
+      const chunks: string[] = [];
+      for (let i = 0; i < ctx.length && chunks.length < MAX_CHUNKS; i += intSize) {
+        chunks.push(ctx.slice(i, i + intSize));
+      }
+      log(`[Solver] chunk_by_size(${intSize}): produced ${chunks.length} chunks`);
+      return chunks;
+    }
+
+    case "chunk_by_lines": {
+      // Split the document into N-line chunks. Trailing remainder (<N lines)
+      // becomes its own chunk.
+      const n = term.lineCount;
+      if (!Number.isFinite(n) || n <= 0) {
+        throw new Error(`chunk_by_lines: lineCount must be a positive finite number, got ${n}`);
+      }
+      const intN = Math.floor(n);
+      const MAX_CHUNKS = 100_000;
+      const allLines = tools.lines;
+      if (allLines.length === 0) return [];
+      const chunks: string[] = [];
+      for (let i = 0; i < allLines.length && chunks.length < MAX_CHUNKS; i += intN) {
+        chunks.push(allLines.slice(i, i + intN).join("\n"));
+      }
+      log(`[Solver] chunk_by_lines(${intN}): produced ${chunks.length} chunks`);
+      return chunks;
+    }
+
+    case "chunk_by_regex": {
+      // Split the document wherever `pattern` matches. Empty chunks
+      // produced by adjacent delimiters are dropped — the paper's OOLONG
+      // pattern wants "substantive" chunks to feed to sub-LLMs, not empty
+      // strings between `\n\n\n\n` sequences.
+      const pat = term.pattern;
+      if (typeof pat !== "string" || pat.length === 0) {
+        throw new Error("chunk_by_regex: pattern must be a non-empty string");
+      }
+      // Route through the shared regex validator so a bad pattern errors
+      // cleanly rather than throwing from deep inside String.prototype.split.
+      const validation = validateRegex(pat);
+      if (!validation.valid) {
+        throw new Error(`chunk_by_regex: invalid pattern "${pat}" — ${validation.error}`);
+      }
+      const regex = new RegExp(pat);
+      const ctx = tools.context;
+      if (ctx.length === 0) return [];
+      const MAX_CHUNKS = 100_000;
+      const rawChunks = ctx.split(regex);
+      const chunks: string[] = [];
+      for (const c of rawChunks) {
+        if (c.length > 0) chunks.push(c);
+        if (chunks.length >= MAX_CHUNKS) break;
+      }
+      log(`[Solver] chunk_by_regex(/${pat}/): produced ${chunks.length} chunks from ${rawChunks.length} raw pieces`);
+      return chunks;
+    }
+
     // ==========================
     // PURE OPERATIONS - Use miniKanren for filtering/classification
     // ==========================

--- a/src/logic/lc-solver.ts
+++ b/src/logic/lc-solver.ts
@@ -1087,8 +1087,10 @@ async function evaluate(
       if (!tools.llmQuery) {
         throw new Error(
           "llm_query is not available in this execution context. " +
-          "The RLM loop provides it; direct NucleusEngine / lattice-mcp " +
-          "sessions do not."
+          "The RLM loop provides it via the caller's llmClient, and " +
+          "lattice-mcp provides it when the MCP client advertises " +
+          "`sampling` capability. Standalone NucleusEngine / HandleSession " +
+          "instances must pass an llmQuery option to enable it."
         );
       }
       let interpolated = term.prompt;

--- a/src/logic/type-inference.ts
+++ b/src/logic/type-inference.ts
@@ -197,6 +197,12 @@ function infer(term: LCTerm, env: TypeEnv): LCType {
       // lines returns array of strings
       return { tag: "array", element: { tag: "string" } };
 
+    case "chunk_by_size":
+    case "chunk_by_lines":
+    case "chunk_by_regex":
+      // All three chunking primitives return array<string>.
+      return { tag: "array", element: { tag: "string" } };
+
     case "sum":
       return { tag: "number" };
 

--- a/src/logic/types.ts
+++ b/src/logic/types.ts
@@ -63,7 +63,10 @@ export type LCTerm =
   | LCImplementations
   | LCDependents
   | LCSymbolGraph
-  | LCLLMQuery;
+  | LCLLMQuery
+  | LCChunkBySize
+  | LCChunkByLines
+  | LCChunkByRegex;
 
 /**
  * (input) - reference to the current input string
@@ -162,6 +165,40 @@ export interface LCLines {
   tag: "lines";
   start: number;
   end: number;
+}
+
+/**
+ * (chunk_by_size N) - split the document context into chunks of N characters.
+ * Returns an array of string slices, the last of which may be shorter than N.
+ * Primary use: `(map (chunk_by_size 2000) (lambda c (llm_query ...)))` to
+ * fire a sub-LLM call per chunk of a document too big for the root window.
+ */
+export interface LCChunkBySize {
+  tag: "chunk_by_size";
+  size: number;
+}
+
+/**
+ * (chunk_by_lines N) - split the document context into chunks of N lines.
+ * Returns an array of newline-joined slices. Trailing remainder (less than
+ * N lines) becomes its own chunk. Primary use: chunk a log file / code file
+ * into N-line slices before mapping per-chunk semantic work over them.
+ */
+export interface LCChunkByLines {
+  tag: "chunk_by_lines";
+  lineCount: number;
+}
+
+/**
+ * (chunk_by_regex "pattern") - split the document context wherever `pattern`
+ * matches. Returns an array of string slices with empty chunks dropped (so
+ * adjacent delimiters don't produce `""` entries). Primary use: split on
+ * paragraph breaks (`\n\n`), section headers, or explicit delimiters. The
+ * pattern is validated via `validateRegex` before splitting.
+ */
+export interface LCChunkByRegex {
+  tag: "chunk_by_regex";
+  pattern: string;
 }
 
 /**

--- a/src/rlm.ts
+++ b/src/rlm.ts
@@ -471,7 +471,9 @@ export async function runRLMFromContent(
   // llmQuery code path falls back to the flat `llmClient(framedPrompt)`
   // call built inside `createSolverTools`, terminating the recursion
   // with a single round-trip.
-  const subRLMSpawner = llmClient && _subRLMDepth < effectiveMaxDepth
+  // `llmClient` is a required field on RLMOptions so we don't need a
+  // null-check here — the depth guard alone decides whether to recurse.
+  const subRLMSpawner = _subRLMDepth < effectiveMaxDepth
     ? async (interpolatedPrompt: string): Promise<string> => {
         const childMaxTurns = Math.max(1, Math.floor(maxTurns / 2));
         const childDepth = _subRLMDepth + 1;
@@ -501,7 +503,17 @@ export async function runRLMFromContent(
             _subRLMDepth: childDepth,
           }
         );
-        return typeof childResult === "string" ? childResult : JSON.stringify(childResult);
+        // runRLMFromContent normally returns a string (the final answer
+        // or a "Max turns reached" message), but the signature is
+        // Promise<unknown>, so be defensive about non-string values and
+        // the possibility of JSON.stringify throwing on circular refs.
+        if (typeof childResult === "string") return childResult;
+        if (childResult === null || childResult === undefined) return "";
+        try {
+          return JSON.stringify(childResult);
+        } catch {
+          return String(childResult);
+        }
       }
     : undefined;
 

--- a/src/rlm.ts
+++ b/src/rlm.ts
@@ -23,10 +23,22 @@ import { buildRLMSpec, createInitialContext, type RLMContext } from "./fsm/rlm-s
 /**
  * Create SolverTools from document content
  * These are the same tools the sandbox provides, but standalone for the solver
+ *
+ * @param context - Document content
+ * @param llmClient - Optional flat LLM entry point for the sub-LLM hook.
+ *   Used for the default (depth=0) fast path where llm_query delegates
+ *   to one round-trip through the parent's llmClient.
+ * @param subRLMSpawner - Optional recursive sub-RLM spawner. When present,
+ *   llm_query routes to this callback instead of the flat llmClient,
+ *   allowing sub-calls to run their own FSM loops with their own
+ *   Nucleus code execution. The spawner receives the already-interpolated
+ *   prompt and is responsible for depth tracking, maxTurns scaling, and
+ *   returning a string result. See `runRLM`'s sub-RLM wiring below.
  */
 function createSolverTools(
   context: string,
-  llmClient?: LLMQueryFn
+  llmClient?: LLMQueryFn,
+  subRLMSpawner?: (prompt: string) => Promise<string>
 ): SolverTools {
   const MAX_SOLVER_LINES = 500_000;
   let lines = context.split("\n");
@@ -165,26 +177,36 @@ function createSolverTools(
 
     text_stats: () => ({ ...textStats }),
 
-    // Optional symbolic-recursion hook — threaded through only when
-    // the caller (runRLM) provides an llmClient. Other consumers that
-    // build a solver tools instance without an llmClient get undefined
-    // here, and `(llm_query …)` at solve time throws a clear error.
+    // Symbolic-recursion hook. Three modes, in priority order:
     //
-    // The sub-LLM is invoked with a standalone prompt that prefixes a
-    // brief role-setting sentence so it doesn't try to act like a root
-    // RLM (which would emit S-expressions, <<<FINAL>>> tags, etc.).
-    llmQuery: llmClient
-      ? async (subPrompt: string) => {
-          const framedPrompt =
-            "You are a sub-LLM invoked by a parent RLM run. Answer the " +
-            "prompt concisely and directly. Do not emit control tags " +
-            "like <<<FINAL>>> or S-expressions — your caller uses your " +
-            "response as a plain string.\n\n" +
-            subPrompt;
-          const response = await llmClient(framedPrompt);
-          return String(response ?? "");
-        }
-      : undefined,
+    //   1. subRLMSpawner given (P3 sub-RLM recursion) — routes the
+    //      interpolated prompt through a full sub-RLM with its own FSM
+    //      loop, Nucleus code execution, and depth tracking. The
+    //      spawner is responsible for enforcing the depth cap; past
+    //      the cap it should fall back to mode 2 internally.
+    //
+    //   2. llmClient given, no spawner (legacy flat sub-LLM) — one
+    //      round-trip through the parent's llmClient with a role-framing
+    //      prefix telling the model to answer as plain text. This is the
+    //      pre-P3 behavior and stays the default when subRLMMaxDepth=0.
+    //
+    //   3. Neither given (standalone NucleusEngine / lattice-mcp without
+    //      a sampling bridge) — undefined, so the solver's llm_query
+    //      case throws a clear "not available" error.
+    llmQuery: subRLMSpawner
+      ? subRLMSpawner
+      : llmClient
+        ? async (subPrompt: string) => {
+            const framedPrompt =
+              "You are a sub-LLM invoked by a parent RLM run. Answer the " +
+              "prompt concisely and directly. Do not emit control tags " +
+              "like <<<FINAL>>> or S-expressions — your caller uses your " +
+              "response as a plain string.\n\n" +
+              subPrompt;
+            const response = await llmClient(framedPrompt);
+            return String(response ?? "");
+          }
+        : undefined,
   };
 }
 
@@ -291,16 +313,73 @@ export interface RLMOptions {
   ragEnabled?: boolean;
   /** Session ID for tracking failures (default: auto-generated) */
   sessionId?: string;
+  /**
+   * Maximum recursive depth for `(llm_query …)` sub-RLM spawning
+   * (P3 in the paper-vs-project gap list — the paper's "symbolic
+   * recursion" feature). Default 0, which preserves the pre-P3 flat
+   * sub-LLM behavior: every `(llm_query …)` call dispatches exactly
+   * one round-trip through `llmClient`. When set to N ≥ 1, each
+   * `(llm_query …)` invocation spawns a sub-RLM whose document is
+   * the interpolated prompt and whose FSM loop can itself run
+   * Nucleus code (grep, chunking, even further sub-RLMs) up to
+   * depth N. Past depth N, sub-RLMs fall back to flat calls so
+   * recursion can't run away. Sub-RLMs inherit the parent's
+   * llmClient and adapter and halve the parent's maxTurns.
+   */
+  subRLMMaxDepth?: number;
+  /**
+   * Internal — current sub-RLM depth. Automatically incremented by
+   * the sub-RLM spawner each time a `(llm_query …)` call recurses.
+   * Never set this manually from user code; it's a private parameter
+   * threaded through the recursive invocation chain.
+   */
+  _subRLMDepth?: number;
 }
+
+/**
+ * Default maximum sub-RLM recursion depth cap, enforced independent
+ * of whatever the caller passes as `subRLMMaxDepth`. Paper Alg. 1 in
+ * principle allows unbounded recursion; in practice a hard cap keeps
+ * pathological programs from infinitely recursing and exhausting
+ * resources. Tuned conservatively — raise in CLAUDE.md if needed.
+ */
+const ABSOLUTE_MAX_SUB_RLM_DEPTH = 5;
 
 // verifyAndReturnResult has moved to fsm/rlm-states.ts
 
 /**
- * Run the RLM execution loop
+ * Run the RLM execution loop against a file on disk.
+ *
+ * Thin wrapper — reads the file and delegates to `runRLMFromContent`,
+ * which contains the actual loop and is reused by the sub-RLM spawner
+ * when `subRLMMaxDepth > 0`.
  */
 export async function runRLM(
   query: string,
   filePath: string,
+  options: RLMOptions
+): Promise<unknown> {
+  let documentContent: string;
+  try {
+    documentContent = await readFile(filePath, "utf-8");
+  } catch (err) {
+    const error = err as Error;
+    return `Error loading file: ${error.message}`;
+  }
+  return runRLMFromContent(query, documentContent, options);
+}
+
+/**
+ * Run the RLM execution loop against in-memory document content.
+ *
+ * Exported as a public entry point — called directly by tests and by
+ * the P3 sub-RLM spawner (which builds a sub-RLM over the interpolated
+ * prompt rather than a file). Behaviorally identical to `runRLM` except
+ * for the file-read step.
+ */
+export async function runRLMFromContent(
+  query: string,
+  documentContent: string,
   options: RLMOptions
 ): Promise<unknown> {
   const {
@@ -311,6 +390,8 @@ export async function runRLM(
     constraint,
     ragEnabled = true,
     sessionId: rawSessionId = `session-${Date.now()}`,
+    subRLMMaxDepth = 0,
+    _subRLMDepth = 0,
   } = options;
 
   // Validate sessionId
@@ -321,6 +402,15 @@ export async function runRLM(
 
   // Validate numeric config parameters
   const maxTurns = Number.isFinite(rawMaxTurns) && rawMaxTurns >= 1 ? Math.floor(rawMaxTurns) : 10;
+
+  // Clamp subRLMMaxDepth to the hard cap.
+  const effectiveMaxDepth = Math.max(
+    0,
+    Math.min(
+      Number.isFinite(subRLMMaxDepth) ? Math.floor(subRLMMaxDepth) : 0,
+      ABSOLUTE_MAX_SUB_RLM_DEPTH
+    )
+  );
 
   const log = (msg: string) => {
     if (verbose) console.log(msg);
@@ -353,16 +443,7 @@ export async function runRLM(
     }
   }
 
-  // Load document
-  let documentContent: string;
-  try {
-    documentContent = await readFile(filePath, "utf-8");
-  } catch (err) {
-    const error = err as Error;
-    return `Error loading file: ${error.message}`;
-  }
-
-  log(`\n[RLM] Loaded document: ${documentContent.length.toLocaleString()} characters`);
+  log(`\n[RLM] Loaded document: ${documentContent.length.toLocaleString()} characters (depth=${_subRLMDepth})`);
 
   // Build system prompt using the adapter (with RAG hints if enabled)
   const registry = createToolRegistry();
@@ -380,10 +461,54 @@ export async function runRLM(
     log(`  4. If synthesis fails, LLM gets feedback and refines constraints`);
   }
 
+  // Build the sub-RLM spawner for P3 symbolic recursion.
+  //
+  // When the current depth is still below the configured max, each
+  // `(llm_query …)` call spawns a full sub-RLM whose document is the
+  // interpolated prompt. The sub-RLM runs its own FSM loop with half
+  // the parent's turn budget and increments the depth counter. When
+  // the depth is at or above max, the spawner is undefined — the
+  // llmQuery code path falls back to the flat `llmClient(framedPrompt)`
+  // call built inside `createSolverTools`, terminating the recursion
+  // with a single round-trip.
+  const subRLMSpawner = llmClient && _subRLMDepth < effectiveMaxDepth
+    ? async (interpolatedPrompt: string): Promise<string> => {
+        const childMaxTurns = Math.max(1, Math.floor(maxTurns / 2));
+        const childDepth = _subRLMDepth + 1;
+        log(`[RLM] Spawning sub-RLM (depth ${childDepth}/${effectiveMaxDepth}) with ${interpolatedPrompt.length} chars of input`);
+        // The sub-RLM's "query" is fixed framing text; the "document"
+        // is the interpolated prompt, so the sub-RLM can grep/chunk/map
+        // over the parent's payload without the parent having to
+        // pre-process it.
+        const childQuery =
+          "Analyze and answer based on the following input: " +
+          interpolatedPrompt.slice(0, 500) +
+          (interpolatedPrompt.length > 500 ? "…" : "");
+        const childResult = await runRLMFromContent(
+          childQuery,
+          interpolatedPrompt,
+          {
+            llmClient,
+            adapter,
+            maxTurns: childMaxTurns,
+            verbose,
+            // Sub-RLMs skip RAG — hint retrieval on every nested call
+            // would be expensive and the hints are tuned for top-level
+            // queries, not recursive payloads.
+            ragEnabled: false,
+            sessionId: `${sessionId}-sub${childDepth}`,
+            subRLMMaxDepth: effectiveMaxDepth,
+            _subRLMDepth: childDepth,
+          }
+        );
+        return typeof childResult === "string" ? childResult : JSON.stringify(childResult);
+      }
+    : undefined;
+
   // Create solver tools for document operations. Passing llmClient here
-  // enables the `(llm_query …)` LC primitive — the symbolic-recursion
-  // entry point used by solve() when the FSM's handleExecute dispatches.
-  const solverTools = createSolverTools(documentContent, llmClient);
+  // enables the `(llm_query …)` LC primitive; passing subRLMSpawner
+  // upgrades it from flat to recursive.
+  const solverTools = createSolverTools(documentContent, llmClient, subRLMSpawner);
 
   // Build user message with optional constraints
   let userMessage = `Query: ${query}`;

--- a/tests/engine/handle-session.test.ts
+++ b/tests/engine/handle-session.test.ts
@@ -453,3 +453,65 @@ describe("HandleSession - Token Savings", () => {
     tsSession.close();
   });
 });
+
+describe("HandleSession — llmQuery option (MCP sampling bridge)", () => {
+  // The lattice-mcp-server wraps `server.createMessage(...)` into an
+  // llmQuery callback and passes it to HandleSession so `(llm_query ...)`
+  // inside a lattice_query can delegate back to the MCP client's LLM.
+  // These tests prove the option is threaded through to the underlying
+  // NucleusEngine / solver.
+
+  it("dispatches (llm_query ...) to the constructor-supplied callback", async () => {
+    const seen: string[] = [];
+    const session = new HandleSession({
+      llmQuery: async (prompt: string) => {
+        seen.push(prompt);
+        return "MCP-SAMPLED RESPONSE";
+      },
+    });
+    session.loadContent("hello world");
+    try {
+      const result = await session.execute('(llm_query "What is this?")');
+      expect(result.success).toBe(true);
+      expect(result.value).toBe("MCP-SAMPLED RESPONSE");
+      expect(seen).toEqual(["What is this?"]);
+    } finally {
+      session.close();
+    }
+  });
+
+  it("without llmQuery, (llm_query ...) errors cleanly", async () => {
+    const session = new HandleSession();
+    session.loadContent("hello world");
+    try {
+      const result = await session.execute('(llm_query "should fail")');
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/llm_query is not available/i);
+    } finally {
+      session.close();
+    }
+  });
+
+  it("supports nested llm_query inside map on a handle result", async () => {
+    const calls: string[] = [];
+    const session = new HandleSession({
+      llmQuery: async (prompt: string) => {
+        calls.push(prompt);
+        return `class-${calls.length}`;
+      },
+    });
+    session.loadContent("ERROR alpha\nERROR beta\nERROR gamma\nINFO ok");
+    try {
+      await session.execute('(grep "ERROR")');
+      const result = await session.execute(
+        '(map RESULTS (lambda x (llm_query "tag: {item}" (item x))))'
+      );
+      expect(result.success).toBe(true);
+      // Map result is an array handle
+      expect(result.handle).toMatch(/^\$res\d+$/);
+      expect(calls).toHaveLength(3);
+    } finally {
+      session.close();
+    }
+  });
+});

--- a/tests/engine/nucleus-engine.test.ts
+++ b/tests/engine/nucleus-engine.test.ts
@@ -427,3 +427,95 @@ describe("dispose", () => {
     expect(engine.getStats()).toBeNull();
   });
 });
+
+describe("llmQuery option — symbolic recursion hook (P0-followup for MCP sampling)", () => {
+  // These tests prove the llmQuery option is threaded through from
+  // NucleusEngine's constructor into the solver's SolverTools. The MCP
+  // sampling bridge in lattice-mcp-server.ts relies on this plumbing —
+  // it passes a `server.createMessage(...)` wrapper as the llmQuery
+  // callback when the client advertises `sampling` capability.
+
+  it("dispatches (llm_query ...) through the constructor-supplied callback", async () => {
+    const seen: string[] = [];
+    const engine = new NucleusEngine({
+      llmQuery: async (prompt: string) => {
+        seen.push(prompt);
+        return "MOCKED SUB-LLM RESPONSE";
+      },
+    });
+    engine.loadContent("hello world\ngoodbye world");
+
+    const result = await engine.execute('(llm_query "What is this document?")');
+
+    expect(result.success).toBe(true);
+    expect(result.value).toBe("MOCKED SUB-LLM RESPONSE");
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toBe("What is this document?");
+  });
+
+  it("interpolates bindings into the sub-LLM prompt", async () => {
+    let seenPrompt = "";
+    const engine = new NucleusEngine({
+      llmQuery: async (prompt: string) => {
+        seenPrompt = prompt;
+        return "classification: error";
+      },
+    });
+    engine.loadContent("ERROR: boom\nERROR: crash\nINFO: ok");
+
+    await engine.execute('(grep "ERROR")');
+    const result = await engine.execute(
+      '(llm_query "Classify these: {items}" (items RESULTS))'
+    );
+
+    expect(result.success).toBe(true);
+    expect(seenPrompt).toContain("Classify these:");
+    expect(seenPrompt).toContain("ERROR: boom");
+    expect(seenPrompt).toContain("ERROR: crash");
+    expect(seenPrompt).not.toContain("{items}");
+  });
+
+  it("supports nested llm_query inside map (OOLONG pattern)", async () => {
+    const calls: string[] = [];
+    const engine = new NucleusEngine({
+      llmQuery: async (prompt: string) => {
+        calls.push(prompt);
+        return `classified-${calls.length}`;
+      },
+    });
+    engine.loadContent("ERROR: one\nERROR: two\nERROR: three");
+
+    await engine.execute('(grep "ERROR")');
+    const result = await engine.execute(
+      '(map RESULTS (lambda x (llm_query "classify: {item}" (item x))))'
+    );
+
+    expect(result.success).toBe(true);
+    expect(Array.isArray(result.value)).toBe(true);
+    expect((result.value as string[]).length).toBe(3);
+    expect(calls).toHaveLength(3);
+  });
+
+  it("reloading with loadContent preserves the llmQuery binding", async () => {
+    let called = 0;
+    const engine = new NucleusEngine({
+      llmQuery: async () => {
+        called++;
+        return "ok";
+      },
+    });
+    engine.loadContent("first");
+    await engine.execute('(llm_query "ping")');
+    engine.loadContent("second");
+    await engine.execute('(llm_query "ping")');
+    expect(called).toBe(2);
+  });
+
+  it("without llmQuery option, (llm_query ...) errors cleanly", async () => {
+    const engine = new NucleusEngine();
+    engine.loadContent("some content");
+    const result = await engine.execute('(llm_query "should fail")');
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/llm_query is not available/i);
+  });
+});

--- a/tests/fsm/rlm-states.test.ts
+++ b/tests/fsm/rlm-states.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { FSMEngine } from "../../src/fsm/engine.js";
 import { buildRLMSpec, createInitialContext, type RLMContext } from "../../src/fsm/rlm-states.js";
 import type { ModelAdapter } from "../../src/adapters/types.js";
@@ -9,8 +9,11 @@ function makeMockAdapter(overrides?: Partial<ModelAdapter>): ModelAdapter {
     name: "mock",
     buildSystemPrompt: () => "system prompt",
     extractCode: (response: string) => {
-      // Extract S-expression from response
-      const match = response.match(/\([\s\S]+\)/);
+      // Strip any FINAL markers first so we don't accidentally match the
+      // `(name)` inside a `FINAL_VAR(name)` payload. The real nucleus
+      // adapter does the equivalent via its KNOWN_COMMANDS allowlist.
+      const stripped = response.replace(/<<<FINAL>>>[\s\S]*?<<<END>>>/g, "");
+      const match = stripped.match(/\([\s\S]+\)/);
       return match ? match[0] : null;
     },
     extractFinalAnswer: (response: string) => {
@@ -226,6 +229,165 @@ describe("RLM FSM States", () => {
       const result = await engine.run(buildRLMSpec(), ctx);
       expect(result.result).toContain("data: 1");
       expect(result.turn).toBe(3); // rejected first, ran code second, accepted third
+    });
+  });
+
+  describe("FINAL_VAR(name) handle deref", () => {
+    // The FINAL_VAR primitive lets the LLM end the loop without inlining
+    // a large binding into its <<<FINAL>>> payload. Instead of:
+    //   <<<FINAL>>>[{line: "...", lineNum: 1}, ...thousand more items]<<<END>>>
+    // it can emit:
+    //   <<<FINAL>>>FINAL_VAR(_1)<<<END>>>
+    // and the FSM resolves `_1` from `ctx.solverBindings` at the final-answer
+    // boundary. This is critical for the paper's "unbounded output tokens"
+    // claim — without it, very large final answers die at the root LLM's
+    // context boundary.
+
+    it("resolves FINAL_VAR(_N) against a prior binding", async () => {
+      // Three ERROR lines → _1 is an array of three grep hits.
+      // The LLM ends with FINAL_VAR(_1) which should expand to the array.
+      const document = "ERROR: disk full\nINFO: ok\nERROR: timeout\nERROR: 500";
+      let turnNum = 0;
+      const llmResponses = [
+        '(grep "ERROR")',
+        "<<<FINAL>>>FINAL_VAR(_1)<<<END>>>",
+      ];
+
+      const ctx = createInitialContext({
+        query: "List the errors",
+        adapter: makeMockAdapter(),
+        llmClient: async () => llmResponses[turnNum++] || "",
+        solverTools: makeMockTools(document),
+        systemPrompt: "system",
+        userMessage: "Query: list errors",
+        maxTurns: 5,
+        sessionId: "test",
+        log: () => {},
+      });
+
+      const engine = new FSMEngine<RLMContext>();
+      const result = await engine.run(buildRLMSpec(), ctx);
+      expect(result.result).not.toBeNull();
+      // The expanded answer should contain evidence of all 3 ERROR lines
+      expect(result.result).toContain("disk full");
+      expect(result.result).toContain("timeout");
+      expect(result.result).toContain("500");
+      // And the literal marker should be gone
+      expect(result.result).not.toContain("FINAL_VAR(_1)");
+    });
+
+    it("resolves FINAL_VAR(RESULTS) to the RESULTS binding", async () => {
+      const document = "alpha 1\nbeta 2\ngamma 3";
+      let turnNum = 0;
+      const llmResponses = [
+        '(grep "alpha")',
+        "<<<FINAL>>>FINAL_VAR(RESULTS)<<<END>>>",
+      ];
+
+      const ctx = createInitialContext({
+        query: "What did grep find?",
+        adapter: makeMockAdapter(),
+        llmClient: async () => llmResponses[turnNum++] || "",
+        solverTools: makeMockTools(document),
+        systemPrompt: "system",
+        userMessage: "Query: grep",
+        maxTurns: 5,
+        sessionId: "test",
+        log: () => {},
+      });
+
+      const engine = new FSMEngine<RLMContext>();
+      const result = await engine.run(buildRLMSpec(), ctx);
+      expect(result.result).toContain("alpha 1");
+      expect(result.result).not.toContain("FINAL_VAR(RESULTS)");
+    });
+
+    it("allows framing text around FINAL_VAR(name)", async () => {
+      // The LLM can wrap the marker with its own framing, e.g. "Here is the
+      // list: FINAL_VAR(_1) — done". The FSM should substitute in place.
+      const document = "foo\nbar\nbaz";
+      let turnNum = 0;
+      const llmResponses = [
+        '(grep "ba")',
+        "<<<FINAL>>>Here are the matches: FINAL_VAR(_1) — done.<<<END>>>",
+      ];
+
+      const ctx = createInitialContext({
+        query: "Find 'ba'",
+        adapter: makeMockAdapter(),
+        llmClient: async () => llmResponses[turnNum++] || "",
+        solverTools: makeMockTools(document),
+        systemPrompt: "system",
+        userMessage: "Query: find",
+        maxTurns: 5,
+        sessionId: "test",
+        log: () => {},
+      });
+
+      const engine = new FSMEngine<RLMContext>();
+      const result = await engine.run(buildRLMSpec(), ctx);
+      expect(result.result).toContain("Here are the matches:");
+      expect(result.result).toContain("— done.");
+      expect(result.result).toContain("bar");
+      expect(result.result).toContain("baz");
+      expect(result.result).not.toContain("FINAL_VAR(_1)");
+    });
+
+    it("leaves FINAL_VAR(unknown) pass-through when name is not bound", async () => {
+      // Defensive: if the LLM references a binding that doesn't exist,
+      // don't crash — leave the marker in place so the user sees the
+      // mistake. The alternative (silent stripping) hides errors.
+      const document = "foo";
+      let turnNum = 0;
+      const llmResponses = [
+        '(grep "foo")',
+        "<<<FINAL>>>Result: FINAL_VAR(_99)<<<END>>>",
+      ];
+
+      const ctx = createInitialContext({
+        query: "Find foo",
+        adapter: makeMockAdapter(),
+        llmClient: async () => llmResponses[turnNum++] || "",
+        solverTools: makeMockTools(document),
+        systemPrompt: "system",
+        userMessage: "Query: find",
+        maxTurns: 5,
+        sessionId: "test",
+        log: () => {},
+      });
+
+      const engine = new FSMEngine<RLMContext>();
+      const result = await engine.run(buildRLMSpec(), ctx);
+      expect(result.result).not.toBeNull();
+      // Unknown binding stays visible so the error is obvious.
+      expect(result.result).toContain("FINAL_VAR(_99)");
+    });
+
+    it("resolves FINAL_VAR(_N) even when it's the only thing in the final answer", async () => {
+      // Edge case: answer is literally "FINAL_VAR(_1)" with no framing.
+      // Regex replace should still work.
+      const document = "x=42";
+      let turnNum = 0;
+      const llmResponses = [
+        '(grep "x=")',
+        "<<<FINAL>>>FINAL_VAR(_1)<<<END>>>",
+      ];
+
+      const ctx = createInitialContext({
+        query: "Extract value",
+        adapter: makeMockAdapter(),
+        llmClient: async () => llmResponses[turnNum++] || "",
+        solverTools: makeMockTools(document),
+        systemPrompt: "system",
+        userMessage: "Query: extract",
+        maxTurns: 5,
+        sessionId: "test",
+        log: () => {},
+      });
+
+      const engine = new FSMEngine<RLMContext>();
+      const result = await engine.run(buildRLMSpec(), ctx);
+      expect(result.result).toContain("x=42");
     });
   });
 });

--- a/tests/logic/chunking.test.ts
+++ b/tests/logic/chunking.test.ts
@@ -219,6 +219,29 @@ describe("chunk_by_regex solver", () => {
     const result = await solve(parsed.term!, tools, new Map());
     expect(result.success).toBe(false);
   });
+
+  it("does not interleave capture groups into the output", async () => {
+    // JavaScript's String.prototype.split(regex) has a subtle behavior:
+    // any capturing group in the pattern is interleaved into the result
+    // array. For chunking, that means a pattern like `(\n)` would
+    // produce odd chunks containing the matched delimiter. We want the
+    // delimiter dropped — chunks should be only the content between
+    // matches, matching the user's intuition.
+    const tools = makeTools("alpha\nbeta\ngamma");
+    const parsed = parse('(chunk_by_regex "(\\n)")');
+    const result = await solve(parsed.term!, tools, new Map());
+    expect(result.success).toBe(true);
+    // Should be exactly ["alpha", "beta", "gamma"] — no newline captures.
+    expect(result.value).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("drops captured delimiters even with alternation", async () => {
+    const tools = makeTools("one;two|three;four");
+    const parsed = parse('(chunk_by_regex "(;|\\\\|)")');
+    const result = await solve(parsed.term!, tools, new Map());
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual(["one", "two", "three", "four"]);
+  });
 });
 
 describe("chunking composition — map over chunks", () => {

--- a/tests/logic/chunking.test.ts
+++ b/tests/logic/chunking.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Tests for the chunking primitives:
+ *
+ *   (chunk_by_size N)   — split the document into chunks of N characters
+ *   (chunk_by_lines N)  — split the document into chunks of N lines
+ *   (chunk_by_regex "pat") — split the document wherever `pat` matches
+ *
+ * These are the "slice a huge binding before mapping over it" primitives
+ * from the paper-vs-project GAP P2. The canonical use-case is:
+ *
+ *   (map (chunk_by_lines 100)
+ *        (lambda c (llm_query "summarize: {chunk}" (chunk c))))
+ *
+ * which chunks a large document into 100-line slices and fires a sub-LLM
+ * at each slice — the classic OOLONG-Pairs pattern for multi-document
+ * summarization applied to a single document that's too big for the
+ * context window.
+ *
+ * Coverage:
+ *   1. Parser accepts each form and rejects malformed shapes.
+ *   2. Type inference returns `array<string>` for each.
+ *   3. Solver produces the expected chunks on a known input.
+ *   4. Edge cases: N=0, N>length, empty regex, overlap, trailing remainder.
+ *   5. End-to-end composition: chunk → map → lambda.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parse } from "../../src/logic/lc-parser.js";
+import { inferType, typeToString } from "../../src/logic/type-inference.js";
+import { solve, type SolverTools, type Bindings } from "../../src/logic/lc-solver.js";
+
+function makeTools(content: string): SolverTools {
+  const lines = content.split("\n");
+  return {
+    context: content,
+    lines,
+    grep: () => [],
+    fuzzy_search: () => [],
+    bm25: () => [],
+    semantic: () => [],
+    text_stats: () => ({
+      length: content.length,
+      lineCount: lines.length,
+      sample: { start: "", middle: "", end: "" },
+    }),
+  };
+}
+
+describe("chunk_by_size parser", () => {
+  it("parses (chunk_by_size N)", () => {
+    const r = parse("(chunk_by_size 100)");
+    expect(r.success).toBe(true);
+    expect(r.term?.tag).toBe("chunk_by_size");
+    if (r.term?.tag === "chunk_by_size") {
+      expect(r.term.size).toBe(100);
+    }
+  });
+
+  it("rejects (chunk_by_size) with no argument", () => {
+    const r = parse("(chunk_by_size)");
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects (chunk_by_size \"foo\") with non-numeric size", () => {
+    const r = parse('(chunk_by_size "foo")');
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("chunk_by_lines parser", () => {
+  it("parses (chunk_by_lines N)", () => {
+    const r = parse("(chunk_by_lines 50)");
+    expect(r.success).toBe(true);
+    expect(r.term?.tag).toBe("chunk_by_lines");
+    if (r.term?.tag === "chunk_by_lines") {
+      expect(r.term.lineCount).toBe(50);
+    }
+  });
+
+  it("rejects (chunk_by_lines) with no argument", () => {
+    const r = parse("(chunk_by_lines)");
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("chunk_by_regex parser", () => {
+  it('parses (chunk_by_regex "pattern")', () => {
+    const r = parse('(chunk_by_regex "\\n\\n")');
+    expect(r.success).toBe(true);
+    expect(r.term?.tag).toBe("chunk_by_regex");
+    if (r.term?.tag === "chunk_by_regex") {
+      expect(r.term.pattern).toBe("\n\n");
+    }
+  });
+
+  it("rejects (chunk_by_regex 42) with non-string argument", () => {
+    const r = parse("(chunk_by_regex 42)");
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects (chunk_by_regex) with no argument", () => {
+    const r = parse("(chunk_by_regex)");
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("chunking type inference", () => {
+  it("chunk_by_size infers array<string>", () => {
+    const r = parse("(chunk_by_size 100)");
+    const t = inferType(r.term!);
+    expect(t.valid).toBe(true);
+    expect(t.type && typeToString(t.type)).toBe("string[]");
+  });
+
+  it("chunk_by_lines infers array<string>", () => {
+    const r = parse("(chunk_by_lines 10)");
+    const t = inferType(r.term!);
+    expect(t.valid).toBe(true);
+    expect(t.type && typeToString(t.type)).toBe("string[]");
+  });
+
+  it("chunk_by_regex infers array<string>", () => {
+    const r = parse('(chunk_by_regex "\\n")');
+    const t = inferType(r.term!);
+    expect(t.valid).toBe(true);
+    expect(t.type && typeToString(t.type)).toBe("string[]");
+  });
+});
+
+describe("chunk_by_size solver", () => {
+  it("splits document into fixed-size chunks", async () => {
+    const tools = makeTools("abcdefghij"); // 10 chars
+    const parsed = parse("(chunk_by_size 3)");
+    const result = await solve(parsed.term!, tools, new Map());
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual(["abc", "def", "ghi", "j"]);
+  });
+
+  it("handles size larger than document length", async () => {
+    const tools = makeTools("short");
+    const parsed = parse("(chunk_by_size 1000)");
+    const result = await solve(parsed.term!, tools, new Map());
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual(["short"]);
+  });
+
+  it("rejects zero or negative size", async () => {
+    const tools = makeTools("abc");
+    const parsed = parse("(chunk_by_size 0)");
+    const result = await solve(parsed.term!, tools, new Map());
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/size/i);
+  });
+
+  it("returns empty array for empty document", async () => {
+    const tools = makeTools("");
+    const parsed = parse("(chunk_by_size 10)");
+    const result = await solve(parsed.term!, tools, new Map());
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual([]);
+  });
+});
+
+describe("chunk_by_lines solver", () => {
+  it("splits document into line-based chunks", async () => {
+    const tools = makeTools("line1\nline2\nline3\nline4\nline5");
+    const parsed = parse("(chunk_by_lines 2)");
+    const result = await solve(parsed.term!, tools, new Map());
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual(["line1\nline2", "line3\nline4", "line5"]);
+  });
+
+  it("handles lineCount larger than document", async () => {
+    const tools = makeTools("just\ntwo");
+    const parsed = parse("(chunk_by_lines 100)");
+    const result = await solve(parsed.term!, tools, new Map());
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual(["just\ntwo"]);
+  });
+
+  it("rejects zero lineCount", async () => {
+    const tools = makeTools("a\nb");
+    const parsed = parse("(chunk_by_lines 0)");
+    const result = await solve(parsed.term!, tools, new Map());
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("chunk_by_regex solver", () => {
+  it("splits on blank lines", async () => {
+    const tools = makeTools("para one\nline two\n\npara two\nline\n\npara three");
+    const parsed = parse('(chunk_by_regex "\\n\\n")');
+    const result = await solve(parsed.term!, tools, new Map());
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual(["para one\nline two", "para two\nline", "para three"]);
+  });
+
+  it("returns the whole document as one chunk if pattern does not match", async () => {
+    const tools = makeTools("one\ntwo\nthree");
+    const parsed = parse('(chunk_by_regex "XXXX")');
+    const result = await solve(parsed.term!, tools, new Map());
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual(["one\ntwo\nthree"]);
+  });
+
+  it("filters empty chunks produced by adjacent delimiters", async () => {
+    const tools = makeTools("a\n\n\n\nb");
+    const parsed = parse('(chunk_by_regex "\\n\\n")');
+    const result = await solve(parsed.term!, tools, new Map());
+    expect(result.success).toBe(true);
+    // Adjacent \n\n pairs produce an empty middle chunk — we drop empties.
+    expect(result.value).toEqual(["a", "b"]);
+  });
+
+  it("rejects a pattern that fails regex validation", async () => {
+    const tools = makeTools("abc");
+    // Unbalanced group — should be caught by validateRegex
+    const parsed = parse('(chunk_by_regex "(unbalanced")');
+    const result = await solve(parsed.term!, tools, new Map());
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("chunking composition — map over chunks", () => {
+  it("(map (chunk_by_lines N) (lambda c ...)) works with nested llm_query", async () => {
+    // The canonical OOLONG pattern at document-chunk granularity:
+    // chunk document into 2-line slices, fire sub-LLM per chunk.
+    const calls: string[] = [];
+    const tools: SolverTools = {
+      ...makeTools("A1\nA2\nB1\nB2\nC1"),
+      llmQuery: async (prompt: string) => {
+        calls.push(prompt);
+        return `summary-${calls.length}`;
+      },
+    };
+    const parsed = parse(
+      '(map (chunk_by_lines 2) (lambda c (llm_query "summarize: {chunk}" (chunk c))))'
+    );
+    expect(parsed.success).toBe(true);
+    const result = await solve(parsed.term!, tools, new Map());
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual(["summary-1", "summary-2", "summary-3"]);
+    expect(calls).toHaveLength(3);
+    expect(calls[0]).toContain("A1\nA2");
+    expect(calls[1]).toContain("B1\nB2");
+    expect(calls[2]).toContain("C1");
+  });
+
+  it("(count (chunk_by_size 10)) counts the produced chunks", async () => {
+    const tools = makeTools("a".repeat(95));
+    const parsed = parse("(count (chunk_by_size 10))");
+    const result = await solve(parsed.term!, tools, new Map());
+    expect(result.success).toBe(true);
+    // 95 chars / 10 = 9 full + 1 short = 10 chunks
+    expect(result.value).toBe(10);
+  });
+});

--- a/tests/purge-final-var.test.ts
+++ b/tests/purge-final-var.test.ts
@@ -1,9 +1,19 @@
 /**
- * Fingerprint test for the FINAL_VAR / memory-buffer legacy purge.
+ * Fingerprint test for the legacy JS-sandbox / memory-buffer purge.
  *
  * Each assertion pins a fact about the purged state so that an accidental
  * revert (e.g. re-adding FinalVarMarker, re-introducing memory.push into a
- * prompt) flips a test red instead of silently drifting back in.
+ * prompt, restoring src/sandbox.ts) flips a test red instead of silently
+ * drifting back in.
+ *
+ * NOTE on FINAL_VAR: the old JS-sandbox-backed `FINAL_VAR(memoryKey)` path
+ * is permanently gone, but a new binding-backed `FINAL_VAR(name)` primitive
+ * was revived in the async-RLM refactor. The new mechanism lives in
+ * `src/fsm/rlm-states.ts` (binding lookup at the final-answer boundary) and
+ * `src/adapters/nucleus.ts` (prompt hint). Those files are excluded from
+ * the FINAL_VAR-absence checks below; the other adapters and rlm.ts itself
+ * must still stay clean of the string, because reviving it there would
+ * reintroduce the FinalVarMarker type or the memory-buffer path.
  *
  * These are deliberately grep-based over source files — the whole point is
  * to assert the *absence* of specific strings/files, which a structural
@@ -56,10 +66,12 @@ describe("FINAL_VAR / memory-buffer legacy purge", () => {
     });
   });
 
-  describe("FINAL_VAR parsing and prompt hints removed", () => {
+  describe("FINAL_VAR legacy path removed (new binding-backed path excluded)", () => {
+    // nucleus.ts is intentionally excluded: it now teaches the LLM the
+    // revived FINAL_VAR(name) primitive in its system prompt. The adapters
+    // below never supported the feature, so they must stay clean.
     it.each([
       "adapters/base.ts",
-      "adapters/nucleus.ts",
       "adapters/deepseek.ts",
       "adapters/qwen.ts",
       "adapters/qwen-synthesis.ts",

--- a/tests/rlm-sub-rlm.test.ts
+++ b/tests/rlm-sub-rlm.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for P3 — Sub-RLM recursion (the paper's true "symbolic recursion").
+ *
+ * Before P3, `(llm_query …)` dispatched to a flat sub-LLM call — one
+ * prompt in, one string out, no Nucleus code execution inside the sub
+ * call. That was a useful POC but missed the paper's Ω(|P|) / Ω(|P|²)
+ * claim, which depends on each sub-call being able to itself run Nucleus
+ * code, access handles, and (transitively) invoke further sub-RLMs.
+ *
+ * This file locks down the recursive variant:
+ *
+ *   - A helper `runRLMFromContent(query, content, options)` that runs
+ *     the same FSM loop as runRLM but skips the file-read step.
+ *   - `RLMOptions.subRLMMaxDepth` — when >0, `(llm_query …)` spawns a
+ *     sub-RLM with the interpolated prompt as its document+query pair.
+ *     The sub-RLM can itself run Nucleus code, use chunking, invoke
+ *     `(llm_query …)` again, etc., up to the depth limit.
+ *   - Depth enforcement: past `subRLMMaxDepth`, falls back to flat
+ *     sub-LLM call so recursion can't run away.
+ *   - Existing `subRLMMaxDepth=0` (default) keeps the current flat
+ *     behavior so pre-P3 tests don't regress.
+ */
+
+import { describe, it, expect } from "vitest";
+import { runRLM, runRLMFromContent } from "../src/rlm.js";
+import { createNucleusAdapter } from "../src/adapters/nucleus.js";
+import { writeFile, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Helper that builds a scripted LLM from a list of responses, recording
+ * every prompt for later inspection. Re-entrant: if the script runs out,
+ * returns the last response (prevents test deadlocks when the sub-RLM
+ * spins a few extra turns).
+ */
+function scripted(responses: string[], seen: string[]): (p: string) => Promise<string> {
+  let idx = 0;
+  return async (prompt: string) => {
+    seen.push(prompt);
+    const r = responses[idx] ?? responses.at(-1) ?? "";
+    idx++;
+    return r;
+  };
+}
+
+async function makeFixture(content: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "matryoshka-subrlm-"));
+  const path = join(dir, "doc.txt");
+  await writeFile(path, content, "utf-8");
+  return path;
+}
+
+describe("runRLMFromContent — content-based entry point", () => {
+  it("is exported and runs the same FSM loop as runRLM", async () => {
+    const seen: string[] = [];
+    const llm = scripted(
+      [`(grep "ERROR")`, `<<<FINAL>>>found errors<<<END>>>`],
+      seen
+    );
+    const result = await runRLMFromContent(
+      "Find errors",
+      "INFO: ok\nERROR: boom\nERROR: crash",
+      {
+        llmClient: llm,
+        adapter: createNucleusAdapter(),
+        maxTurns: 5,
+        ragEnabled: false,
+      }
+    );
+    expect(typeof result).toBe("string");
+    expect(result).toContain("found errors");
+    expect(seen.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("subRLMMaxDepth — recursive sub-RLM spawn", () => {
+  it("default (depth=0) keeps flat sub-LLM behavior — llm_query fires 1 sub-call", async () => {
+    // With flat behavior, llm_query delegates directly to the llmClient
+    // with a single framed prompt. The sub-LLM sees exactly ONE call
+    // per llm_query invocation.
+    const seen: string[] = [];
+    let subCallCount = 0;
+    const llm = async (prompt: string): Promise<string> => {
+      seen.push(prompt);
+      // Sub-LLM calls are marked by the framing prefix
+      if (prompt.startsWith("You are a sub-LLM invoked")) {
+        subCallCount++;
+        return "flat sub-LLM response";
+      }
+      // Parent calls
+      const turn = seen.filter(p => !p.startsWith("You are a sub-LLM invoked")).length;
+      if (turn === 1) return `(llm_query "what is 2+2")`;
+      return `<<<FINAL>>>done<<<END>>>`;
+    };
+    const path = await makeFixture("doc content\nline 2\nline 3");
+    const result = await runRLM("ask", path, {
+      llmClient: llm,
+      adapter: createNucleusAdapter(),
+      maxTurns: 5,
+      ragEnabled: false,
+      // subRLMMaxDepth omitted → default 0 → flat behavior
+    });
+    expect(typeof result).toBe("string");
+    expect(subCallCount).toBe(1);
+  });
+
+  it("subRLMMaxDepth=1 spawns a sub-RLM that executes its own Nucleus code", async () => {
+    // The sub-RLM's document is the interpolated prompt. With
+    // subRLMMaxDepth=1, we get one level of recursion: the parent runs
+    // its FSM, issues llm_query, the sub-RLM runs ITS OWN FSM loop
+    // (multiple calls to llmClient), and returns a string.
+    //
+    // The sub-RLM is detected via its distinctive user-message prefix
+    // "Analyze and answer based on" — that string is injected by the
+    // spawner (see rlm.ts subRLMSpawner) into the sub-RLM's user
+    // message and persists through its history, but never appears in
+    // the parent's history because the parent's query and Nucleus
+    // code don't contain it.
+    //
+    // Parent flow: grep → llm_query → final.
+    // Sub-RLM flow: (inside llm_query) grep → final.
+    const allCalls: Array<{ role: "parent" | "child"; turn: number }> = [];
+    let parentTurn = 0;
+    let childTurn = 0;
+
+    const llm = async (prompt: string): Promise<string> => {
+      const isChild = prompt.includes("Analyze and answer based on");
+      if (isChild) {
+        childTurn++;
+        allCalls.push({ role: "child", turn: childTurn });
+        // Inside the sub-RLM, the document is the interpolated prompt.
+        // The sub-RLM runs its own grep over it.
+        if (childTurn === 1) return `(grep "ERROR")`;
+        return `<<<FINAL>>>child found errors<<<END>>>`;
+      }
+      parentTurn++;
+      allCalls.push({ role: "parent", turn: parentTurn });
+      if (parentTurn === 1) return `(grep "ERROR")`;
+      if (parentTurn === 2) {
+        return `(llm_query "inspect these: {items}" (items RESULTS))`;
+      }
+      return `<<<FINAL>>>parent done<<<END>>>`;
+    };
+
+    const path = await makeFixture(
+      "ERROR: one\nWARN: a\nERROR: two\nWARN: b\nINFO: ok"
+    );
+    const result = await runRLM("inspect logs", path, {
+      llmClient: llm,
+      adapter: createNucleusAdapter(),
+      maxTurns: 5,
+      ragEnabled: false,
+      subRLMMaxDepth: 1,
+    });
+
+    expect(typeof result).toBe("string");
+    expect(result).toContain("parent done");
+    // The sub-RLM must have run at least 2 turns (its own loop).
+    const childCalls = allCalls.filter(c => c.role === "child");
+    expect(childCalls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("subRLMMaxDepth enforces a depth cap — falls back to flat at the boundary", async () => {
+    // With subRLMMaxDepth=1, the FIRST sub-RLM runs a full FSM loop. Any
+    // llm_query from inside that sub-RLM (depth=2) must fall back to
+    // flat behavior — the flat llmQuery wraps the prompt with the
+    // "You are a sub-LLM invoked" framing string, which we detect here
+    // to distinguish it from the recursive sub-RLM user message prefix
+    // "Analyze and answer based on".
+    const callLog: Array<{ role: string; head: string }> = [];
+    const llm = async (prompt: string): Promise<string> => {
+      const role =
+        prompt.startsWith("You are a sub-LLM invoked")
+          ? "flat_leaf"  // depth 2 flat fallback
+          : prompt.includes("Analyze and answer based on")
+            ? "recursive_child"  // depth 1 sub-RLM
+            : "root";
+      callLog.push({ role, head: prompt.slice(0, 60) });
+
+      if (role === "root") {
+        const rootTurn = callLog.filter(c => c.role === "root").length;
+        if (rootTurn === 1) return `(grep "foo")`;
+        if (rootTurn === 2) return `(llm_query "level1-payload: {items}" (items RESULTS))`;
+        return `<<<FINAL>>>root done<<<END>>>`;
+      }
+      if (role === "recursive_child") {
+        const d1Turn = callLog.filter(c => c.role === "recursive_child").length;
+        if (d1Turn === 1) return `(grep "foo")`;
+        // Sub-RLM at depth 1 tries to spawn ANOTHER sub-RLM
+        if (d1Turn === 2) return `(llm_query "level2-payload: {x}" (x RESULTS))`;
+        return `<<<FINAL>>>depth1 done<<<END>>>`;
+      }
+      // flat_leaf — only fires once per llm_query invocation (no FSM loop).
+      return "flat depth2 response";
+    };
+
+    const path = await makeFixture("foo\nfoo\nfoo");
+    await runRLM("recursive depth test", path, {
+      llmClient: llm,
+      adapter: createNucleusAdapter(),
+      maxTurns: 10,
+      ragEnabled: false,
+      subRLMMaxDepth: 1,
+    });
+
+    const flatLeafCalls = callLog.filter(c => c.role === "flat_leaf");
+    const recursiveChildCalls = callLog.filter(c => c.role === "recursive_child");
+    // The sub-RLM should have run a full FSM loop (multiple turns).
+    expect(recursiveChildCalls.length).toBeGreaterThanOrEqual(2);
+    // And its attempt to spawn a second level should have fallen back
+    // to a single flat sub-LLM call, not a new FSM loop.
+    expect(flatLeafCalls.length).toBe(1);
+  });
+
+  it("the sub-RLM can use chunking primitives over the interpolated prompt", async () => {
+    // The paper's killer demo: the sub-RLM chunks its input and runs
+    // Nucleus code over the chunks. We test composability: chunking
+    // primitives work inside a sub-RLM's own FSM loop.
+    const parentCalls: string[] = [];
+    const subCalls: string[] = [];
+    const llm = async (prompt: string): Promise<string> => {
+      const isChild = prompt.includes("Analyze and answer based on");
+      if (isChild) {
+        subCalls.push(prompt);
+        if (subCalls.length === 1) return `(count (chunk_by_lines 2))`;
+        return `<<<FINAL>>>sub counted chunks<<<END>>>`;
+      }
+      parentCalls.push(prompt);
+      const p = parentCalls.length;
+      if (p === 1) return `(grep "key")`;
+      if (p === 2) return `(llm_query "inspect: {x}" (x RESULTS))`;
+      return `<<<FINAL>>>parent received report<<<END>>>`;
+    };
+
+    const path = await makeFixture(
+      "key: alpha\nkey: beta\nkey: gamma\nkey: delta"
+    );
+    const result = await runRLM("chunk test", path, {
+      llmClient: llm,
+      adapter: createNucleusAdapter(),
+      maxTurns: 5,
+      ragEnabled: false,
+      subRLMMaxDepth: 1,
+    });
+    expect(typeof result).toBe("string");
+    expect(result).toContain("parent received report");
+    // The sub-RLM must have run code on its own (at least 2 sub calls).
+    expect(subCalls.length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the remaining 4 gaps from the Zhang/Kraska/Khattab RLM paper (arXiv 2512.24601v2) paper-vs-project review, each as an independent commit so they can be split into smaller PRs if desired.

With this PR, matryoshka now implements all three of the paper's design-choice pillars end-to-end:
1. **Symbolic handle** to the user prompt — shipped earlier (handle system, 97% token savings)
2. **Non-autoregressive output** — covered by the existing `<<<FINAL>>>...<<<END>>>` tags, plus **P1** adds `FINAL_VAR(name)` so the LLM can return a binding without inlining it
3. **Symbolic recursion** — **P3** upgrades `(llm_query ...)` from a flat sub-LLM call to a full recursive sub-RLM

Plus **P0-followup** wires the MCP `sampling/createMessage` protocol so `(llm_query ...)` over lattice-mcp delegates back to the MCP client's LLM, and **P2** adds chunking primitives for pre-slicing documents that are too large to map over directly.

## Commits

| Priority | Commit | Feature |
|---|---|---|
| **P0-followup** | `6b4b4c3` | `(llm_query ...)` via MCP `sampling/createMessage` — routes sub-LLM calls back to the client LLM when it advertises `sampling` capability |
| **P1** | `8adb385` | `FINAL_VAR(name)` revival — binding-backed final answers, regex expansion at the FSM boundary with per-marker caps and unknown-binding pass-through |
| **P2** | `08e7184` | Chunking primitives — `(chunk_by_size N)`, `(chunk_by_lines N)`, `(chunk_by_regex "pat")` for the paper's OOLONG-Pairs pattern applied to oversized documents |
| **P3** | `f32dd73` | Sub-RLM recursion — `(llm_query ...)` spawns a full sub-RLM with its own FSM loop, chunking, handles, and up to `subRLMMaxDepth` levels of further recursion |
| **fix** | `16506ab` | Review-round fixes (3 bugs found during final review — see details below) |

## Review-round fixes (`16506ab`)

Three bugs caught during the final review pass before opening this PR:

1. **`lattice-mcp-server.ts` — sampling bridge race (HIGH)**
   The MCP SDK populates `_clientCapabilities` only inside `_oninitialize()`, which fires *after* `server.connect()` returns. The original code read `getClientCapabilities()` synchronously right after connect, so it always got `undefined` — the bridge never actually installed, and `(llm_query ...)` over MCP was effectively dead. Fix: install the bridge *before* `await server.connect()` and make it lazy — each invocation re-reads caps at call time, throwing a clear error if `sampling` isn't advertised.

2. **`lc-solver.ts chunk_by_regex` — capture-group interleaving (MEDIUM)**
   `String.prototype.split(regex)` interleaves captured groups into its output. A user pattern like `(chunk_by_regex "(\n)")` would produce `["alpha", "\n", "beta", "\n", "gamma"]` — the newline delimiter captured into the chunks. Fix: replace `split(regex)` with a manual `matchAll()` walk that extracts text between match ranges, naturally ignoring capture groups. Zero-width matches are forced forward by one char to prevent infinite loops. Two regression tests added.

3. **`rlm.ts` sub-RLM return-value wrap (LOW)**
   `JSON.stringify(childResult)` on line 504 could throw on circular references. Defensive wrap with a try/catch and explicit null-handling. Also removed a useless `llmClient &&` null-check (TS flagged it as always-truthy).

## Verification

- **Full suite**: 194 files, **2951 passed**, 3 skipped, 0 failures
- **Chiasmus graph analysis**: dead-code (12 false positives from FSM dynamic dispatch), cycles (expected `runRLMFromContent` mutual recursion from P3), no layer-violation hits
- **Live exercise — combined P0-followup + P1 + P2 + P3** (22ms): chunking → sub-RLM map → count → FINAL_VAR expansion in the final answer, composed through `runRLM`
- **Per-task live exercises**: each of the 4 features validated independently with dedicated scripted-LLM scenarios

## New public API

```typescript
// P1: FINAL_VAR(name) — no API change, handled at FSM boundary
// The LLM emits <<<FINAL>>>FINAL_VAR(_2)<<<END>>> and the FSM expands it.

// P2: three new LC terms
(chunk_by_size N)        // N-character slices
(chunk_by_lines N)       // N-line slices
(chunk_by_regex "pat")   // split wherever pat matches (captures ignored)

// P3: new RLMOptions field
runRLM(query, filePath, {
  // ...existing options...
  subRLMMaxDepth: 1,  // enable up to 1 level of recursive sub-RLM; default 0
});

// P3: new public content-based entry point
runRLMFromContent(query, content, options)

// P0-followup: no API change — lattice-mcp-server auto-wires the sampling
// bridge if the connected MCP client advertises `sampling` capability.
```

## Test plan

- [x] `npx vitest run` — 2951 passed / 0 failed
- [x] TDD: every feature written red first, flipped green with implementation
- [x] Live exercises: P0-followup (4 scenarios), P1 (5), P2 (6), P3 (4), combined (4), review fixes (3)
- [x] Full suite after review fixes still green
- [x] Chiasmus dead-code / cycles / layer-violation analyses clean
- [ ] Real-MCP-client smoke test: load a large document via lattice-mcp from Claude Code or Claude Desktop and issue a `(llm_query ...)` that triggers the sampling bridge end-to-end. Deferred to a follow-up because it requires a human in the loop.
- [ ] Real-LLM-client smoke test for sub-RLM recursion with an actual model emitting its own Nucleus code inside a sub-call.

Paper: *Recursive Language Models*, Zhang/Kraska/Khattab (MIT CSAIL, arXiv 2512.24601v2) — GAPs P0-P3.