### PR TITLE
fix(graph): address review findings from commit 62c5dc96

### DIFF
--- a/src/graph/community-detector.ts
+++ b/src/graph/community-detector.ts
@@ -36,6 +36,10 @@ export class GraphCommunityDetector {
     this.communities = precomputed ?? null;
   }
 
+  invalidate(): void {
+    this.communities = null;
+  }
+
   detect(): CommunityMap {
     if (this.communities) return this.communities;
 

--- a/src/graph/relationship-analyzer.ts
+++ b/src/graph/relationship-analyzer.ts
@@ -39,7 +39,7 @@ export class RelationshipAnalyzer {
     const edgeSet = new Set<string>();
 
     const addEdge = (source: string, target: string, relation: EdgeRelation, confidence: Confidence) => {
-      const key = `${source}|${target}|${relation}|${confidence}`;
+      const key = `${source}|${target}|${relation}`;
       if (!edgeSet.has(key)) {
         edgeSet.add(key);
         edges.push({ source, target, relation, confidence });

--- a/src/logic/lc-solver.ts
+++ b/src/logic/lc-solver.ts
@@ -1273,7 +1273,10 @@ async function evaluate(
           throw new Error(`community_of: Node "${term.name}" has no community assignment (graph may have been modified since detection)`);
         }
         const community = detector.communityList().find((c) => c.id === cid);
-        return community ?? { id: cid, nodes: [term.name], cohesion: 1.0 };
+        if (!community) {
+          throw new Error(`community_of: Node "${term.name}" has community ID ${cid} but no matching community in the cached list. Call invalidate() on the detector and retry.`);
+        }
+        return community;
       }
 
       const { GraphAnalyzer } = await import("../graph/graph-analyzer.js");

--- a/tests/graph/community-detector.test.ts
+++ b/tests/graph/community-detector.test.ts
@@ -120,4 +120,35 @@ describe("GraphCommunityDetector", () => {
       expect(detect.nodeCommunity("ghost")).toBeUndefined();
     });
   });
+
+  describe("invalidate", () => {
+    it("should re-run Louvain after invalidate() when graph has changed", () => {
+      const { graph, detect } = buildGraphWithCommunities();
+      const first = detect.detect();
+
+      graph.addSymbol(makeSymbol("NewService", "class"));
+      graph.addEdge("NewService", "Database", "calls");
+      graph.addEdge("NewService", "QueryBuilder", "calls");
+      graph.addEdge("NewService", "Migration", "calls");
+
+      const stale = detect.detect();
+      expect(stale["NewService"]).toBeUndefined();
+
+      detect.invalidate();
+      const fresh = detect.detect();
+      expect(fresh["NewService"]).toBeDefined();
+      expect(fresh["NewService"]).not.toEqual(first["AuthService"]);
+    });
+
+    it("should clear communityList cache after invalidate()", () => {
+      const { detect } = buildGraphWithCommunities();
+      detect.detect();
+      const firstList = detect.communityList();
+      const firstCount = firstList.length;
+
+      detect.invalidate();
+      const secondList = detect.communityList();
+      expect(secondList.length).toBe(firstCount);
+    });
+  });
 });

--- a/tests/graph/relationship-analyzer.test.ts
+++ b/tests/graph/relationship-analyzer.test.ts
@@ -235,6 +235,29 @@ function main() {
       const callEdges = edges.filter((e) => e.source === "main" && e.target === "helper" && e.relation === "calls");
       expect(callEdges).toHaveLength(1);
     });
+
+    it("should deduplicate by source+target+relation regardless of confidence", () => {
+      const analyzer = new RelationshipAnalyzer();
+      const code = `
+class Base {}
+class Foo extends Base {
+  bar() {
+    return Base;
+  }
+}
+`.trim();
+
+      const symbols = [
+        makeSymbol("Base", "class", 1, 1),
+        makeSymbol("Foo", "class", 2, 6),
+        makeSymbol("bar", "method", 3, 5, { parentSymbolId: 1 }),
+      ];
+
+      const edges = analyzer.analyze(symbols, code);
+      const fooToBase = edges.filter((e) => e.source === "Foo" && e.target === "Base");
+      expect(fooToBase).toHaveLength(1);
+      expect(fooToBase[0].relation).toBe("extends");
+    });
   });
 
   describe("large symbol sets", () => {

--- a/tests/logic/lc-solver-graph-analysis.test.ts
+++ b/tests/logic/lc-solver-graph-analysis.test.ts
@@ -102,6 +102,14 @@ describe("Graph Analysis Nucleus Commands", () => {
       const result = await query('(community_of "ghost")', bindings, tools);
       expect(result.success).toBe(false);
     });
+
+    it("should throw when node was added after community detection", async () => {
+      const graph = bindings.get("_symbolGraph") as SymbolGraph;
+      graph.addSymbol({ name: "lateNode", kind: "function", startLine: 1, endLine: 1, startCol: 0, endCol: 0 });
+
+      const result = await query('(community_of "lateNode")', bindings, tools);
+      expect(result.success).toBe(false);
+    });
   });
 
   describe("god_nodes", () => {


### PR DESCRIPTION
- Add invalidate() to GraphCommunityDetector so callers can force a Louvain re-run after mutating the graph, preventing stale community assignments from being served indefinitely.
- Revert edge dedup key in RelationshipAnalyzer to exclude confidence. Including it allowed the same logical edge (same source/target/relation) to appear twice with different confidence labels — a latent duplicate risk if future producers stamp the same relation differently.
- Replace the silent synthetic fallback in community_of (which fabricated {id, nodes:[name], cohesion:1.0}) with an explicit error throw, making cache inconsistencies visible instead of masked.
- Add tests for all three fixes: invalidate+re-detect, confidence-blind dedup, and error on stale community lookup.