### PR TITLE
feat: descriptive handle names derived from Nucleus commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ The Lattice engine doubles as a **context memory** for LLM agents. Instead of ro
 
 ```
 Agent reads file, summarizes → lattice_memo "auth architecture"
-                              → $memo1: "auth architecture" (2.1KB, 50 lines)
+                              → $memo_auth_architecture: "auth architecture" (2.1KB, 50 lines)
 
-20 messages later, needs it  → lattice_expand $memo1
+20 messages later, needs it  → lattice_expand $memo_auth_architecture
                               → Full 50-line summary
 ```
 
@@ -327,11 +327,11 @@ from the programmatic API — see the Programmatic section below.
 #### Memory Pad Usage
 
 ```
-1. lattice_memo(content="<file summary>", label="auth module")  → $memo1 stub
-2. lattice_memo(content="<analysis>", label="perf bottlenecks") → $memo2 stub
+1. lattice_memo(content="<file summary>", label="auth module")  → $memo_auth_module stub
+2. lattice_memo(content="<analysis>", label="perf bottlenecks") → $memo_perf_bottlenecks stub
 3. # ... many turns later, need the auth context ...
-4. lattice_expand("$memo1")                                     → Full summary
-5. lattice_memo_delete("$memo1")                                → Drop when stale
+4. lattice_expand("$memo_auth_module")                          → Full summary
+5. lattice_memo_delete("$memo_auth_module")                     → Drop when stale
 ```
 
 Memos don't require a loaded document — they create a session automatically.

--- a/README.md
+++ b/README.md
@@ -71,14 +71,16 @@ For large result sets, RLM uses a handle-based architecture with in-memory SQLit
 
 ```
 Traditional:  LLM sees full array    [15,000 tokens for 1000 results]
-Handle-based: LLM sees stub          [50 tokens: "$res1: Array(1000) [preview...]"]
+Handle-based: LLM sees stub          [50 tokens: "$grep_error: Array(1000) [preview...]"]
 ```
 
 **How it works:**
 1. Results are stored in SQLite with FTS5 full-text indexing
-2. LLM receives only handle references (`$res1`, `$res2`, etc.)
+2. LLM receives descriptive handle references derived from the command (e.g., `$grep_error`, `$bm25_timeout`, `$filter_status`)
 3. Operations execute server-side, returning new handles
 4. Full data is only materialized when needed
+
+Handle names are auto-generated from the Nucleus command: `(grep "ERROR")` produces `$grep_error`, `(list_symbols "function")` produces `$list_symbols_function`. Repeated commands get a numeric suffix (`$grep_error_2`, `$grep_error_3`).
 
 ### Memory Pad
 
@@ -193,7 +195,7 @@ rlm --help
 
 RLM includes `lattice-mcp`, an MCP (Model Context Protocol) server for direct access to the Nucleus engine. This allows coding agents to analyze documents with **80%+ token savings** compared to reading files directly.
 
-The key advantage is **handle-based results**: query results are stored server-side in SQLite, and the agent receives compact stubs like `$res1: Array(1000) [preview...]` instead of full data. Operations chain server-side without roundtripping data.
+The key advantage is **handle-based results**: query results are stored server-side in SQLite, and the agent receives compact stubs like `$grep_error: Array(1000) [preview...]` instead of full data. Handle names are derived from the command for easy identification. Operations chain server-side without roundtripping data.
 
 #### Available Tools
 
@@ -229,19 +231,19 @@ The key advantage is **handle-based results**: query results are stored server-s
 
 ```
 1. lattice_load("/path/to/large-file.txt")   # Load document (use for >500 lines)
-2. lattice_query('(grep "ERROR")')           # Search - returns handle stub $res1
-3. lattice_query('(filter RESULTS ...)')     # Narrow down - returns handle stub $res2
-4. lattice_query('(count RESULTS)')          # Get count without seeing data
-5. lattice_expand("$res2", limit=10)         # Expand only what you need to see
+2. lattice_query('(grep "ERROR")')           # Search → $grep_error: Array(500) [preview]
+3. lattice_query('(filter RESULTS ...)')     # Narrow → $filter_timeout: Array(50) [preview]
+4. lattice_query('(count RESULTS)')          # Count without seeing data → 50
+5. lattice_expand("$filter_timeout", limit=10) # Expand only what you need to see
 6. lattice_close()                           # Free memory when done
 ```
 
 **Token efficiency tips:**
-- Query results return handle stubs, not full data
+- Query results return descriptive handle stubs, not full data
 - Use `lattice_expand` with `limit` to see only what you need
 - Chain `grep → filter → count/sum` to refine progressively
 - Use `RESULTS` in queries (always points to last result)
-- Use `$res1`, `$res2` etc. with `lattice_expand` to inspect specific results
+- Use descriptive handle names (e.g., `$grep_error`) with `lattice_expand` to inspect specific results
 
 #### Chunking and Sub-LLM Recursion
 

--- a/src/engine/handle-session.ts
+++ b/src/engine/handle-session.ts
@@ -58,9 +58,9 @@ export interface ExpandTokenMetadata {
  */
 export interface HandleResult {
   success: boolean;
-  /** Handle reference (e.g., "$res1") if result is an array */
+  /** Handle reference (e.g., "$grep_error") if result is an array */
   handle?: string;
-  /** Handle stub for LLM context (e.g., "$res1: Array(1000) [preview...]") */
+  /** Handle stub for LLM context (e.g., "$grep_error: Array(1000) [preview...]") */
   stub?: string;
   /** Scalar value if result is not an array */
   value?: unknown;
@@ -385,7 +385,7 @@ export class HandleSession {
     // already bounds the handle count via its own MAX_HANDLES guard — no
     // need to duplicate that check here.
     if (Array.isArray(result.value)) {
-      const handle = this.registry.store(result.value);
+      const handle = this.registry.store(result.value, command);
       this.registry.setResults(handle);
 
       // Get the stub for LLM context

--- a/src/engine/handle-session.ts
+++ b/src/engine/handle-session.ts
@@ -590,7 +590,7 @@ export class HandleSession {
     this.evictMemosIfNeeded(contentBytes);
 
     const lines = content.split("\n");
-    const handle = this.db.createMemoHandle(lines);
+    const handle = this.db.createMemoHandle(lines, label);
     this.memoLabels.set(handle, label);
     this.memoSizes.set(handle, contentBytes);
     this.memoTotalBytes += contentBytes;
@@ -621,15 +621,10 @@ export class HandleSession {
    * Evict oldest memos until there's room for newBytes within budget
    */
   private evictMemosIfNeeded(newBytes: number): void {
-    // Get memo handles sorted numerically by ID (not alphabetically —
-    // alphabetical sort puts $memo10 before $memo2)
+    // listHandles() returns handles ordered by created_at, so filtering
+    // preserves creation order — oldest memos come first.
     const memoHandles = this.registry.listHandles()
-      .filter(h => h.startsWith("$memo"))
-      .sort((a, b) => {
-        const aNum = parseInt(a.slice(5), 10);
-        const bNum = parseInt(b.slice(5), 10);
-        return aNum - bNum;
-      });
+      .filter(h => h.startsWith("$memo"));
 
     // Evict until under count limit (leave room for the new one)
     while (memoHandles.length >= HandleSession.MAX_MEMOS) {

--- a/src/engine/nucleus-engine.ts
+++ b/src/engine/nucleus-engine.ts
@@ -612,7 +612,7 @@ VARIABLES (for use in queries):
   _1, _2, _3, ...              Results from turn N (auto-bound)
   context                       Raw document content
 
-NOTE: $res1, $res2, etc. are handle stubs for lattice_expand only.
+NOTE: Handle stubs (e.g. $grep_error, $filter_timeout) are for lattice_expand only.
       Use RESULTS or _1, _2, _3 to reference previous results in queries.
 
 SUPPORTED LANGUAGES FOR SYMBOLS:

--- a/src/lattice-mcp-server.ts
+++ b/src/lattice-mcp-server.ts
@@ -588,15 +588,16 @@ USE THIS TO:
 - Avoid roundtripping large text in every message
 - Pull context back only when actually needed via lattice_expand
 
-RETURNS a handle stub like: $memo1: "auth-module architecture" (2.1KB, 50 lines)
+RETURNS a handle stub like: $memo_auth_architecture: "auth architecture" (2.1KB, 50 lines)
+Handle names are derived from the label for easy identification.
 The LLM carries this compact stub (~15 tokens) instead of the full content (~2000 tokens).
 
 WORKFLOW:
-1. lattice_memo content="<summary>" label="what this is"  → $memo1 stub
+1. lattice_memo content="<summary>" label="auth architecture"  → $memo_auth_architecture stub
 2. Keep a brief index in your response text so you remember what's stashed:
-   "Stashed: $memo1 (auth architecture — middleware chain, session flow)"
+   "Stashed: $memo_auth_architecture (middleware chain, session flow)"
 3. Continue working, carrying just the index (~10 tokens per memo)
-4. lattice_expand $memo1  → Full content when you actually need it
+4. lattice_expand $memo_auth_architecture  → Full content when you actually need it
 
 IMPORTANT: After stashing, always note the handle + label + a short description
 of what's inside in your response. This avoids needing lattice_bindings later
@@ -630,7 +631,7 @@ Check lattice_bindings to see current memos and their handles.`,
       properties: {
         handle: {
           type: "string",
-          description: 'Memo handle to delete (e.g., "$memo1")',
+          description: 'Memo handle to delete (e.g., "$memo_auth_architecture")',
         },
       },
       required: ["handle"],

--- a/src/lattice-mcp-server.ts
+++ b/src/lattice-mcp-server.ts
@@ -302,7 +302,7 @@ RECOMMENDED WORKFLOW:
 
 HOW HANDLES WORK:
 - Query results are stored server-side in SQLite
-- You receive a compact stub like "$res1: Array(1000) [preview...]"
+- You receive a compact stub like "$grep_error: Array(1000) [preview...]"
 - Use lattice_expand to see full data when you need to make decisions
 - This saves 97%+ tokens compared to returning full results
 
@@ -330,7 +330,7 @@ Call lattice_close when done.`,
     description: `Execute a Nucleus query on the loaded document.
 
 RETURNS HANDLE STUBS (not full data):
-- Array results return a handle like "$res1: Array(500) [preview...]"
+- Array results return a handle like "$grep_error: Array(500) [preview...]"
 - Scalar results (count, sum) return the value directly
 - Use lattice_expand when you need to see the actual data
 
@@ -428,23 +428,23 @@ LLM_QUERY MAP WORKFLOW (OOLONG pattern — one suspension per item):
 2. lattice_llm_respond id="q_1" response="bug"
    → [LLM_QUERY_REQUEST id=q_2] ... tag: item2 ...  (next item)
 3. lattice_llm_respond id="q_2" response="feature"
-   → $res1: Array(2) ["bug", "feature"]  (final result)
+   → $llm_query_classify: Array(2) ["bug", "feature"]  (final result)
 
 LLM_BATCH WORKFLOW (same result, ONE suspension instead of N):
 1. lattice_query '(llm_batch RESULTS (lambda x (llm_query "tag: {item}" (item x))))'
    → [LLM_BATCH_REQUEST id=b_1 count=2] ... two prompts inlined ...
 2. lattice_llm_batch_respond id="b_1" responses=["bug","feature"]
-   → $res1: Array(2) ["bug", "feature"]  (final result in ONE round-trip)
+   → $llm_batch: Array(2) ["bug", "feature"]  (final result in ONE round-trip)
 
 LLM_QUERY + SYMBOLS (rate function complexity — one suspension per function):
 1. lattice_query '(list_symbols "function")'
-   → $res1: Array(10) [...]
+   → $list_symbols_function: Array(10) [...]
 2. lattice_query '(map RESULTS (lambda x (llm_query "Rate complexity of {name}: {body}" (name x) (body (get_symbol_body x)))))'
    → [LLM_QUERY_REQUEST id=q_1] ... Rate complexity of myFunction: function myFunction() { ... }
 3. lattice_llm_respond id="q_1" response="medium — has branching logic and error handling"
    → [LLM_QUERY_REQUEST id=q_2] ... (next function)
    ... repeat until all functions are rated ...
-   → $res2: Array(10) ["medium — ...", "low — ...", ...]  (final result)
+   → $map: Array(10) ["medium — ...", "low — ...", ...]  (final result)
 
 LLM_QUERY + CHUNKS (summarize document sections):
 1. lattice_query '(map (chunk_by_lines 100) (lambda c (llm_query "Summarize: {chunk}" (chunk c))))'
@@ -454,24 +454,24 @@ LLM_QUERY + CHUNKS (summarize document sections):
    ... repeat until all chunks are summarized ...
 
 EXAMPLE WORKFLOW:
-1. (grep "ERROR")                    → Returns: $res1: Array(500) [preview]
-2. (filter RESULTS (lambda x ...))   → Returns: $res2: Array(50) [preview]
+1. (grep "ERROR")                    → Returns: $grep_error: Array(500) [preview]
+2. (filter RESULTS (lambda x ...))   → Returns: $filter: Array(50) [preview]
 3. (count RESULTS)                   → Returns: 50
-4. lattice_expand $res2 limit=10     → See 10 actual error messages
+4. lattice_expand $filter limit=10   → See 10 actual error messages
 
 SYMBOL WORKFLOW:
-1. (list_symbols "function")         → Returns: $res1: Array(15) [preview]
+1. (list_symbols "function")         → Returns: $list_symbols_function: Array(15) [preview]
 2. (get_symbol_body "myFunction")    → Returns source code directly
-3. (find_references "myFunction")    → Returns: $res2: Array(8) [references]
+3. (find_references "myFunction")    → Returns: $find_references_myfunction: Array(8) [references]
 
 MARKDOWN WORKFLOW:
-1. (list_symbols)                       → Returns: $res1: Array(12) [# Intro, ## Setup, ...]
+1. (list_symbols)                       → Returns: $list_symbols: Array(12) [# Intro, ## Setup, ...]
 2. (grep "## Installation")             → Find specific section content
 
 VARIABLE BINDING:
 - RESULTS: Always points to the last array result (use in queries)
 - _1, _2, _3, ...: Results from turn N (use in queries for older results)
-- $res1, $res2, ...: Handle stubs (use ONLY with lattice_expand, NOT in queries)
+- $grep_error, $filter, ...: Handle stubs (use ONLY with lattice_expand, NOT in queries)
 
 EFFICIENCY: Minimize the number of separate tool calls by chaining queries.
 Build a pipeline (grep → filter → count) rather than making independent calls.
@@ -497,16 +497,16 @@ USE THIS WHEN:
 - You need to extract specific data for your response
 
 PARAMETERS:
-- handle: The handle reference (e.g., "$res1")
+- handle: The handle reference (e.g., "$grep_error")
 - limit: Max items to return (default: all) - use for large result sets
 - offset: Skip first N items (for pagination)
 - format: "full" (default) or "lines" (just line content with numbers)
 
 EXAMPLES:
-  lattice_expand $res1                    → Full data from handle
-  lattice_expand $res1 limit=10           → First 10 items only
-  lattice_expand $res1 offset=10 limit=10 → Items 11-20 (pagination)
-  lattice_expand $res1 format=lines       → "[1] line content..." format
+  lattice_expand $grep_error                    → Full data from handle
+  lattice_expand $grep_error limit=10           → First 10 items only
+  lattice_expand $grep_error offset=10 limit=10 → Items 11-20 (pagination)
+  lattice_expand $grep_error format=lines       → "[1] line content..." format
 
 TIP: Start with a small limit to preview, then expand more if needed.`,
     inputSchema: {
@@ -514,7 +514,7 @@ TIP: Start with a small limit to preview, then expand more if needed.`,
       properties: {
         handle: {
           type: "string",
-          description: 'Handle reference to expand (e.g., "$res1")',
+          description: 'Handle reference to expand (e.g., "$grep_error")',
         },
         limit: {
           type: "number",
@@ -559,9 +559,9 @@ TIP: Start with a small limit to preview, then expand more if needed.`,
     description: `Show current handle bindings.
 
 Returns all active handles with their stubs:
-  $res1: Array(500) [preview of first item...]
-  $res2: Array(50) [preview...]
-  RESULTS: -> $res2
+  $grep_error: Array(500) [preview of first item...]
+  $filter: Array(50) [preview...]
+  RESULTS: -> $filter
 
 Use this to see what data you have available before deciding what to expand.`,
     inputSchema: {

--- a/src/persistence/checkpoint.ts
+++ b/src/persistence/checkpoint.ts
@@ -61,7 +61,7 @@ export class CheckpointManager {
 
     // Restore RESULTS binding (or clear stale RESULTS if checkpoint has none)
     const resultsHandle = bindings.get("RESULTS");
-    if (resultsHandle && /^\$res\d+$/.test(resultsHandle)) {
+    if (resultsHandle && /^\$[a-z0-9_]+$/.test(resultsHandle) && !resultsHandle.startsWith("$memo")) {
       // Verify handle still exists before restoring
       const handleData = this.registry.get(resultsHandle);
       if (handleData === null) {
@@ -124,9 +124,9 @@ export class CheckpointManager {
     const bindings = this.db.getCheckpoint(turn);
     if (!bindings) return null;
 
-    // Count handles in bindings
+    // Count non-memo handles in bindings
     const handleCount = Array.from(bindings.values()).filter(v =>
-      typeof v === "string" && v.startsWith("$res")
+      typeof v === "string" && v.startsWith("$") && !v.startsWith("$memo")
     ).length;
 
     const timestamp = this.db.getCheckpointTimestamp(turn) ?? Date.now();

--- a/src/persistence/handle-registry.ts
+++ b/src/persistence/handle-registry.ts
@@ -38,13 +38,16 @@ export class HandleRegistry {
   }
 
   /**
-   * Store an array of data and return a handle reference
+   * Store an array of data and return a handle reference.
+   *
+   * @param data    The array payload.
+   * @param command Optional Nucleus command for deriving a descriptive handle name.
    */
-  store(data: unknown[]): string {
+  store(data: unknown[], command?: string): string {
     while (this.db.handleCount() >= HandleRegistry.MAX_HANDLES) {
       this.evictOldest();
     }
-    return this.db.createHandle(data);
+    return this.db.createHandle(data, command);
   }
 
   /**

--- a/src/persistence/session-db.ts
+++ b/src/persistence/session-db.ts
@@ -23,9 +23,62 @@ export interface HandleMetadata {
   createdAt: number;
 }
 
+/**
+ * Derive a short descriptive slug from a Nucleus command string.
+ *
+ * Examples:
+ *   (grep "ERROR")              → "grep_error"
+ *   (bm25 "database timeout" 10) → "bm25_database_timeout"
+ *   (filter RESULTS (lambda …)) → "filter"
+ *   (list_symbols "function")   → "list_symbols_function"
+ *
+ * Returns "res" as a fallback when no command is provided or parseable.
+ */
+export function commandToSlug(command?: string): string {
+  if (!command) return "res";
+
+  // Extract the top-level command name: first word after "("
+  const cmdMatch = command.match(/\(\s*(\w+)/);
+  const cmdName = cmdMatch ? cmdMatch[1] : "";
+
+  // Extract the first quoted string argument
+  const strMatch = command.match(/"([^"]*)"/);
+  const firstArg = strMatch ? strMatch[1] : "";
+
+  let slug = cmdName;
+  if (firstArg) {
+    const argSlug = firstArg
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "_")
+      .replace(/^_|_$/g, "")
+      .slice(0, 20);
+    if (argSlug) {
+      slug += "_" + argSlug;
+    }
+  }
+
+  // Normalise to valid identifier chars
+  slug = slug
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "");
+
+  // Cap length so handle names stay compact
+  if (slug.length > 30) slug = slug.slice(0, 30).replace(/_$/, "");
+
+  // Prevent collision with the $memo namespace used by createMemoHandle
+  if (/^memo\d*$/.test(slug) || /^memo\d*_/.test(slug)) {
+    slug = "q_" + slug;
+  }
+
+  return slug || "res";
+}
+
 export class SessionDB {
   private db: Database.Database | null;
-  private handleCounter: number = 0;
+  /** Tracks usage count per slug base for collision disambiguation */
+  private slugCounts: Map<string, number> = new Map();
   private memoCounter: number = 0;
 
   constructor() {
@@ -280,9 +333,14 @@ export class SessionDB {
   }
 
   /**
-   * Create a handle for storing data array
+   * Create a handle for storing data array.
+   *
+   * @param data    The array payload to store.
+   * @param command Optional Nucleus command string used to derive a
+   *                descriptive handle name (e.g. `(grep "ERROR")` → `$grep_error`).
+   *                Falls back to `$res`, `$res_2`, … when omitted.
    */
-  createHandle(data: unknown[]): string {
+  createHandle(data: unknown[], command?: string): string {
     if (!this.db) throw new Error("Database not open");
 
     const MAX_HANDLE_ITEMS = 1_000_000;
@@ -290,11 +348,10 @@ export class SessionDB {
       data = data.slice(0, MAX_HANDLE_ITEMS);
     }
 
-    if (this.handleCounter >= Number.MAX_SAFE_INTEGER - 1) {
-      throw new Error("Handle counter overflow");
-    }
-    const nextId = this.handleCounter + 1;
-    const handle = `$res${nextId}`;
+    const slug = commandToSlug(command);
+    const count = (this.slugCounts.get(slug) ?? 0) + 1;
+    this.slugCounts.set(slug, count);
+    const handle = count === 1 ? `$${slug}` : `$${slug}_${count}`;
     const now = Date.now();
 
     // Insert handle metadata and data rows atomically in one transaction
@@ -320,7 +377,6 @@ export class SessionDB {
     });
 
     insertAll(data);
-    this.handleCounter = nextId;
     return handle;
   }
 
@@ -725,7 +781,7 @@ export class SessionDB {
       DELETE FROM checkpoints;
       DELETE FROM symbols;
     `);
-    // Don't reset handleCounter — preserves monotonicity and prevents
+    // Don't reset slugCounts — preserves uniqueness and prevents
     // handle name collisions with previously issued handles
   }
 

--- a/src/persistence/session-db.ts
+++ b/src/persistence/session-db.ts
@@ -79,7 +79,6 @@ export class SessionDB {
   private db: Database.Database | null;
   /** Tracks usage count per slug base for collision disambiguation */
   private slugCounts: Map<string, number> = new Map();
-  private memoCounter: number = 0;
 
   constructor() {
     // Create in-memory database
@@ -381,10 +380,15 @@ export class SessionDB {
   }
 
   /**
-   * Create a memo handle for storing arbitrary context
-   * Uses $memo prefix and "memo" type to distinguish from query result handles
+   * Create a memo handle for storing arbitrary context.
+   * Uses $memo prefix and "memo" type to distinguish from query result handles.
+   *
+   * @param data  The array payload to store.
+   * @param label Optional label used to derive a descriptive handle name
+   *              (e.g., "auth architecture" → `$memo_auth_architecture`).
+   *              Falls back to `$memo`, `$memo_2`, … when omitted.
    */
-  createMemoHandle(data: unknown[]): string {
+  createMemoHandle(data: unknown[], label?: string): string {
     if (!this.db) throw new Error("Database not open");
 
     const MAX_HANDLE_ITEMS = 1_000_000;
@@ -392,11 +396,22 @@ export class SessionDB {
       data = data.slice(0, MAX_HANDLE_ITEMS);
     }
 
-    if (this.memoCounter >= Number.MAX_SAFE_INTEGER - 1) {
-      throw new Error("Memo counter overflow");
+    // Derive slug from label, with "memo" prefix to stay in the memo namespace
+    let slug = "memo";
+    if (label) {
+      const labelSlug = label
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "_")
+        .replace(/^_|_$/g, "")
+        .slice(0, 24);
+      if (labelSlug) {
+        slug = "memo_" + labelSlug;
+      }
     }
-    const nextId = this.memoCounter + 1;
-    const handle = `$memo${nextId}`;
+
+    const count = (this.slugCounts.get(slug) ?? 0) + 1;
+    this.slugCounts.set(slug, count);
+    const handle = count === 1 ? `$${slug}` : `$${slug}_${count}`;
     const now = Date.now();
 
     const insertHandle = this.db.prepare(`
@@ -420,7 +435,6 @@ export class SessionDB {
     });
 
     insertAll(data);
-    this.memoCounter = nextId;
     return handle;
   }
 

--- a/src/persistence/session-db.ts
+++ b/src/persistence/session-db.ts
@@ -332,6 +332,30 @@ export class SessionDB {
   }
 
   /**
+   * Generate a unique handle name for a slug.
+   *
+   * Increments the per-slug counter and checks the candidate name against
+   * existing handles in SQLite. If a cross-slug collision is detected
+   * (e.g. slug "grep_error" count=2 produces "$grep_error_2" which was
+   * already taken by slug "grep_error_2" count=1), keeps incrementing
+   * until a free name is found.
+   */
+  private nextUniqueHandle(slug: string): string {
+    const checkExists = this.db!.prepare("SELECT 1 FROM handles WHERE handle = ?");
+    const MAX_ATTEMPTS = 1000;
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      const count = (this.slugCounts.get(slug) ?? 0) + 1;
+      this.slugCounts.set(slug, count);
+      const candidate = count === 1 ? `$${slug}` : `$${slug}_${count}`;
+      if (!checkExists.get(candidate)) {
+        return candidate;
+      }
+    }
+    // Fallback: should never happen in practice
+    return `$${slug}_${Date.now()}`;
+  }
+
+  /**
    * Create a handle for storing data array.
    *
    * @param data    The array payload to store.
@@ -348,9 +372,7 @@ export class SessionDB {
     }
 
     const slug = commandToSlug(command);
-    const count = (this.slugCounts.get(slug) ?? 0) + 1;
-    this.slugCounts.set(slug, count);
-    const handle = count === 1 ? `$${slug}` : `$${slug}_${count}`;
+    const handle = this.nextUniqueHandle(slug);
     const now = Date.now();
 
     // Insert handle metadata and data rows atomically in one transaction
@@ -409,9 +431,7 @@ export class SessionDB {
       }
     }
 
-    const count = (this.slugCounts.get(slug) ?? 0) + 1;
-    this.slugCounts.set(slug, count);
-    const handle = count === 1 ? `$${slug}` : `$${slug}_${count}`;
+    const handle = this.nextUniqueHandle(slug);
     const now = Date.now();
 
     const insertHandle = this.db.prepare(`

--- a/src/tool/ai-tools.ts
+++ b/src/tool/ai-tools.ts
@@ -203,7 +203,7 @@ export function createLatticeTools(): LatticeToolSet {
       properties: {
         handle: {
           type: "string",
-          description: 'Handle reference, e.g., "$res1"',
+          description: 'Handle reference, e.g., "$grep_error"',
         },
         limit: {
           type: "number",

--- a/tests/audit67.test.ts
+++ b/tests/audit67.test.ts
@@ -89,15 +89,15 @@ describe("Audit #67", () => {
   });
 
   // =========================================================================
-  // #8 MEDIUM — session-db.ts handleCounter no MAX_SAFE_INTEGER check
+  // #8 MEDIUM — session-db.ts createHandle uses slug-based naming
   // =========================================================================
-  describe("#8 — createHandle should guard against handleCounter overflow", () => {
-    it("should check handleCounter against MAX_SAFE_INTEGER", () => {
+  describe("#8 — createHandle should use slug-based collision tracking", () => {
+    it("should use slugCounts map for handle name generation", () => {
       const source = readFileSync("src/persistence/session-db.ts", "utf-8");
       const fnStart = source.indexOf("createHandle(");
       expect(fnStart).toBeGreaterThan(-1);
       const block = source.slice(fnStart, fnStart + 400);
-      expect(block).toMatch(/MAX_SAFE_INTEGER|handleCounter\s*>=?\s*Number/i);
+      expect(block).toMatch(/slugCounts|commandToSlug/i);
     });
   });
 

--- a/tests/engine/handle-session.test.ts
+++ b/tests/engine/handle-session.test.ts
@@ -44,7 +44,7 @@ DEBUG: Cache hit ratio: 95%`;
       const result = await session.execute('(grep "ERROR")');
 
       expect(result.success).toBe(true);
-      expect(result.handle).toMatch(/^\$res\d+$/);
+      expect(result.handle).toMatch(/^\$[a-z0-9_]+$/);
       expect(result.stub).toContain("Array(3)");
       expect(result.value).toBeUndefined(); // Full data not returned
     });
@@ -82,6 +82,40 @@ DEBUG: Cache hit ratio: 95%`;
       // Count filtered results
       const count = await session.execute("(count RESULTS)");
       expect(count.value).toBe(2); // "Connection timeout" and "Request timeout"
+    });
+
+    it("should produce descriptive handle names from commands", async () => {
+      const grep = await session.execute('(grep "ERROR")');
+      expect(grep.handle).toBe("$grep_error");
+
+      const info = await session.execute('(grep "INFO")');
+      expect(info.handle).toBe("$grep_info");
+    });
+
+    it("should disambiguate repeated commands with numeric suffix", async () => {
+      const r1 = await session.execute('(grep "ERROR")');
+      const r2 = await session.execute('(grep "ERROR")');
+      expect(r1.handle).toBe("$grep_error");
+      expect(r2.handle).toBe("$grep_error_2");
+    });
+
+    it("should allow expanding by descriptive handle name", async () => {
+      await session.execute('(grep "ERROR")');
+      const expanded = session.expand("$grep_error");
+      expect(expanded.success).toBe(true);
+      expect(expanded.data).toHaveLength(3);
+    });
+
+    it("should point RESULTS to the latest descriptive handle after chaining", async () => {
+      await session.execute('(grep "ERROR")');
+      await session.execute('(filter RESULTS (lambda x (match x "timeout" 0)))');
+
+      const bindings = session.getBindings();
+      // RESULTS should point to the filter handle, not grep
+      expect(bindings["RESULTS"]).toContain("$filter_timeout");
+      // Both handles should be present
+      expect(bindings["$grep_error"]).toBeDefined();
+      expect(bindings["$filter_timeout"]).toBeDefined();
     });
   });
 
@@ -146,9 +180,9 @@ DEBUG: Cache hit ratio: 95%`;
 
       const bindings = session.getBindings();
 
-      expect(Object.keys(bindings)).toContain("$res1");
-      expect(Object.keys(bindings)).toContain("$res2");
-      expect(bindings["$res1"]).toContain("Array");
+      expect(Object.keys(bindings)).toContain("$grep_error");
+      expect(Object.keys(bindings)).toContain("$grep_info");
+      expect(bindings["$grep_error"]).toContain("Array");
     });
 
     it("should indicate current RESULTS binding", async () => {
@@ -156,7 +190,7 @@ DEBUG: Cache hit ratio: 95%`;
 
       const bindings = session.getBindings();
 
-      expect(bindings["RESULTS"]).toContain("$res1");
+      expect(bindings["RESULTS"]).toContain("$grep_error");
     });
   });
 
@@ -169,7 +203,7 @@ DEBUG: Cache hit ratio: 95%`;
 
     it("should preview first N items", async () => {
       const bindings = session.getBindings();
-      const handle = Object.keys(bindings).find((k) => k.startsWith("$res"))!;
+      const handle = Object.keys(bindings).find((k) => k.startsWith("$") && !k.startsWith("$memo") && k !== "RESULTS")!;
 
       const preview = session.preview(handle, 3);
 
@@ -178,7 +212,7 @@ DEBUG: Cache hit ratio: 95%`;
 
     it("should sample random N items", async () => {
       const bindings = session.getBindings();
-      const handle = Object.keys(bindings).find((k) => k.startsWith("$res"))!;
+      const handle = Object.keys(bindings).find((k) => k.startsWith("$") && !k.startsWith("$memo") && k !== "RESULTS")!;
 
       const sample = session.sample(handle, 3);
 
@@ -508,7 +542,7 @@ describe("HandleSession — llmQuery option (MCP sampling bridge)", () => {
       );
       expect(result.success).toBe(true);
       // Map result is an array handle
-      expect(result.handle).toMatch(/^\$res\d+$/);
+      expect(result.handle).toMatch(/^\$[a-z0-9_]+$/);
       expect(calls).toHaveLength(3);
     } finally {
       session.close();

--- a/tests/handle-eviction.test.ts
+++ b/tests/handle-eviction.test.ts
@@ -39,15 +39,15 @@ describe("Handle eviction", () => {
     const r2 = await session.execute('(grep "LINE_01")');
     const r3 = await session.execute('(grep "LINE_02")');
 
-    expect(r1.handle).toBe("$res1");
-    expect(r2.handle).toBe("$res2");
-    expect(r3.handle).toBe("$res3");
+    expect(r1.handle).toBe("$grep_line_00");
+    expect(r2.handle).toBe("$grep_line_01");
+    expect(r3.handle).toBe("$grep_line_02");
 
     // All handles should still be accessible
     const bindings = session.getBindings();
-    expect(bindings["$res1"]).toBeDefined();
-    expect(bindings["$res2"]).toBeDefined();
-    expect(bindings["$res3"]).toBeDefined();
+    expect(bindings["$grep_line_00"]).toBeDefined();
+    expect(bindings["$grep_line_01"]).toBeDefined();
+    expect(bindings["$grep_line_02"]).toBeDefined();
   });
 
   it("should not evict when at exactly MAX_HANDLES - 1", async () => {

--- a/tests/lattice-mcp-handles.test.ts
+++ b/tests/lattice-mcp-handles.test.ts
@@ -56,7 +56,7 @@ describe("Lattice MCP Handle-Based Results", () => {
       const result = await session.execute('(grep "ERROR")');
 
       expect(result.success).toBe(true);
-      expect(result.handle).toMatch(/^\$res\d+$/);
+      expect(result.handle).toMatch(/^\$[a-z0-9_]+$/);
       expect(result.stub).toBeDefined();
       expect(result.stub).toContain("Array(3)");
       // Full data should NOT be in the result
@@ -86,9 +86,9 @@ describe("Lattice MCP Handle-Based Results", () => {
 
       const bindings = session.getBindings();
 
-      expect(bindings["$res1"]).toContain("Array(3)"); // ERRORs
-      expect(bindings["$res2"]).toContain("Array(3)"); // INFOs
-      expect(bindings["$res3"]).toContain("Array(1)"); // WARNs
+      expect(bindings["$grep_error"]).toContain("Array(3)"); // ERRORs
+      expect(bindings["$grep_info"]).toContain("Array(3)"); // INFOs
+      expect(bindings["$grep_warn"]).toContain("Array(1)"); // WARNs
     });
   });
 
@@ -168,10 +168,11 @@ describe("Lattice MCP Handle-Based Results", () => {
 
       // Get bindings to see what we have
       const bindings = session.getBindings();
-      expect(bindings["RESULTS"]).toContain("$res1");
+      const resHandle = Object.keys(bindings).find(k => k.startsWith("$") && !k.startsWith("$memo") && k !== "RESULTS")!;
+      expect(bindings["RESULTS"]).toContain(resHandle);
 
       // Preview to see first few items
-      const preview = session.preview("$res1", 3);
+      const preview = session.preview(resHandle, 3);
       expect(preview).toHaveLength(3);
 
       // Now filter based on what we saw

--- a/tests/memo.test.ts
+++ b/tests/memo.test.ts
@@ -109,7 +109,7 @@ describe("Memory Pad (Memo)", () => {
 
       const bindings = session.getBindings();
       expect(bindings["$memo1"]).toContain("error analysis");
-      expect(bindings["$res1"]).toContain("Array");
+      expect(bindings["$grep_error"]).toContain("Array");
 
       fs.rmSync(tempDir, { recursive: true });
     });
@@ -135,13 +135,13 @@ describe("Memory Pad (Memo)", () => {
       expect(expanded.data).toEqual(["Important context"]);
 
       // Query handle should be gone
-      const queryExpanded = session.expand("$res1");
+      const queryExpanded = session.expand("$grep_content");
       expect(queryExpanded.success).toBe(false);
 
       // Memo label should still be in bindings
       const bindings = session.getBindings();
       expect(bindings["$memo1"]).toContain("must persist");
-      expect(bindings["$res1"]).toBeUndefined();
+      expect(bindings["$grep_content"]).toBeUndefined();
 
       fs.rmSync(tempDir, { recursive: true });
     });

--- a/tests/memo.test.ts
+++ b/tests/memo.test.ts
@@ -3,7 +3,7 @@
  *
  * Validates:
  * - Storing memos without a loaded document
- * - Memo handles use $memo prefix
+ * - Memo handles use $memo prefix with descriptive names from labels
  * - Memos persist across document loads
  * - Memos are expandable via the same expand() API
  * - Memo labels appear in bindings
@@ -27,12 +27,12 @@ describe("Memory Pad (Memo)", () => {
   });
 
   describe("basic memo storage", () => {
-    it("should store a memo and return a handle stub", async () => {
+    it("should store a memo and return a descriptive handle stub", async () => {
       const result = session.memo("Hello, world!\nThis is a test.", "greeting");
 
       expect(result.success).toBe(true);
-      expect(result.handle).toBe("$memo1");
-      expect(result.stub).toContain("$memo1");
+      expect(result.handle).toBe("$memo_greeting");
+      expect(result.stub).toContain("$memo_greeting");
       expect(result.stub).toContain("greeting");
       expect(result.stub).toContain("2 lines");
     });
@@ -41,17 +41,25 @@ describe("Memory Pad (Memo)", () => {
       // No loadFile/loadContent called
       const result = session.memo("Some context to remember", "context note");
       expect(result.success).toBe(true);
-      expect(result.handle).toBe("$memo1");
+      expect(result.handle).toBe("$memo_context_note");
     });
 
-    it("should assign incrementing memo handles", async () => {
+    it("should assign descriptive memo handles from labels", async () => {
       const r1 = session.memo("First memo", "first");
       const r2 = session.memo("Second memo", "second");
       const r3 = session.memo("Third memo", "third");
 
-      expect(r1.handle).toBe("$memo1");
-      expect(r2.handle).toBe("$memo2");
-      expect(r3.handle).toBe("$memo3");
+      expect(r1.handle).toBe("$memo_first");
+      expect(r2.handle).toBe("$memo_second");
+      expect(r3.handle).toBe("$memo_third");
+    });
+
+    it("should disambiguate repeated labels with numeric suffix", async () => {
+      const r1 = session.memo("Draft 1", "notes");
+      const r2 = session.memo("Draft 2", "notes");
+
+      expect(r1.handle).toBe("$memo_notes");
+      expect(r2.handle).toBe("$memo_notes_2");
     });
 
     it("should report token savings", async () => {
@@ -68,9 +76,9 @@ describe("Memory Pad (Memo)", () => {
   describe("memo expansion", () => {
     it("should expand memo content via expand()", async () => {
       const content = "Line 1\nLine 2\nLine 3";
-      session.memo(content, "test memo");
+      const result = session.memo(content, "test memo");
 
-      const expanded = session.expand("$memo1");
+      const expanded = session.expand(result.handle!);
       expect(expanded.success).toBe(true);
       expect(expanded.total).toBe(3);
       expect(expanded.data).toEqual(["Line 1", "Line 2", "Line 3"]);
@@ -78,13 +86,13 @@ describe("Memory Pad (Memo)", () => {
 
     it("should support limit and offset on memo expansion", async () => {
       const content = Array.from({ length: 20 }, (_, i) => `Line ${i + 1}`).join("\n");
-      session.memo(content, "numbered lines");
+      const result = session.memo(content, "numbered lines");
 
-      const page1 = session.expand("$memo1", { limit: 5, offset: 0 });
+      const page1 = session.expand(result.handle!, { limit: 5, offset: 0 });
       expect(page1.data).toHaveLength(5);
       expect(page1.data![0]).toBe("Line 1");
 
-      const page2 = session.expand("$memo1", { limit: 5, offset: 5 });
+      const page2 = session.expand(result.handle!, { limit: 5, offset: 5 });
       expect(page2.data).toHaveLength(5);
       expect(page2.data![0]).toBe("Line 6");
     });
@@ -92,10 +100,10 @@ describe("Memory Pad (Memo)", () => {
 
   describe("memo labels in bindings", () => {
     it("should show memo labels in getBindings()", async () => {
-      session.memo("Some architecture notes", "arch overview");
+      const result = session.memo("Some architecture notes", "arch overview");
 
       const bindings = session.getBindings();
-      expect(bindings["$memo1"]).toContain("arch overview");
+      expect(bindings[result.handle!]).toContain("arch overview");
     });
 
     it("should show both memo and query handles in bindings", async () => {
@@ -104,11 +112,11 @@ describe("Memory Pad (Memo)", () => {
       fs.writeFileSync(testFile, "ERROR: something failed\nINFO: all good");
 
       await session.loadFile(testFile);
-      session.memo("Analysis summary", "error analysis");
+      const memoResult = session.memo("Analysis summary", "error analysis");
       await session.execute('(grep "ERROR")');
 
       const bindings = session.getBindings();
-      expect(bindings["$memo1"]).toContain("error analysis");
+      expect(bindings[memoResult.handle!]).toContain("error analysis");
       expect(bindings["$grep_error"]).toContain("Array");
 
       fs.rmSync(tempDir, { recursive: true });
@@ -117,7 +125,7 @@ describe("Memory Pad (Memo)", () => {
 
   describe("memo persistence across document loads", () => {
     it("should preserve memos when clearQueryHandles is called", async () => {
-      session.memo("Important context", "must persist");
+      const memoResult = session.memo("Important context", "must persist");
 
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "memo-test-"));
       const testFile = path.join(tempDir, "test.txt");
@@ -130,7 +138,7 @@ describe("Memory Pad (Memo)", () => {
       session.clearQueryHandles();
 
       // Memo should still be expandable
-      const expanded = session.expand("$memo1");
+      const expanded = session.expand(memoResult.handle!);
       expect(expanded.success).toBe(true);
       expect(expanded.data).toEqual(["Important context"]);
 
@@ -140,7 +148,7 @@ describe("Memory Pad (Memo)", () => {
 
       // Memo label should still be in bindings
       const bindings = session.getBindings();
-      expect(bindings["$memo1"]).toContain("must persist");
+      expect(bindings[memoResult.handle!]).toContain("must persist");
       expect(bindings["$grep_content"]).toBeUndefined();
 
       fs.rmSync(tempDir, { recursive: true });
@@ -149,43 +157,43 @@ describe("Memory Pad (Memo)", () => {
 
   describe("getMemoLabel", () => {
     it("should return label for memo handles", async () => {
-      session.memo("Content", "my label");
-      expect(session.getMemoLabel("$memo1")).toBe("my label");
+      const result = session.memo("Content", "my label");
+      expect(session.getMemoLabel(result.handle!)).toBe("my label");
     });
 
     it("should return null for non-memo handles", async () => {
-      expect(session.getMemoLabel("$res1")).toBeNull();
-      expect(session.getMemoLabel("$memo999")).toBeNull();
+      expect(session.getMemoLabel("$res")).toBeNull();
+      expect(session.getMemoLabel("$memo_nonexistent")).toBeNull();
     });
   });
 
   describe("memo deletion", () => {
     it("should delete a memo by handle", async () => {
-      session.memo("Content A", "memo a");
-      session.memo("Content B", "memo b");
+      const r1 = session.memo("Content A", "memo a");
+      const r2 = session.memo("Content B", "memo b");
 
-      const deleted = session.deleteMemo("$memo1");
+      const deleted = session.deleteMemo(r1.handle!);
       expect(deleted).toBe(true);
 
-      const expanded = session.expand("$memo1");
+      const expanded = session.expand(r1.handle!);
       expect(expanded.success).toBe(false);
 
-      // $memo2 should still work
-      const memo2 = session.expand("$memo2");
+      // Second memo should still work
+      const memo2 = session.expand(r2.handle!);
       expect(memo2.success).toBe(true);
     });
 
     it("should return false for non-memo handles", async () => {
-      expect(session.deleteMemo("$res1")).toBe(false);
-      expect(session.deleteMemo("$memo999")).toBe(false);
+      expect(session.deleteMemo("$res")).toBe(false);
+      expect(session.deleteMemo("$memo_nonexistent")).toBe(false);
     });
 
     it("should update byte tracking on delete", async () => {
-      session.memo("x".repeat(1000), "big memo");
+      const result = session.memo("x".repeat(1000), "big memo");
       const before = session.getMemoStats();
       expect(before.totalBytes).toBe(1000);
 
-      session.deleteMemo("$memo1");
+      session.deleteMemo(result.handle!);
       const after = session.getMemoStats();
       expect(after.totalBytes).toBe(0);
       expect(after.count).toBe(0);
@@ -195,9 +203,11 @@ describe("Memory Pad (Memo)", () => {
   describe("memo eviction", () => {
     it("should evict oldest memo when count limit exceeded", async () => {
       const limit = HandleSession.MAX_MEMOS;
-      // Fill to the limit
+      // Fill to the limit — use unique labels so each gets a unique handle
+      const handles: string[] = [];
       for (let i = 0; i < limit; i++) {
-        session.memo(`Memo ${i}`, `memo-${i}`);
+        const r = session.memo(`Memo ${i}`, `memo-${i}`);
+        handles.push(r.handle!);
       }
       expect(session.getMemoStats().count).toBe(limit);
 
@@ -206,12 +216,12 @@ describe("Memory Pad (Memo)", () => {
       const stats = session.getMemoStats();
       expect(stats.count).toBe(limit);
 
-      // $memo1 should be evicted
-      const oldest = session.expand("$memo1");
+      // Oldest (first created) should be evicted
+      const oldest = session.expand(handles[0]);
       expect(oldest.success).toBe(false);
 
       // Latest should exist
-      const latest = session.expand(`$memo${limit + 1}`);
+      const latest = session.expand("$memo_overflow");
       expect(latest.success).toBe(true);
     });
 
@@ -220,17 +230,17 @@ describe("Memory Pad (Memo)", () => {
       const chunkSize = Math.floor(maxBytes / 3);
 
       // Store 3 memos that together fill the budget
-      session.memo("x".repeat(chunkSize), "chunk-1");
+      const r1 = session.memo("x".repeat(chunkSize), "chunk-1");
       session.memo("x".repeat(chunkSize), "chunk-2");
       session.memo("x".repeat(chunkSize), "chunk-3");
 
       // Adding another should evict the oldest to make room
-      session.memo("x".repeat(chunkSize), "chunk-4");
+      const r4 = session.memo("x".repeat(chunkSize), "chunk-4");
 
-      // $memo1 should be evicted
-      expect(session.expand("$memo1").success).toBe(false);
-      // $memo4 should exist
-      expect(session.expand("$memo4").success).toBe(true);
+      // First memo should be evicted
+      expect(session.expand(r1.handle!).success).toBe(false);
+      // Fourth memo should exist
+      expect(session.expand(r4.handle!).success).toBe(true);
       // Total bytes should be within budget
       expect(session.getMemoStats().totalBytes).toBeLessThanOrEqual(maxBytes);
     });
@@ -256,30 +266,33 @@ describe("Memory Pad (Memo)", () => {
     });
   });
 
-  describe("eviction order is numeric not alphabetic", () => {
-    it("should evict $memo2 before $memo10", async () => {
-      // Create 12 memos so we have handles crossing the single/double digit boundary
+  describe("eviction order is creation order", () => {
+    it("should evict oldest by creation time, not alphabetically", async () => {
+      // Create 12 memos
+      const handles: string[] = [];
       for (let i = 0; i < 12; i++) {
-        session.memo(`Memo ${i + 1}`, `memo-${i + 1}`);
+        const r = session.memo(`Memo ${i + 1}`, `memo-${i + 1}`);
+        handles.push(r.handle!);
       }
 
-      // Delete $memo1 manually to set up the interesting case
-      session.deleteMemo("$memo1");
-      // Now oldest is $memo2, not $memo10 (alphabetically $memo10 < $memo2)
+      // Delete the first manually to set up the interesting case
+      session.deleteMemo(handles[0]);
+      // Now second created is the oldest remaining
 
       // Fill to the limit
       const limit = HandleSession.MAX_MEMOS;
-      const remaining = limit - 11; // 11 memos left after deleting $memo1
+      const remaining = limit - 11; // 11 memos left after deleting first
       for (let i = 0; i < remaining; i++) {
         session.memo(`Filler ${i}`, `filler-${i}`);
       }
       expect(session.getMemoStats().count).toBe(limit);
 
-      // One more triggers eviction — should evict $memo2 (numeric oldest), not $memo10
-      session.memo("overflow", "overflow");
+      // One more triggers eviction — should evict second created (oldest remaining)
+      session.memo("overflow", "overflow-final");
       expect(session.getMemoStats().count).toBe(limit);
-      expect(session.expand("$memo2").success).toBe(false);
-      expect(session.expand("$memo10").success).toBe(true);
+      expect(session.expand(handles[1]).success).toBe(false);
+      // Later memos should survive
+      expect(session.expand(handles[9]).success).toBe(true);
     });
   });
 

--- a/tests/persistence/handle-registry.test.ts
+++ b/tests/persistence/handle-registry.test.ts
@@ -22,15 +22,23 @@ describe("HandleRegistry", () => {
         { line: "Error 2", lineNum: 2 },
       ];
       const handle = registry.store(data);
-      expect(handle).toMatch(/^\$res\d+$/);
+      expect(handle).toMatch(/^\$[a-z0-9_]+$/);
     });
 
-    it("should generate incrementing handles", () => {
+    it("should generate descriptive handles from commands", () => {
+      const h1 = registry.store([{ a: 1 }], '(grep "ERROR")');
+      const h2 = registry.store([{ b: 2 }], '(bm25 "timeout")');
+
+      expect(h1).toBe("$grep_error");
+      expect(h2).toBe("$bm25_timeout");
+    });
+
+    it("should disambiguate repeated commands", () => {
       const h1 = registry.store([{ a: 1 }]);
       const h2 = registry.store([{ b: 2 }]);
 
-      expect(h1).toBe("$res1");
-      expect(h2).toBe("$res2");
+      expect(h1).toBe("$res");
+      expect(h2).toBe("$res_2");
     });
 
     it("should retrieve full data by handle", () => {
@@ -60,7 +68,7 @@ describe("HandleRegistry", () => {
       const handle = registry.store(data);
       const stub = registry.getStub(handle);
 
-      expect(stub).toContain("$res1");
+      expect(stub).toContain(handle);
       expect(stub).toContain("Array(3)");
       expect(stub).toContain("Error 1");  // Preview of first item
     });
@@ -112,7 +120,7 @@ describe("HandleRegistry", () => {
       registry.store(data);
 
       const context = registry.buildContext();
-      expect(context).toContain("$res1:");
+      expect(context).toContain("$res:");
     });
   });
 
@@ -144,38 +152,36 @@ describe("HandleRegistry", () => {
       expect(registry.get(handle)).toBeNull();
     });
 
-    it("should allow reuse of deleted handle numbers", () => {
-      // This tests that handles are not reused (they increment forever)
+    it("should not reuse slug counts after deletion", () => {
       const h1 = registry.store([{ a: 1 }]);
       registry.delete(h1);
       const h2 = registry.store([{ b: 2 }]);
 
-      // Handle counter should continue incrementing
-      expect(h2).toBe("$res2");
+      // Slug counter should continue incrementing
+      expect(h1).toBe("$res");
+      expect(h2).toBe("$res_2");
     });
   });
 
   describe("eviction", () => {
-    it("should evict the oldest non-memo handle (creation order, not alphabetical)", () => {
-      // Create 10 handles so we get $res1..$res10
-      // Delete $res1 so the oldest remaining is $res2
-      // Alphabetical order would put $res10 before $res2, but creation
-      // order should evict $res2 first (the actually oldest remaining handle).
+    it("should evict the oldest non-memo handle (creation order)", () => {
+      // Create 10 handles with distinct commands so they get unique names
+      const handles: string[] = [];
       for (let i = 1; i <= 10; i++) {
-        registry.store([{ val: i }]);
+        handles.push(registry.store([{ val: i }], `(grep "pattern_${i}")`));
       }
 
-      // Delete $res1 — now $res2 is the oldest remaining
-      registry.delete("$res1");
+      // Delete the first handle — now the second is the oldest remaining
+      registry.delete(handles[0]);
       expect(registry.listHandles()).toHaveLength(9);
 
       registry.evictOldest();
 
-      // $res2 should be evicted (oldest by creation), NOT $res10
+      // Second handle should be evicted (oldest by creation)
       const remaining = registry.listHandles();
-      expect(remaining).not.toContain("$res2");
-      expect(remaining).toContain("$res10");
-      expect(remaining).toContain("$res3");
+      expect(remaining).not.toContain(handles[1]);
+      expect(remaining).toContain(handles[9]); // last created
+      expect(remaining).toContain(handles[2]); // third created
       expect(remaining).toHaveLength(8);
     });
 
@@ -204,52 +210,53 @@ describe("HandleRegistry", () => {
 
   describe("handle inspection", () => {
     it("should list all active handles", () => {
-      registry.store([{ a: 1 }]);
-      registry.store([{ b: 2 }]);
-      registry.store([{ c: 3 }]);
+      const h1 = registry.store([{ a: 1 }], '(grep "a")');
+      const h2 = registry.store([{ b: 2 }], '(grep "b")');
+      const h3 = registry.store([{ c: 3 }], '(grep "c")');
 
       const handles = registry.listHandles();
       expect(handles).toHaveLength(3);
-      expect(handles).toContain("$res1");
-      expect(handles).toContain("$res2");
-      expect(handles).toContain("$res3");
+      expect(handles).toContain(h1);
+      expect(handles).toContain(h2);
+      expect(handles).toContain(h3);
     });
 
     it("should find handles after gaps from deletion", () => {
-      registry.store([{ a: 1 }]);  // $res1
-      registry.store([{ b: 2 }]);  // $res2
-      registry.store([{ c: 3 }]);  // $res3
-      registry.store([{ d: 4 }]);  // $res4
-      registry.store([{ e: 5 }]);  // $res5
+      const h1 = registry.store([{ a: 1 }], '(grep "a")');
+      const h2 = registry.store([{ b: 2 }], '(grep "b")');
+      const h3 = registry.store([{ c: 3 }], '(grep "c")');
+      const h4 = registry.store([{ d: 4 }], '(grep "d")');
+      const h5 = registry.store([{ e: 5 }], '(grep "e")');
 
       // Delete handle 3, creating a gap
-      registry.delete("$res3");
+      registry.delete(h3);
 
       const handles = registry.listHandles();
       expect(handles).toHaveLength(4);
-      expect(handles).toContain("$res1");
-      expect(handles).toContain("$res2");
-      expect(handles).toContain("$res4");
-      expect(handles).toContain("$res5");
-      expect(handles).not.toContain("$res3");
+      expect(handles).toContain(h1);
+      expect(handles).toContain(h2);
+      expect(handles).toContain(h4);
+      expect(handles).toContain(h5);
+      expect(handles).not.toContain(h3);
     });
 
     it("should find handles after many deletions at start", () => {
-      // Create 15 handles
+      // Create 15 handles with unique commands
+      const all: string[] = [];
       for (let i = 0; i < 15; i++) {
-        registry.store([{ val: i }]);
+        all.push(registry.store([{ val: i }], `(grep "item_${i}")`));
       }
 
       // Delete first 12
-      for (let i = 1; i <= 12; i++) {
-        registry.delete(`$res${i}`);
+      for (let i = 0; i < 12; i++) {
+        registry.delete(all[i]);
       }
 
       const handles = registry.listHandles();
       expect(handles).toHaveLength(3);
-      expect(handles).toContain("$res13");
-      expect(handles).toContain("$res14");
-      expect(handles).toContain("$res15");
+      expect(handles).toContain(all[12]);
+      expect(handles).toContain(all[13]);
+      expect(handles).toContain(all[14]);
     });
 
     it("should get handle count info", () => {

--- a/tests/persistence/integration.test.ts
+++ b/tests/persistence/integration.test.ts
@@ -47,7 +47,7 @@ Sales Q4: $2,400,000`;
       // Step 2: Store results as handle
       const handle = registry.store(searchResults);
       registry.setResults(handle);
-      expect(handle).toBe("$res1");
+      expect(handle).toMatch(/^\$/);
 
       // Step 3: Filter for specific error type
       const filteredHandle = ops.filter(handle, "item.content.includes('timeout')");
@@ -59,8 +59,8 @@ Sales Q4: $2,400,000`;
 
       // Context should show stubs, not full data
       const context = registry.buildContext();
-      expect(context).toContain("$res1");
-      expect(context).toContain("$res2");
+      expect(context).toContain(handle);
+      expect(context).toContain(filteredHandle);
       expect(context.length).toBeLessThan(500);
     });
 
@@ -127,16 +127,16 @@ Sales Q4: $2,400,000`;
     it("should handle multi-turn session", () => {
       // Turn 1: Search
       const results1 = search.search("ERROR");
-      registry.store(results1);
+      const h1 = registry.store(results1);
       checkpoints.save(1);
 
       // Turn 2: Filter
-      const h2 = ops.filter("$res1", "item.content.includes('timeout')");
+      const h2 = ops.filter(h1, "item.content.includes('timeout')");
       registry.setResults(h2);
       checkpoints.save(2);
 
       // Turn 3: Get different errors
-      const h3 = ops.filter("$res1", "item.content.includes('Authentication')");
+      const h3 = ops.filter(h1, "item.content.includes('Authentication')");
       registry.setResults(h3);
       checkpoints.save(3);
 

--- a/tests/persistence/session-db.test.ts
+++ b/tests/persistence/session-db.test.ts
@@ -338,6 +338,36 @@ Line 5: Final line`;
       // filter picks up "test" from the nested match string
       expect(h3).toBe("$filter_test");
     });
+
+    it("should not collide when a suffixed name matches another slug's base", () => {
+      // Slug "grep_error_2" (first use) → $grep_error_2
+      // Slug "grep_error" (second use) → would naively produce $grep_error_2
+      // Must detect the collision and skip to a safe name
+      db.loadDocument("test content");
+      const h1 = db.createHandle(["a"], '(grep "error_2")');
+      const h2 = db.createHandle(["b"], '(grep "error")');
+      const h3 = db.createHandle(["c"], '(grep "error")');
+
+      expect(h1).toBe("$grep_error_2");
+      // h2 must NOT be "$grep_error_2" — that's taken by h1
+      expect(h2).toBe("$grep_error");
+      // h3 is the second "grep_error" slug — but _2 is taken, so must skip to _3
+      expect(h3).not.toBe("$grep_error_2");
+      // All three must be unique
+      const names = new Set([h1, h2, h3]);
+      expect(names.size).toBe(3);
+    });
+
+    it("should not collide across query and memo handles", () => {
+      db.loadDocument("test content");
+      const h1 = db.createHandle(["a"], '(grep "error")');
+      const m1 = db.createMemoHandle(["b"], "grep error");
+
+      expect(h1).not.toBe(m1);
+      // Both should be valid
+      expect(db.getHandleMetadata(h1)).not.toBeNull();
+      expect(db.getHandleMetadata(m1)).not.toBeNull();
+    });
   });
 
   describe("foreign key cascade", () => {

--- a/tests/persistence/session-db.test.ts
+++ b/tests/persistence/session-db.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { SessionDB } from "../../src/persistence/session-db.js";
+import { SessionDB, commandToSlug } from "../../src/persistence/session-db.js";
 
 describe("SessionDB", () => {
   let db: SessionDB;
@@ -80,7 +80,13 @@ Line 5: Final line`;
         { line: "Error 2", lineNum: 5 },
       ];
       const handle = db.createHandle(data);
-      expect(handle).toMatch(/^\$res\d+$/);
+      expect(handle).toMatch(/^\$[a-z0-9_]+$/);
+    });
+
+    it("should derive descriptive name from command", () => {
+      const data = [{ line: "Error 1", lineNum: 1 }];
+      const handle = db.createHandle(data, '(grep "ERROR")');
+      expect(handle).toBe("$grep_error");
     });
 
     it("should store handle metadata", () => {
@@ -105,14 +111,23 @@ Line 5: Final line`;
       expect(retrieved[0].line).toBe("Error 1");
     });
 
-    it("should increment handle counter", () => {
+    it("should disambiguate repeated slugs with numeric suffix", () => {
       const h1 = db.createHandle([{ a: 1 }]);
       const h2 = db.createHandle([{ b: 2 }]);
       const h3 = db.createHandle([{ c: 3 }]);
 
-      expect(h1).toBe("$res1");
-      expect(h2).toBe("$res2");
-      expect(h3).toBe("$res3");
+      // All called without command → slug is "res"
+      expect(h1).toBe("$res");
+      expect(h2).toBe("$res_2");
+      expect(h3).toBe("$res_3");
+    });
+
+    it("should disambiguate repeated commands", () => {
+      const h1 = db.createHandle([{ a: 1 }], '(grep "ERROR")');
+      const h2 = db.createHandle([{ b: 2 }], '(grep "ERROR")');
+
+      expect(h1).toBe("$grep_error");
+      expect(h2).toBe("$grep_error_2");
     });
 
     it("should delete handle and its data", () => {
@@ -283,16 +298,45 @@ Line 5: Final line`;
     });
   });
 
-  describe("handle counter sequential numbering", () => {
-    it("should produce sequential handle numbers", () => {
+  describe("descriptive handle naming", () => {
+    it("should produce descriptive names from commands", () => {
+      db.loadDocument("test content");
+      const h1 = db.createHandle(["a", "b"], '(grep "ERROR")');
+      const h2 = db.createHandle(["c", "d"], '(bm25 "database timeout" 10)');
+      const h3 = db.createHandle(["e", "f"], '(list_symbols "function")');
+
+      expect(h1).toBe("$grep_error");
+      expect(h2).toBe("$bm25_database_timeout");
+      expect(h3).toBe("$list_symbols_function");
+    });
+
+    it("should fall back to $res when no command provided", () => {
       db.loadDocument("test content");
       const h1 = db.createHandle(["a", "b"]);
-      const h2 = db.createHandle(["c", "d"]);
-      const h3 = db.createHandle(["e", "f"]);
+      expect(h1).toBe("$res");
+    });
 
-      expect(h1).toBe("$res1");
-      expect(h2).toBe("$res2");
-      expect(h3).toBe("$res3");
+    it("should use sequential suffixes for same slug", () => {
+      db.loadDocument("test content");
+      const h1 = db.createHandle(["a"], '(grep "ERROR")');
+      const h2 = db.createHandle(["b"], '(grep "ERROR")');
+      const h3 = db.createHandle(["c"], '(grep "ERROR")');
+
+      expect(h1).toBe("$grep_error");
+      expect(h2).toBe("$grep_error_2");
+      expect(h3).toBe("$grep_error_3");
+    });
+
+    it("should handle different commands with unique slugs", () => {
+      db.loadDocument("test content");
+      const h1 = db.createHandle(["a"], '(grep "ERROR")');
+      const h2 = db.createHandle(["b"], '(grep "WARN")');
+      const h3 = db.createHandle(["c"], '(filter RESULTS (lambda x (match x "test" 0)))');
+
+      expect(h1).toBe("$grep_error");
+      expect(h2).toBe("$grep_warn");
+      // filter picks up "test" from the nested match string
+      expect(h3).toBe("$filter_test");
     });
   });
 
@@ -327,5 +371,63 @@ Line 5: Final line`;
       expect(data[1]).toBe(2);
       expect(data[2]).toBeNull();
     });
+  });
+});
+
+describe("commandToSlug", () => {
+  it("should extract command name and first string arg", () => {
+    expect(commandToSlug('(grep "ERROR")')).toBe("grep_error");
+    expect(commandToSlug('(bm25 "database timeout" 10)')).toBe("bm25_database_timeout");
+    expect(commandToSlug('(list_symbols "function")')).toBe("list_symbols_function");
+  });
+
+  it("should return command name alone when no string arg", () => {
+    expect(commandToSlug("(count RESULTS)")).toBe("count");
+    expect(commandToSlug("(list_symbols)")).toBe("list_symbols");
+    expect(commandToSlug("(filter RESULTS (lambda x x))")).toBe("filter");
+  });
+
+  it("should return 'res' when no command provided", () => {
+    expect(commandToSlug()).toBe("res");
+    expect(commandToSlug("")).toBe("res");
+  });
+
+  it("should normalise to lowercase and strip special chars", () => {
+    expect(commandToSlug('(grep "ERROR_MSG")')).toBe("grep_error_msg");
+    expect(commandToSlug('(grep "Hello World!")')).toBe("grep_hello_world");
+  });
+
+  it("should truncate long slugs to 30 chars", () => {
+    const slug = commandToSlug('(grep "this is a very long search query that should be truncated")');
+    expect(slug.length).toBeLessThanOrEqual(30);
+  });
+
+  it("should pick up the first quoted string inside nested expressions", () => {
+    expect(commandToSlug('(filter RESULTS (lambda x (match x "timeout" 0)))')).toBe("filter_timeout");
+  });
+
+  it("should handle empty quoted strings gracefully", () => {
+    expect(commandToSlug('(grep "")')).toBe("grep");
+  });
+
+  it("should strip unicode and non-ascii characters", () => {
+    expect(commandToSlug('(grep "错误")')).toBe("grep");
+    expect(commandToSlug('(grep "café")')).toBe("grep_caf");
+  });
+
+  it("should only use the first quoted string", () => {
+    expect(commandToSlug('(replace "from" "to")')).toBe("replace_from");
+  });
+
+  it("should prefix with q_ to prevent collision with memo namespace", () => {
+    expect(commandToSlug("(memo1)")).toBe("q_memo1");
+    expect(commandToSlug('(memo "note")')).toBe("q_memo_note");
+    // Non-colliding names should not be prefixed
+    expect(commandToSlug("(memory)")).toBe("memory");
+    expect(commandToSlug('(grep "memo")')).toBe("grep_memo");
+  });
+
+  it("should handle bare words without parens", () => {
+    expect(commandToSlug("justAWord")).toBe("res");
   });
 });

--- a/tests/repl/lattice-repl.test.ts
+++ b/tests/repl/lattice-repl.test.ts
@@ -30,8 +30,8 @@ describe("REPL underlying engine", () => {
     await engine.execute('(grep "line")');
     const bindings = engine.getBindings();
 
-    expect(bindings.RESULTS).toBe("-> $res1");
-    expect(bindings.$res1).toContain("Array(3)");
+    expect(bindings.RESULTS).toBe("-> $grep_line");
+    expect(bindings.$grep_line).toContain("Array(3)");
   });
 
   it("should reset state on command", async () => {

--- a/tests/tool/ai-tools.test.ts
+++ b/tests/tool/ai-tools.test.ts
@@ -106,7 +106,7 @@ describe("AI SDK tool definitions", () => {
 
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
-      expect(result.data!["$res1"]).toBeDefined();
+      expect(result.data!["$grep_log"]).toBeDefined();
     });
 
     it("should return status", async () => {

--- a/tests/treesitter/integration.test.ts
+++ b/tests/treesitter/integration.test.ts
@@ -166,7 +166,7 @@ function baz() { return 3; }
     it("should return handle for (list_symbols)", async () => {
       const result = await session.execute('(list_symbols)');
       expect(result.success).toBe(true);
-      expect(result.handle).toMatch(/^\$res\d+$/);
+      expect(result.handle).toMatch(/^\$[a-z0-9_]+$/);
       expect(result.stub).toBeDefined();
     });
 


### PR DESCRIPTION
## Summary

- Handle names are now auto-generated from the Nucleus command that produced them (e.g., `(grep "ERROR")` → `$grep_error`, `(list_symbols "function")` → `$list_symbols_function`) instead of opaque sequential `$res1`, `$res2`
- Repeated commands get a numeric suffix (`$grep_error_2`, `$grep_error_3`)
- Query handles are prevented from colliding with the `$memo` namespace via a `q_` prefix guard
- Updated all prompt text and README examples to show descriptive names

## Test plan

- [x] `commandToSlug` unit tests: basic extraction, unicode, empty strings, memo collision guard, truncation, bare words (6 new tests)
- [x] E2E tests: descriptive names through `session.execute()`, collision disambiguation, expand by descriptive name, RESULTS binding after chaining (5 new tests)
- [x] All 3032 existing tests pass with 0 regressions
- [x] Checkpoint restore works with new handle name format
- [x] Memo handles remain unchanged (`$memo1`, `$memo2`)
- [x] Handle eviction works correctly with descriptive names