### PR TITLE
feat(mcp): multi-turn llm_query protocol for clients without sampling

### DIFF
--- a/src/lattice-mcp-server.ts
+++ b/src/lattice-mcp-server.ts
@@ -31,7 +31,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { stat } from "node:fs/promises";
 import { resolve, sep } from "node:path";
-import { HandleSession } from "./engine/handle-session.js";
+import { HandleSession, type HandleResult } from "./engine/handle-session.js";
 import { getVersion } from "./version.js";
 import { hasTraversalSegment } from "./utils/path-safety.js";
 
@@ -58,6 +58,31 @@ const MAX_DOCUMENT_SIZE = 50 * 1024 * 1024; // 50MB limit
 let session: HandleSession | null = null;
 let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
 
+// Multi-turn LLM query protocol — Promise-based suspension for clients
+// without MCP sampling support. When the solver hits (llm_query ...) and
+// the client doesn't advertise sampling, the bridge creates a pending
+// Promise and signals the tool handler to return a suspension request.
+// The LLM client then calls lattice_llm_respond to provide the response,
+// which resolves the Promise and lets the solver continue. This works with
+// any MCP client (Claude Code, opencode, custom clients) — no special
+// capabilities required. Session timeout rejects all pending queries, so
+// there's no memory leak beyond the session lifetime.
+interface PendingQuery {
+  id: string;
+  prompt: string;
+  resolve: (response: string) => void;
+  reject: (error: Error) => void;
+  createdAt: number;
+}
+
+const pendingQueries = new Map<string, PendingQuery>();
+let suspensionCallback: ((info: { id: string; prompt: string }) => void) | null = null;
+let activeExecution: Promise<HandleResult> | null = null;
+// For top-level llm_query: the bridge fires synchronously inside
+// session.execute() before raceExecution() installs the callback.
+// The bridge stores the suspension here so raceExecution() can pick it up.
+let earlySuspension: { id: string; prompt: string } | null = null;
+
 function resetInactivityTimer(): void {
   if (timeoutHandle) {
     clearTimeout(timeoutHandle);
@@ -77,6 +102,8 @@ function resetInactivityTimer(): void {
 }
 
 function closeSession(reason: string): void {
+  rejectAllPendingQueries(reason);
+
   if (session) {
     const info = session.getSessionInfo();
     const duration = info.loadedAt ? Date.now() - info.loadedAt.getTime() : 0;
@@ -95,6 +122,66 @@ function closeSession(reason: string): void {
     clearTimeout(timeoutHandle);
     timeoutHandle = null;
   }
+}
+
+type RaceResult =
+  | { type: "completed"; result: HandleResult }
+  | { type: "suspended"; id: string; prompt: string };
+
+async function raceExecution(): Promise<RaceResult> {
+  if (!activeExecution) {
+    throw new Error("No active execution");
+  }
+
+  // Check for early suspension: when (llm_query ...) is at the top level,
+  // the bridge fires synchronously inside session.execute() — before this
+  // function was called. The bridge stores the info in earlySuspension.
+  if (earlySuspension) {
+    const info = earlySuspension;
+    earlySuspension = null;
+    return { type: "suspended", ...info };
+  }
+
+  let resolveSuspension: (info: { id: string; prompt: string }) => void;
+  const suspensionPromise = new Promise<RaceResult>((resolve) => {
+    resolveSuspension = (info) => resolve({ type: "suspended", ...info });
+  });
+
+  // Install callback for nested llm_query calls (e.g., inside map/filter).
+  // These fire on a microtask after the collection evaluation yields, so
+  // the callback is installed before they run.
+  suspensionCallback = resolveSuspension!;
+
+  return Promise.race([
+    activeExecution.then((result): RaceResult => {
+      suspensionCallback = null;
+      activeExecution = null;
+      return { type: "completed", result };
+    }),
+    suspensionPromise,
+  ]);
+}
+
+function formatSuspensionRequest(id: string, prompt: string): string {
+  return (
+    `[LLM_QUERY_REQUEST id=${id}]\n\n` +
+    `Please respond to the following prompt:\n\n  ${prompt}\n\n` +
+    `Respond using lattice_llm_respond:\n` +
+    `  id: "${id}"\n` +
+    `  response: "your response here"`
+  );
+}
+
+function rejectAllPendingQueries(reason: string): void {
+  for (const [id, entry] of pendingQueries) {
+    try {
+      entry.reject(new Error(`Session closed: ${reason}`));
+    } catch { /* ignore double-reject */ }
+    pendingQueries.delete(id);
+  }
+  activeExecution = null;
+  suspensionCallback = null;
+  earlySuspension = null;
 }
 
 function getSessionInfo(): string {
@@ -390,6 +477,39 @@ Check lattice_bindings to see current memos and their handles.`,
       required: [],
     },
   },
+  {
+    name: "lattice_llm_respond",
+    description: `Respond to a pending (llm_query ...) request from a Nucleus query.
+
+When a query containing (llm_query "prompt" ...) is executed and the MCP client
+doesn't support sampling, the server suspends execution and returns a pending
+request instead of a result. Use this tool to provide the LLM response and
+continue execution.
+
+The execution resumes from where it left off. If the query contains multiple
+llm_query calls (e.g., inside a map over many items), you may receive another
+pending request after responding — this is normal for the OOLONG pattern.
+
+WORKFLOW:
+1. lattice_query returns: "[LLM_QUERY_REQUEST id=q_abc] Please respond to: ..."
+2. You respond: lattice_llm_respond id="q_abc" response="your answer"
+3. If more llm_query calls follow, you get another request (repeat step 2)
+4. When all llm_query calls are answered, you get the final query result`,
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        id: {
+          type: "string",
+          description: "The query ID from the LLM_QUERY_REQUEST message",
+        },
+        response: {
+          type: "string",
+          description: "Your response to the prompt",
+        },
+      },
+      required: ["id", "response"],
+    },
+  },
 ];
 
 function formatHandleResult(result: {
@@ -582,10 +702,38 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
           return { content: [{ type: "text", text: "Error: command is required" }] };
         }
 
+        // Guard: if there's a pending LLM query, the client must respond first
+        if (activeExecution && pendingQueries.size > 0) {
+          const pending = pendingQueries.values().next().value as PendingQuery;
+          resetInactivityTimer();
+          return {
+            content: [{
+              type: "text",
+              text: `There is a pending LLM query that must be answered first.\n\n` +
+                formatSuspensionRequest(pending.id, pending.prompt),
+            }],
+          };
+        }
+
         resetInactivityTimer();
 
-        const result = await session.execute(command);
-        return { content: [{ type: "text", text: formatHandleResult(result) }] };
+        // Clear stale suspension state before starting a new execution
+        earlySuspension = null;
+
+        activeExecution = session.execute(command);
+
+        const raceResult = await raceExecution();
+
+        if (raceResult.type === "completed") {
+          return { content: [{ type: "text", text: formatHandleResult(raceResult.result) }] };
+        }
+
+        return {
+          content: [{
+            type: "text",
+            text: formatSuspensionRequest(raceResult.id, raceResult.prompt),
+          }],
+        };
       }
 
       case "lattice_expand": {
@@ -728,6 +876,54 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
         };
       }
 
+      case "lattice_llm_respond": {
+        const id = args.id as string;
+        const response = args.response as string;
+
+        if (!id || response === undefined || response === null) {
+          return { content: [{ type: "text", text: "Error: id and response are required" }] };
+        }
+
+        if (!activeExecution) {
+          return {
+            content: [{
+              type: "text",
+              text: "Error: No active execution to continue. Start with lattice_query.",
+            }],
+          };
+        }
+
+        const entry = pendingQueries.get(id);
+        if (!entry) {
+          return {
+            content: [{
+              type: "text",
+              text: `Error: Unknown or expired query ID: ${id}. The session may have timed out.`,
+            }],
+          };
+        }
+
+        // Resolve the pending query — this unblocks the solver
+        pendingQueries.delete(id);
+        entry.resolve(response);
+
+        resetInactivityTimer();
+
+        // Race for completion or next suspension (e.g., next item in a map)
+        const raceResult = await raceExecution();
+
+        if (raceResult.type === "completed") {
+          return { content: [{ type: "text", text: formatHandleResult(raceResult.result) }] };
+        }
+
+        return {
+          content: [{
+            type: "text",
+            text: formatSuspensionRequest(raceResult.id, raceResult.prompt),
+          }],
+        };
+      }
+
       default:
         return { content: [{ type: "text", text: `Unknown tool: ${name}` }] };
     }
@@ -795,46 +991,48 @@ async function main() {
   // check sees the right capabilities.
   samplingBridge = async (prompt: string): Promise<string> => {
     const caps = server.getClientCapabilities();
-    if (!caps?.sampling) {
-      // Client compatibility (empirically tested 2026-04-11):
-      //   - Claude Code CLI: does NOT advertise `sampling` as of this
-      //     writing — `(llm_query ...)` will always hit this error.
-      //   - Claude Desktop: supports sampling via the per-tool allowlist
-      //     UI (check the server's sampling permissions in settings).
-      //   - Custom MCP clients: must set `capabilities.sampling` in
-      //     their initialize request and implement the
-      //     `sampling/createMessage` handler.
-      // If your client is in the first group, compose your query
-      // without `(llm_query ...)` — grep/filter/map/chunk are all
-      // available and cover most deterministic workflows.
-      throw new Error(
-        "llm_query is not available: the connected MCP client did not " +
-        "advertise `sampling` capability. Claude Code CLI does not " +
-        "currently support MCP sampling — use Claude Desktop or a custom " +
-        "client that implements `sampling/createMessage`. Alternatively, " +
-        "rewrite the query without `(llm_query ...)` — deterministic " +
-        "primitives (grep, filter, map, chunk_by_*) cover most workflows."
-      );
+    if (caps?.sampling) {
+      // Native MCP sampling path — client supports sampling/createMessage.
+      const result = await server.createMessage({
+        messages: [{ role: "user", content: { type: "text", text: prompt } }],
+        maxTokens: SAMPLING_MAX_TOKENS,
+        includeContext: "none",
+      });
+      if (result.content?.type === "text") {
+        return result.content.text;
+      }
+      return `[sub-LLM returned non-text content: ${result.content?.type ?? "unknown"}]`;
     }
-    const result = await server.createMessage({
-      messages: [{ role: "user", content: { type: "text", text: prompt } }],
-      maxTokens: SAMPLING_MAX_TOKENS,
-      // `none` keeps the sub-LLM isolated from the parent conversation —
-      // the paper's sub-RLM model spins up a fresh context per sub-call.
-      includeContext: "none",
+
+    // Fallback: multi-turn protocol for clients without sampling.
+    // Create a pending Promise that the tool handler will return as a
+    // suspension request. The LLM client calls lattice_llm_respond to
+    // resolve it and continue execution. Works with any MCP client.
+    const id = `q_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+    const promise = new Promise<string>((resolve, reject) => {
+      pendingQueries.set(id, { id, prompt, resolve, reject, createdAt: Date.now() });
     });
-    // CreateMessageResult.content is a single block for the no-tools path.
-    if (result.content?.type === "text") {
-      return result.content.text;
+
+    // Signal the tool handler that we've suspended.
+    //
+    // Two paths:
+    // 1. Nested llm_query (inside map/filter): fires on a microtask AFTER
+    //    raceExecution() installed suspensionCallback. Call it directly.
+    // 2. Top-level llm_query: fires synchronously inside session.execute()
+    //    BEFORE raceExecution() runs. Store in earlySuspension for pickup.
+    if (suspensionCallback) {
+      suspensionCallback({ id, prompt });
+    } else {
+      earlySuspension = { id, prompt };
     }
-    // Image / audio content blocks are not useful for string interpolation;
-    // return a visible placeholder so the solver doesn't crash.
-    return `[sub-LLM returned non-text content: ${result.content?.type ?? "unknown"}]`;
+
+    return promise;
   };
 
   await server.connect(transport);
 
-  console.error("[Lattice] Sampling bridge installed — (llm_query ...) will route via MCP sampling when client supports it");
+  console.error("[Lattice] LLM query bridge installed — (llm_query ...) uses MCP sampling when available, multi-turn protocol otherwise");
 
   console.error("[Lattice] MCP server started (handle-based mode)");
   console.error(`[Lattice] Session timeout: ${SESSION_TIMEOUT_MS / 1000}s`);

--- a/src/lattice-mcp-server.ts
+++ b/src/lattice-mcp-server.ts
@@ -285,6 +285,34 @@ TRANSFORM (returns new handle):
 EXTRACT:
   (match str "pattern" 1)       Extract regex group from string
 
+LLM_QUERY (multi-turn — works with any MCP client, no sampling required):
+  (llm_query "prompt")                                     Ask a question, get your response
+  (llm_query "describe: {item}" (item x))                  With variable binding
+  (map RESULTS (lambda x (llm_query "tag: {item}" (item x))))  Per-item via map
+  (filter RESULTS (lambda x (match (llm_query "keep?: {item}" (item x)) "keep" 0)))  Per-item filter
+
+When a query contains (llm_query ...), execution SUSPENDS and returns a request like:
+  [LLM_QUERY_REQUEST id=q_abc] Please respond to: ...
+You MUST respond using lattice_llm_respond before the query can continue:
+  lattice_llm_respond id="q_abc" response="your answer"
+After responding, you either get the final result or another suspension (if the
+query has multiple llm_query calls, e.g. inside map over many items). Keep
+responding until you get a handle stub or scalar result — that's the final output.
+
+LLM_QUERY WORKFLOW:
+1. lattice_query '(llm_query "classify this")'
+   → [LLM_QUERY_REQUEST id=q_abc] Please respond to: classify this
+2. lattice_llm_respond id="q_abc" response="It's a technical document"
+   → "It's a technical document"  (final result)
+
+LLM_QUERY MAP WORKFLOW (OOLONG pattern — one suspension per item):
+1. lattice_query '(map RESULTS (lambda x (llm_query "tag: {item}" (item x))))'
+   → [LLM_QUERY_REQUEST id=q_1] ... tag: item1 ...
+2. lattice_llm_respond id="q_1" response="bug"
+   → [LLM_QUERY_REQUEST id=q_2] ... tag: item2 ...  (next item)
+3. lattice_llm_respond id="q_2" response="feature"
+   → $res1: Array(2) ["bug", "feature"]  (final result)
+
 EXAMPLE WORKFLOW:
 1. (grep "ERROR")                    → Returns: $res1: Array(500) [preview]
 2. (filter RESULTS (lambda x ...))   → Returns: $res2: Array(50) [preview]

--- a/tests/logic/llm-query-multiturn.test.ts
+++ b/tests/logic/llm-query-multiturn.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests for the multi-turn LLM query protocol — Promise-based suspension
+ * that replaces MCP sampling for clients without sampling support.
+ *
+ * The protocol works by:
+ * 1. The solver hits (llm_query ...) and awaits tools.llmQuery(prompt)
+ * 2. The bridge creates a pending Promise and signals suspension
+ * 3. The tool handler returns a suspension request to the LLM client
+ * 4. The LLM client calls back with a response
+ * 5. The bridge resolves the pending Promise
+ * 6. The solver continues from where it left off
+ *
+ * These tests exercise the core mechanism using NucleusEngine directly,
+ * simulating what lattice-mcp-server.ts does with raceExecution().
+ */
+
+import { describe, it, expect } from "vitest";
+import { NucleusEngine } from "../../src/engine/nucleus-engine.js";
+
+interface PendingQuery {
+  id: string;
+  prompt: string;
+  resolve: (response: string) => void;
+  reject: (error: Error) => void;
+}
+
+type EngineResult = Awaited<ReturnType<NucleusEngine["execute"]>>;
+
+function createSuspendableBridge() {
+  const pendingQueries = new Map<string, PendingQuery>();
+  let suspensionCallback: ((info: { id: string; prompt: string }) => void) | null = null;
+  let earlySuspension: { id: string; prompt: string } | null = null;
+
+  const bridge = async (prompt: string): Promise<string> => {
+    const id = `q_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+    const promise = new Promise<string>((resolve, reject) => {
+      pendingQueries.set(id, { id, prompt, resolve, reject, createdAt: Date.now() });
+    });
+
+    if (suspensionCallback) {
+      suspensionCallback({ id, prompt });
+    } else {
+      earlySuspension = { id, prompt };
+    }
+
+    return promise;
+  };
+
+  function setCallback(cb: ((info: { id: string; prompt: string }) => void) | null) {
+    suspensionCallback = cb;
+  }
+
+  function getPending() {
+    return pendingQueries;
+  }
+
+  function respond(id: string, response: string) {
+    const entry = pendingQueries.get(id);
+    if (entry) {
+      pendingQueries.delete(id);
+      entry.resolve(response);
+    }
+  }
+
+  function rejectAll(reason: string) {
+    for (const [id, entry] of pendingQueries) {
+      entry.reject(new Error(reason));
+      pendingQueries.delete(id);
+    }
+  }
+
+  function clearEarly() {
+    earlySuspension = null;
+  }
+
+  return { bridge, setCallback, getPending, respond, rejectAll, clearEarly, getEarlySuspension: () => earlySuspension };
+}
+
+type RaceResult =
+  | { type: "completed"; result: EngineResult }
+  | { type: "suspended"; id: string; prompt: string };
+
+function raceExecution(
+  execPromise: Promise<EngineResult>,
+  ctx: { setCallback: (cb: ((info: { id: string; prompt: string }) => void) | null) => void; getEarlySuspension: () => { id: string; prompt: string } | null; clearEarly: () => void },
+): Promise<RaceResult> {
+  const early = ctx.getEarlySuspension();
+  if (early) {
+    ctx.clearEarly();
+    return Promise.resolve({ type: "suspended", ...early });
+  }
+
+  let resolveSuspension: (info: { id: string; prompt: string }) => void;
+  const suspensionPromise = new Promise<RaceResult>((resolve) => {
+    resolveSuspension = (info) => resolve({ type: "suspended", ...info });
+  });
+
+  ctx.setCallback(resolveSuspension!);
+
+  return Promise.race([
+    execPromise.then((result): RaceResult => {
+      ctx.setCallback(null);
+      return { type: "completed", result };
+    }),
+    suspensionPromise,
+  ]);
+}
+
+async function respondAndContinue(
+  race: RaceResult & { type: "suspended" },
+  execPromise: Promise<EngineResult>,
+  ctx: ReturnType<typeof createSuspendableBridge>,
+  response: string,
+): Promise<RaceResult> {
+  ctx.respond(race.id, response);
+  return raceExecution(execPromise, ctx);
+}
+
+describe("multi-turn LLM query protocol", () => {
+  it("suspends on top-level llm_query and resumes when responded", async () => {
+    const ctx = createSuspendableBridge();
+    const engine = new NucleusEngine({ llmQuery: ctx.bridge });
+    engine.loadContent("some document content");
+
+    ctx.clearEarly();
+    const execPromise = engine.execute('(llm_query "classify this")');
+    const race = await raceExecution(execPromise, ctx);
+
+    expect(race.type).toBe("suspended");
+    if (race.type !== "suspended") return;
+
+    expect(race.prompt).toBe("classify this");
+
+    const next = await respondAndContinue(race, execPromise, ctx, "It's a technical document");
+    expect(next.type).toBe("completed");
+    if (next.type !== "completed") return;
+    expect(next.result.success).toBe(true);
+    expect(next.result.value).toBe("It's a technical document");
+  });
+
+  it("handles map with llm_query — one suspension per item", async () => {
+    const ctx = createSuspendableBridge();
+    const engine = new NucleusEngine({ llmQuery: ctx.bridge });
+    engine.loadContent("line1\nline2\nline3");
+
+    await engine.execute('(grep "line")');
+
+    ctx.clearEarly();
+    const execPromise = engine.execute(
+      '(map RESULTS (lambda x (llm_query "tag: {item}" (item x))))'
+    );
+
+    // Item 1
+    let race = await raceExecution(execPromise, ctx);
+    expect(race.type).toBe("suspended");
+    if (race.type !== "suspended") return;
+    expect(race.prompt).toContain("line1");
+
+    let next = await respondAndContinue(race, execPromise, ctx, "tag-A");
+    expect(next.type).toBe("suspended");
+    if (next.type !== "suspended") return;
+    expect(next.prompt).toContain("line2");
+
+    next = await respondAndContinue(next, execPromise, ctx, "tag-B");
+    expect(next.type).toBe("suspended");
+    if (next.type !== "suspended") return;
+    expect(next.prompt).toContain("line3");
+
+    next = await respondAndContinue(next, execPromise, ctx, "tag-C");
+    expect(next.type).toBe("completed");
+    if (next.type !== "completed") return;
+    expect(next.result.success).toBe(true);
+    expect(next.result.value).toEqual(["tag-A", "tag-B", "tag-C"]);
+  });
+
+  it("filter with llm_query suspends per item", async () => {
+    const ctx = createSuspendableBridge();
+    const engine = new NucleusEngine({ llmQuery: ctx.bridge });
+    engine.loadContent("good item\nbad item\nanother good item");
+
+    await engine.execute('(grep "item")');
+
+    ctx.clearEarly();
+    const execPromise = engine.execute(
+      '(filter RESULTS (lambda x (match (llm_query "judge: {item}" (item x)) "keep" 0)))'
+    );
+
+    // Item 1: "good item" → say "keep"
+    let race = await raceExecution(execPromise, ctx);
+    expect(race.type).toBe("suspended");
+    if (race.type !== "suspended") return;
+    expect(race.prompt).toContain("good item");
+
+    let next = await respondAndContinue(race, execPromise, ctx, "keep");
+
+    // Item 2: "bad item" → say "drop"
+    expect(next.type).toBe("suspended");
+    if (next.type !== "suspended") return;
+    expect(next.prompt).toContain("bad item");
+
+    next = await respondAndContinue(next, execPromise, ctx, "drop");
+
+    // Item 3: "another good item" → say "keep"
+    expect(next.type).toBe("suspended");
+    if (next.type !== "suspended") return;
+    expect(next.prompt).toContain("another good item");
+
+    next = await respondAndContinue(next, execPromise, ctx, "keep");
+
+    // Final result
+    expect(next.type).toBe("completed");
+    if (next.type !== "completed") return;
+    expect(next.result.success).toBe(true);
+    const filtered = next.result.value as Array<{ line: string }>;
+    expect(filtered.map((r) => r.line)).toEqual(["good item", "another good item"]);
+  });
+
+  it("rejecting pending queries propagates as solver error", async () => {
+    const ctx = createSuspendableBridge();
+    const engine = new NucleusEngine({ llmQuery: ctx.bridge });
+    engine.loadContent("content");
+
+    ctx.clearEarly();
+    const execPromise = engine.execute('(llm_query "prompt")');
+    const race = await raceExecution(execPromise, ctx);
+
+    expect(race.type).toBe("suspended");
+
+    ctx.rejectAll("Session expired");
+
+    const result = await execPromise;
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Session expired");
+  });
+
+  it("queries without llm_query complete normally without suspension", async () => {
+    const ctx = createSuspendableBridge();
+    const engine = new NucleusEngine({ llmQuery: ctx.bridge });
+    engine.loadContent("ERROR: something\nWARN: other\nERROR: more");
+
+    ctx.clearEarly();
+    const execPromise = engine.execute('(grep "ERROR")');
+    const race = await raceExecution(execPromise, ctx);
+
+    expect(race.type).toBe("completed");
+    if (race.type !== "completed") return;
+    expect(race.result.success).toBe(true);
+    const hits = race.result.value as Array<{ line: string }>;
+    expect(hits).toHaveLength(2);
+  });
+
+  it("bindings are preserved across suspension boundaries", async () => {
+    const ctx = createSuspendableBridge();
+    const engine = new NucleusEngine({ llmQuery: ctx.bridge });
+    engine.loadContent("hello world\nfoo bar");
+
+    await engine.execute('(grep "hello")');
+
+    ctx.clearEarly();
+    const execPromise = engine.execute(
+      '(llm_query "Summarize: {data}" (data RESULTS))'
+    );
+
+    const race = await raceExecution(execPromise, ctx);
+    expect(race.type).toBe("suspended");
+    if (race.type !== "suspended") return;
+
+    expect(race.prompt).toContain("hello world");
+    expect(race.prompt).not.toContain("{data}");
+
+    const next = await respondAndContinue(race, execPromise, ctx, "A greeting document");
+    expect(next.type).toBe("completed");
+    if (next.type !== "completed") return;
+    expect(next.result.success).toBe(true);
+    expect(next.result.value).toBe("A greeting document");
+  });
+});


### PR DESCRIPTION
When the MCP client doesn't support sampling/createMessage (Claude Code, opencode, etc.), llm_query now falls back to a Promise-based suspension protocol instead of throwing an error. The solver pauses mid-execution, returns a suspension request to the client, and resumes when the client responds via the new lattice_llm_respond tool. Works for top-level and nested llm_query (map/filter). MCP sampling still used when available.