### PR TITLE
feat(phase6): history compaction with summary fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Matryoshka has two execution paths and not every primitive works in both:
 |---|---|---|
 | `(grep …)`, `(filter …)`, `(map …)`, etc. | ✅ | ✅ |
 | `(llm_query …)`, `(llm_batch …)` | ✅ | ✅ via MCP sampling protocol |
-| `(rlm_query …)`, `(rlm_batch …)` | ✅ | ✅ — child Nucleus session spawns via the same MCP sampling bridge; the user sees M suspensions per call where M = child's turn count to FINAL |
+| `(rlm_query …)`, `(rlm_batch …)` | ✅ (concurrent rlm_batch) | ✅ — child Nucleus session spawns via the same MCP sampling bridge; M suspensions per `rlm_query` call. `rlm_batch` runs **sequentially** (children one at a time) because the multi-turn suspension protocol only carries one pending request at a time — concurrent children would lose suspensions. Round-trip count is the same; wall-clock is N×slower for non-sampling clients. |
 | `(context N)` selector | ✅ (multi-doc via `runRLMFromContent(query, string[])`) | partial — `(context 0)` works; multi-doc loading not exposed via `lattice_load` |
 | `(grep "X" haystack)` | ✅ | ✅ |
 | `(show_vars)` | ✅ | ✅ (internal `_<name>` bindings filtered out) |
@@ -86,14 +86,15 @@ The resource-limit features remain `runRLM`-only. The recursive primitives (`rlm
 (rlm_query "summarize each error type")
 ```
 
-`rlm_batch` is the concurrent variant — N child sessions run in parallel up to `maxConcurrentSubcalls` (default 4):
+`rlm_batch` runs the same per-item recursion across a collection. Each item produces one entry in the returned array, in input order. Per-item failures surface as `"Error: rlm_batch item N failed — …"` strings without aborting the rest of the batch:
 
 ```scheme
 (rlm_batch (chunk_by_lines 100)
   (lambda c (rlm_query "extract metrics" (context c))))
 ```
 
-Each item produces one entry in the returned array, in input order. Per-item failures surface as `"Error: rlm_batch item N failed — …"` strings without aborting the rest of the batch.
+- **`runRLM`**: children fan out concurrently via a worker pool capped at `maxConcurrentSubcalls` (default 4).
+- **`lattice-mcp`**: children run **sequentially** because the multi-turn suspension protocol can carry only one pending request at a time. Round-trip count is identical to the concurrent path (N children × M turns each); only wall-clock differs.
 
 #### Multi-Context Loading
 

--- a/README.md
+++ b/README.md
@@ -62,15 +62,15 @@ Matryoshka has two execution paths and not every primitive works in both:
 |---|---|---|
 | `(grep …)`, `(filter …)`, `(map …)`, etc. | ✅ | ✅ |
 | `(llm_query …)`, `(llm_batch …)` | ✅ | ✅ via MCP sampling protocol |
-| `(rlm_query …)`, `(rlm_batch …)` | ✅ | ❌ throws "not available in this execution context" |
+| `(rlm_query …)`, `(rlm_batch …)` | ✅ | ✅ — child Nucleus session spawns via the same MCP sampling bridge; the user sees M suspensions per call where M = child's turn count to FINAL |
 | `(context N)` selector | ✅ (multi-doc via `runRLMFromContent(query, string[])`) | partial — `(context 0)` works; multi-doc loading not exposed via `lattice_load` |
 | `(grep "X" haystack)` | ✅ | ✅ |
-| `(show_vars)` | ✅ | ✅ |
+| `(show_vars)` | ✅ | ✅ (internal `_<name>` bindings filtered out) |
 | `FINAL_VAR(name)` resolution | ✅ | N/A — MCP returns query results directly |
 | `maxTimeoutMs` / `maxTokens` / `maxErrors` | ✅ | ❌ — MCP has its own session timeout |
 | `compactionThresholdChars` | ✅ | ❌ — MCP doesn't have a multi-turn FSM history |
 
-The recursive (`rlm_query`/`rlm_batch`) and resource-limit features were built for the `runRLM` FSM loop. Wiring them into `lattice-mcp-server` would require additional plumbing (child-session spawning, MCP-protocol propagation of timeouts) that hasn't been done.
+The resource-limit features remain `runRLM`-only. The recursive primitives (`rlm_query`/`rlm_batch`) work in both paths — the MCP path spawns a child `runRLMFromContent` whose `llmClient` is the same sampling bridge as the parent, so each child turn flows through the existing MCP suspension/sampling protocol.
 
 #### Recursive Primitives
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,102 @@ The LLM outputs commands in the Nucleus DSL—an S-expression language designed 
 <<<FINAL>>>13000000<<<END>>>
 ```
 
+#### Feature availability by execution path
+
+Matryoshka has two execution paths and not every primitive works in both:
+
+| Feature | `runRLM` (CLI / programmatic) | `lattice-mcp` (MCP server) |
+|---|---|---|
+| `(grep …)`, `(filter …)`, `(map …)`, etc. | ✅ | ✅ |
+| `(llm_query …)`, `(llm_batch …)` | ✅ | ✅ via MCP sampling protocol |
+| `(rlm_query …)`, `(rlm_batch …)` | ✅ | ❌ throws "not available in this execution context" |
+| `(context N)` selector | ✅ (multi-doc via `runRLMFromContent(query, string[])`) | partial — `(context 0)` works; multi-doc loading not exposed via `lattice_load` |
+| `(grep "X" haystack)` | ✅ | ✅ |
+| `(show_vars)` | ✅ | ✅ |
+| `FINAL_VAR(name)` resolution | ✅ | N/A — MCP returns query results directly |
+| `maxTimeoutMs` / `maxTokens` / `maxErrors` | ✅ | ❌ — MCP has its own session timeout |
+| `compactionThresholdChars` | ✅ | ❌ — MCP doesn't have a multi-turn FSM history |
+
+The recursive (`rlm_query`/`rlm_batch`) and resource-limit features were built for the `runRLM` FSM loop. Wiring them into `lattice-mcp-server` would require additional plumbing (child-session spawning, MCP-protocol propagation of timeouts) that hasn't been done.
+
+#### Recursive Primitives
+
+`rlm_query` spawns a child Nucleus session with its own FSM loop. The child runs to FINAL and returns a string — useful when a sub-task needs multi-turn reasoning over a structured handle:
+
+```scheme
+; Child sees the resolved handle as its working document, NOT a
+; JSON-stringified prompt blob. Lets the child use grep/lines/
+; chunk_by_lines over arrays without JSON-syntax noise.
+(rlm_query "extract dates" (context RESULTS))
+
+; No (context …) → child's document is the prompt itself.
+(rlm_query "summarize each error type")
+```
+
+`rlm_batch` is the concurrent variant — N child sessions run in parallel up to `maxConcurrentSubcalls` (default 4):
+
+```scheme
+(rlm_batch (chunk_by_lines 100)
+  (lambda c (rlm_query "extract metrics" (context c))))
+```
+
+Each item produces one entry in the returned array, in input order. Per-item failures surface as `"Error: rlm_batch item N failed — …"` strings without aborting the rest of the batch.
+
+#### Multi-Context Loading
+
+Pass `string[]` to `runRLMFromContent` to load multiple documents. Address them via `(context N)`; index 0 is the default for primitives that don't specify a haystack:
+
+```scheme
+(grep "DEPLOY" (context 0))   ; deploy.log
+(grep "OUTAGE" (context 2))   ; comms.log
+
+; (context N) is just a term — pipe it anywhere a string is expected
+(rlm_query "scan" (context (context 1)))   ; child sees doc 1
+```
+
+Per-doc line numbers come back, so the LLM can cite "doc 0 line 4, doc 2 line 2" with confidence rather than inventing absolute offsets across a concatenation.
+
+#### Introspection
+
+```scheme
+(show_vars)   ; Returns a string summary of every binding currently
+              ; in scope. Useful before a (filter RESULTS …) or a
+              ; FINAL_VAR(name) reference when the LLM lost track of
+              ; what's bound. Same surface as the `lattice_bindings`
+              ; MCP tool but reachable from inside a query.
+```
+
+Unknown FINAL_VAR markers surface a clear error rather than passing the literal text through:
+
+```
+<<<FINAL>>>FINAL_VAR(_99)<<<END>>>
+→ "[FINAL_VAR error: unknown binding "_99". Available: _1, RESULTS]"
+```
+
+#### Resource Limits
+
+All optional. With none set, behavior is unchanged:
+
+```typescript
+runRLM(query, file, {
+  maxTimeoutMs: 30_000,    // wall-clock cap, propagates to children
+  maxTokens: 100_000,      // cumulative chars sent + received
+  maxErrors: 5,            // consecutive parse/execution errors
+  compactionThresholdChars: 50_000,  // summarize history when prompt grows past this
+})
+```
+
+When a limit hits, the run terminates cleanly with a string of the form:
+
+```
+[aborted: timeout 32100ms of 30000ms]
+
+Best partial answer:
+<the most recent meaningful solver result>
+```
+
+The partial answer is always preserved when present — completed work is never silently lost on abort.
+
 ### The Lattice Engine
 
 The Lattice engine (`src/logic/`) processes Nucleus commands:

--- a/demos/phase6-compaction/1-baseline.test.ts
+++ b/demos/phase6-compaction/1-baseline.test.ts
@@ -1,0 +1,53 @@
+/**
+ * BEFORE — Phase 6 baseline: no compaction, model rejects oversized
+ * prompts with [CONTEXT_OVERFLOW]. Locks in the failure mode the
+ * phase fixes.
+ */
+
+import { describe, it, expect } from "vitest";
+import { writeFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runRLMFromContent } from "../../src/rlm.js";
+import { createNucleusAdapter } from "../../src/adapters/nucleus.js";
+import {
+  SCENARIO_DOC,
+  SCENARIO_QUERY,
+  buildResponder,
+  makeBoundedLLM,
+  SIMULATED_CONTEXT_LIMIT,
+} from "./scenario.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SNAPSHOT_PATH = join(__dirname, "baseline.json");
+
+describe("Phase 6 baseline — no compaction, prompt grows past context limit", () => {
+  it("the model rejects oversized prompts and the run never reaches FINAL", async () => {
+    const llm = makeBoundedLLM(buildResponder());
+    const result = (await runRLMFromContent(SCENARIO_QUERY, SCENARIO_DOC, {
+      llmClient: llm,
+      adapter: createNucleusAdapter(),
+      maxTurns: 10,
+      ragEnabled: false,
+    })) as string;
+
+    const snapshot = {
+      mode: "baseline",
+      scenario: "context-overflow",
+      simContextLimit: SIMULATED_CONTEXT_LIMIT,
+      docChars: SCENARIO_DOC.length,
+      result: result.slice(0, 300),
+    };
+    await writeFile(SNAPSHOT_PATH, JSON.stringify(snapshot, null, 2) + "\n", "utf-8");
+    // eslint-disable-next-line no-console
+    console.log("[phase6-baseline]", snapshot);
+
+    // Without compaction, the run cannot complete — either it
+    // hit max turns or the FSM accepted the [CONTEXT_OVERFLOW]
+    // string as a final answer (which is wrong but possible).
+    // Either way, the result MUST NOT contain a real grep result
+    // (TAG-N-occurrence-J) — that would mean the run somehow
+    // completed despite the limit.
+    expect(result).not.toMatch(/TAG-\d+-occurrence-\d+/);
+  });
+});

--- a/demos/phase6-compaction/2-phase6.test.ts
+++ b/demos/phase6-compaction/2-phase6.test.ts
@@ -1,0 +1,56 @@
+/**
+ * AFTER — Phase 6 with compaction at the right threshold.
+ *
+ * Same scripted run, now `compactionThresholdChars` set below the
+ * simulated context limit. The FSM trims history before the prompt
+ * crosses the limit; the run completes with a real FINAL answer.
+ */
+
+import { describe, it, expect } from "vitest";
+import { writeFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runRLMFromContent } from "../../src/rlm.js";
+import { createNucleusAdapter } from "../../src/adapters/nucleus.js";
+import {
+  SCENARIO_DOC,
+  SCENARIO_QUERY,
+  buildResponder,
+  makeBoundedLLM,
+  SIMULATED_CONTEXT_LIMIT,
+  COMPACTION_THRESHOLD,
+} from "./scenario.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const AFTER_PATH = join(__dirname, "after.json");
+
+describe("Phase 6 — compaction keeps the run alive past context limit", () => {
+  it("produces a real FINAL answer with grep results despite the simulated context cap", async () => {
+    const llm = makeBoundedLLM(buildResponder());
+    const result = (await runRLMFromContent(SCENARIO_QUERY, SCENARIO_DOC, {
+      llmClient: llm,
+      adapter: createNucleusAdapter(),
+      maxTurns: 10,
+      ragEnabled: false,
+      compactionThresholdChars: COMPACTION_THRESHOLD,
+    })) as string;
+
+    const snapshot = {
+      mode: "phase6",
+      scenario: "context-overflow",
+      simContextLimit: SIMULATED_CONTEXT_LIMIT,
+      compactionThresholdChars: COMPACTION_THRESHOLD,
+      result: result.slice(0, 600),
+    };
+    await writeFile(AFTER_PATH, JSON.stringify(snapshot, null, 2) + "\n", "utf-8");
+    // eslint-disable-next-line no-console
+    console.log("[phase6-after]", snapshot);
+
+    // Correctness gate: the result MUST contain a real grep
+    // match line (TAG-N-occurrence-J pattern). That proves the
+    // FSM completed and FINAL_VAR resolved against actual
+    // bindings.
+    expect(result).toMatch(/TAG-\d+-occurrence-\d+/);
+    expect(result).not.toMatch(/CONTEXT_OVERFLOW/);
+  });
+});

--- a/demos/phase6-compaction/baseline.json
+++ b/demos/phase6-compaction/baseline.json
@@ -1,0 +1,7 @@
+{
+  "mode": "baseline",
+  "scenario": "context-overflow",
+  "simContextLimit": 6000,
+  "docChars": 6551,
+  "result": "Max turns (10) reached without final answer."
+}

--- a/demos/phase6-compaction/scenario.ts
+++ b/demos/phase6-compaction/scenario.ts
@@ -1,0 +1,88 @@
+/**
+ * Phase 6 — compaction benefit demo.
+ *
+ * The premise: a long-running query whose accumulated history grows
+ * past a model's context window. Without compaction, the FSM's last
+ * turns send a prompt larger than what the model can accept. With
+ * compaction, the loop summarizes mid-trajectory and continues.
+ *
+ * In a unit test we don't have a real model context limit, so we
+ * simulate one: the scripted LLM returns an "[CONTEXT_OVERFLOW]"
+ * error string when the prompt exceeds a configured limit. Without
+ * compaction, this happens around turn 4-5 and the run fails.
+ * With compaction at a threshold below the simulated limit, the
+ * loop trims history before crossing it and the run completes.
+ *
+ * Pass criteria:
+ *   - Baseline: hits the simulated overflow → result is the error
+ *     marker (no FINAL).
+ *   - Phase 6: completes with a real FINAL answer that includes
+ *     the per-turn grep results.
+ */
+
+import type { Responder } from "../phase1-rlm-query/harness.js";
+
+/** Simulated model context limit in chars. */
+export const SIMULATED_CONTEXT_LIMIT = 6000;
+
+/** Threshold below the sim limit. Compaction fires before overflow. */
+export const COMPACTION_THRESHOLD = 4500;
+
+const TAGS = Array.from({ length: 12 }, (_, i) => `TAG-${i + 1}`);
+export const SCENARIO_DOC: string = TAGS.flatMap((tag) =>
+  Array.from({ length: 8 }, (_, j) => `${tag}-occurrence-${j}: filler ${"x".repeat(40)}`)
+).join("\n");
+
+export const SCENARIO_QUERY = "Inspect each tag in turn.";
+
+/**
+ * The "model": echoes overflow when the prompt is too large; else
+ * runs the scripted FSM responder. Compaction prompts are detected
+ * by the canonical prefix and answered with a short summary.
+ */
+export function makeBoundedLLM(
+  responder: Responder
+): (prompt: string) => Promise<string> {
+  return async (prompt: string): Promise<string> => {
+    if (/Summarize your progress so far/.test(prompt)) {
+      return "Summary: scanned several tags, found multiple occurrences each.";
+    }
+    if (prompt.length > SIMULATED_CONTEXT_LIMIT) {
+      // The "model" rejects with an overflow signal. Real models
+      // would reject with HTTP 400 or similar — we render it as a
+      // sentinel string the FSM will treat as an LLM error and
+      // surface in subsequent turns. The run never reaches FINAL.
+      return `[CONTEXT_OVERFLOW: prompt was ${prompt.length} chars, limit ${SIMULATED_CONTEXT_LIMIT}]`;
+    }
+    // turn-tracking is owned by the responder caller via inferTurn
+    return responder(prompt, 0);
+  };
+}
+
+/**
+ * Parent script: emit a different grep on each turn so history grows
+ * with each turn's grep result. By turn 5 the accumulated history
+ * exceeds the simulated context limit (without compaction).
+ *
+ * Final turn: emit FINAL referencing the latest grep binding.
+ *
+ * Uses a closure counter rather than counting `Bindings:` markers in
+ * the prompt — that marker count is invalidated by compaction
+ * (post-compaction history is small, marker disappears).
+ */
+export function buildResponder(): Responder {
+  let turn = 0;
+  return (prompt) => {
+    if (/Summarize your progress so far/.test(prompt)) {
+      return "Summary: scanned several tags, found multiple occurrences each.";
+    }
+    turn++;
+    if (turn >= 6) {
+      // After 5 grep turns, FINAL referencing the most recent
+      // binding (which is `_${turn-1}` since this turn produces _N
+      // only for code execution).
+      return `<<<FINAL>>>FINAL_VAR(_${turn - 1})<<<END>>>`;
+    }
+    return `(grep "${TAGS[turn - 1]}-")`;
+  };
+}

--- a/src/adapters/nucleus.ts
+++ b/src/adapters/nucleus.ts
@@ -252,7 +252,13 @@ function extractCode(response: string): string | null {
       const expr = response.slice(parenIdx, end);
       // Check the expression starts with a known command
       const exprContent = expr.slice(1).trim(); // remove leading (
-      const firstWord = exprContent.match(/^(\S+)/)?.[1];
+      // Match identifier characters only — terms like `(show_vars)`
+      // (no args) leave a `)` immediately after the head word, so a
+      // greedy `\S+` would capture "show_vars)" and miss the
+      // KNOWN_COMMANDS lookup. Constraining to identifier chars
+      // stops at the closing paren, the leading whitespace, or any
+      // non-identifier character.
+      const firstWord = exprContent.match(/^([A-Za-z_][A-Za-z0-9_-]*)/)?.[1];
       if (firstWord && KNOWN_COMMANDS.includes(firstWord)) {
         return expr;
       }

--- a/src/engine/handle-session.ts
+++ b/src/engine/handle-session.ts
@@ -135,6 +135,24 @@ export interface HandleSessionOptions {
     prompts: string[],
     options?: { calibrate?: boolean }
   ) => Promise<string[]>;
+  /**
+   * Optional recursive child-session bridge for `(rlm_query …)`.
+   * When wired (typically by lattice-mcp-server's
+   * samplingRlmBridge), the Phase 1 recursive primitive becomes
+   * available to MCP users — same surface as runRLM. The bridge is
+   * responsible for spawning a child Nucleus FSM and routing its
+   * LLM calls back through the MCP client.
+   */
+  rlmQuery?: (prompt: string, contextDoc: string | null) => Promise<string>;
+  /**
+   * Optional batched recursive bridge for `(rlm_batch …)`.
+   * Receives N (prompt, contextDoc) pairs in one call; returns N
+   * response strings in matching order. Implementation typically
+   * fans out to N rlmQuery calls in parallel.
+   */
+  rlmBatch?: (
+    items: Array<{ prompt: string; contextDoc: string | null }>
+  ) => Promise<string[]>;
 }
 
 export class HandleSession {
@@ -178,6 +196,8 @@ export class HandleSession {
       verbose: options.verbose,
       llmQuery: options.llmQuery,
       llmBatch: options.llmBatch,
+      rlmQuery: options.rlmQuery,
+      rlmBatch: options.rlmBatch,
     });
     this.db = new SessionDB();
     this.registry = new HandleRegistry(this.db);

--- a/src/engine/nucleus-engine.ts
+++ b/src/engine/nucleus-engine.ts
@@ -60,6 +60,27 @@ export interface NucleusEngineOptions {
     prompts: string[],
     options?: { calibrate?: boolean }
   ) => Promise<string[]>;
+  /**
+   * Optional recursive child-session bridge for `(rlm_query …)`.
+   *
+   * When wired (typically via the MCP path's samplingRlmBridge),
+   * spawning a child Nucleus FSM is delegated to this callback.
+   * The contract: receive (prompt, materialized contextDoc) and
+   * return the child's FINAL string. The MCP bridge implementation
+   * runs `runRLMFromContent` with the same llmClient as the parent
+   * so the child's LLM calls flow through the same MCP protocol.
+   */
+  rlmQuery?: (prompt: string, contextDoc: string | null) => Promise<string>;
+  /**
+   * Optional batched recursive bridge for `(rlm_batch …)`.
+   *
+   * Receives N (prompt, contextDoc) pairs in one call and must
+   * return N response strings in matching order. The MCP bridge
+   * fans out to N rlmQuery calls in parallel.
+   */
+  rlmBatch?: (
+    items: Array<{ prompt: string; contextDoc: string | null }>
+  ) => Promise<string[]>;
 }
 
 /**
@@ -78,6 +99,10 @@ function createSolverTools(
   llmBatch?: (
     prompts: string[],
     options?: { calibrate?: boolean }
+  ) => Promise<string[]>,
+  rlmQuery?: (prompt: string, contextDoc: string | null) => Promise<string>,
+  rlmBatch?: (
+    items: Array<{ prompt: string; contextDoc: string | null }>
   ) => Promise<string[]>
 ): SolverTools {
   const lines = context.split("\n");
@@ -239,6 +264,12 @@ function createSolverTools(
     // Batched sibling of llmQuery — dispatches all N prompts from
     // `(llm_batch …)` in a single call. Omitted means `(llm_batch …)` throws.
     llmBatch,
+    // Phase 1/2 — recursive child Nucleus session bridges. Wired
+    // by the MCP path (samplingRlmBridge / samplingRlmBatchBridge)
+    // so `(rlm_query …)` and `(rlm_batch …)` work end-to-end via
+    // the same llmClient suspension protocol the parent uses.
+    rlmQuery,
+    rlmBatch,
   };
 }
 
@@ -269,11 +300,17 @@ export class NucleusEngine {
     prompts: string[],
     options?: { calibrate?: boolean }
   ) => Promise<string[]>;
+  private rlmQuery?: (prompt: string, contextDoc: string | null) => Promise<string>;
+  private rlmBatch?: (
+    items: Array<{ prompt: string; contextDoc: string | null }>
+  ) => Promise<string[]>;
 
   constructor(options: NucleusEngineOptions = {}) {
     this.verbose = options.verbose ?? false;
     this.llmQuery = options.llmQuery;
     this.llmBatch = options.llmBatch;
+    this.rlmQuery = options.rlmQuery;
+    this.rlmBatch = options.rlmBatch;
   }
 
   /**
@@ -290,7 +327,16 @@ export class NucleusEngine {
   loadContent(content: string): void {
     const trimmed = content.trim();
     this.context = trimmed.length > 0 ? content : "";
-    this.solverTools = trimmed.length > 0 ? createSolverTools(content, this.llmQuery, this.llmBatch) : null;
+    this.solverTools =
+      trimmed.length > 0
+        ? createSolverTools(
+            content,
+            this.llmQuery,
+            this.llmBatch,
+            this.rlmQuery,
+            this.rlmBatch
+          )
+        : null;
     this.bindings.clear();
     this.turnCounter = 0;
 

--- a/src/fsm/rlm-states.ts
+++ b/src/fsm/rlm-states.ts
@@ -78,6 +78,18 @@ export interface RLMContext {
   startTime: number;
   totalTokens: number;
   consecutiveErrors: number;
+  compactionThresholdChars?: number;
+  compactionCount: number;
+  /**
+   * Number of consecutive compaction failures (e.g., the summarize
+   * llm call threw). Once this hits the cap, we stop attempting
+   * compaction for the rest of the run — otherwise a failing
+   * summarize call would loop on every turn since the threshold
+   * check never advances. Per project rule (correctness >
+   * performance): better to let the run hit its other limits
+   * cleanly than to spin in the compaction loop forever.
+   */
+  compactionFailures: number;
   /**
    * Phase 5 — most recent meaningful solver result, formatted as a
    * string. Populated unconditionally after every successful solver
@@ -236,6 +248,106 @@ function formatAbort(
   return `[aborted: ${reason} ${detail}]\n\nBest partial answer:\n${partial}`;
 }
 
+/**
+ * Phase 6 — render the prompt the FSM would send to the LLM right
+ * now. Used to measure prompt size for compaction decisions before
+ * the actual handleQueryLLM build step. Kept in sync with that
+ * builder by literally being the same join.
+ */
+function renderPrompt(history: RLMContext["history"]): string {
+  return history.map((h) => `${h.role.toUpperCase()}: ${h.content}`).join("\n\n");
+}
+
+/**
+ * Phase 6 — summarize turns 2..N into a single assistant message
+ * and trim the history to [system, first user, summary, latest
+ * user-feedback turn]. Stashes the full pre-compaction history as
+ * the `_compaction_trace` solver binding so a follow-up
+ * `FINAL_VAR(_compaction_trace)` can retrieve it.
+ *
+ * Re-entrant via `compactionCount`: the binding name carries the
+ * count when there are multiple events
+ * (`_compaction_trace_2`, etc.) so a third compaction doesn't
+ * destroy the previously stashed trace.
+ *
+ * Heuristic: keep the most recent ASSISTANT response and any user
+ * feedback that came AFTER it untouched, so the LLM still sees the
+ * latest action and result on the next turn. Earlier turns are
+ * folded into the summary.
+ */
+async function compactHistory(ctx: RLMContext): Promise<void> {
+  if (ctx.history.length < 4) return; // nothing useful to compact
+
+  // Stash the full pre-compaction history first so it can be
+  // recovered later. Render as a string for FINAL_VAR consumption.
+  const traceText = ctx.history
+    .map((h) => `[${h.role}] ${h.content}`)
+    .join("\n---\n");
+  const stashName =
+    ctx.compactionCount === 0
+      ? "_compaction_trace"
+      : `_compaction_trace_${ctx.compactionCount + 1}`;
+  ctx.solverBindings.set(stashName, traceText);
+
+  // Prepare the summarization prompt. We send the FULL prior
+  // history wrapped in an instruction asking for a tight summary
+  // that preserves intermediate values + binding names, so the
+  // post-compaction LLM can reference earlier work.
+  const historyText = ctx.history
+    .slice(2) // skip system + initial user (kept verbatim)
+    .map((h) => `[${h.role}] ${h.content}`)
+    .join("\n");
+  const summarizePrompt =
+    "Summarize your progress so far. Include: " +
+    "(1) which steps/sub-tasks you completed; " +
+    "(2) any concrete intermediate results (counts, matches, " +
+    "binding names like RESULTS or _N) — preserve these exactly; " +
+    "(3) what your next action should be. " +
+    "Be concise (1-3 paragraphs). Conversation:\n" +
+    historyText;
+
+  ctx.log(
+    `[Compaction #${ctx.compactionCount + 1}] firing — history is ${
+      historyText.length
+    } chars`
+  );
+  let summary: string;
+  try {
+    summary = await ctx.llmClient(summarizePrompt);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.log(`[Compaction] summarization failed: ${msg} — skipping compaction`);
+    // Roll back the stash; if we couldn't summarize, leaving the
+    // binding around could mislead.
+    ctx.solverBindings.delete(stashName);
+    ctx.compactionFailures++;
+    return;
+  }
+
+  // Replace history[2..N] with the summary. Keep system + initial
+  // user verbatim. Future turns build on this trimmed shape.
+  const system = ctx.history[0];
+  const initialUser = ctx.history[1];
+  ctx.history = [
+    system,
+    initialUser,
+    {
+      role: "assistant",
+      content: `Summary (after compaction #${ctx.compactionCount + 1}):\n${summary}`,
+    },
+    {
+      role: "user",
+      content:
+        "The conversation above has been compacted. " +
+        "Continue from the summary. Do NOT repeat completed work; " +
+        "the binding names and intermediate values mentioned in the " +
+        "summary are still available via the solver bindings. " +
+        "Your next action:",
+    },
+  ];
+  ctx.compactionCount++;
+}
+
 // ===== STATE HANDLERS =====
 
 async function handleQueryLLM(ctx: RLMContext): Promise<RLMContext> {
@@ -280,7 +392,27 @@ async function handleQueryLLM(ctx: RLMContext): Promise<RLMContext> {
     return ctx;
   }
 
-  const prompt = ctx.history.map((h) => `${h.role.toUpperCase()}: ${h.content}`).join("\n\n");
+  // Phase 6 — check whether the next prompt would exceed the
+  // compaction threshold. When it would, summarize prior turns
+  // first so the actual LLM call sees a smaller history. Skipped
+  // when the threshold is unset (back-compat) OR when prior
+  // compaction attempts have failed too many times — letting the
+  // run hit other limits cleanly is better than spinning forever
+  // in a failing compaction loop (a failing summarize call
+  // doesn't shrink history, so the threshold check would re-fire
+  // on every turn).
+  const COMPACTION_FAILURE_CAP = 2;
+  if (
+    ctx.compactionThresholdChars !== undefined &&
+    ctx.compactionFailures < COMPACTION_FAILURE_CAP
+  ) {
+    const projected = renderPrompt(ctx.history);
+    if (projected.length > ctx.compactionThresholdChars) {
+      await compactHistory(ctx);
+    }
+  }
+
+  const prompt = renderPrompt(ctx.history);
   ctx.totalTokens += prompt.length;
   let response: string;
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
@@ -914,6 +1046,7 @@ export function createInitialContext(opts: {
   maxTimeoutMs?: number;
   maxTokens?: number;
   maxErrors?: number;
+  compactionThresholdChars?: number;
 }): RLMContext {
   return {
     query: opts.query,
@@ -958,6 +1091,9 @@ export function createInitialContext(opts: {
     totalTokens: 0,
     consecutiveErrors: 0,
     bestPartialAnswer: "",
+    compactionThresholdChars: opts.compactionThresholdChars,
+    compactionCount: 0,
+    compactionFailures: 0,
 
     result: null,
   };

--- a/src/lattice-mcp-server.ts
+++ b/src/lattice-mcp-server.ts
@@ -33,6 +33,8 @@ import { stat } from "node:fs/promises";
 import { resolve, sep } from "node:path";
 import { randomUUID } from "node:crypto";
 import { HandleSession, type HandleResult } from "./engine/handle-session.js";
+import { runRLMFromContent } from "./rlm.js";
+import { createNucleusAdapter } from "./adapters/nucleus.js";
 import { getVersion } from "./version.js";
 import { hasTraversalSegment } from "./utils/path-safety.js";
 import {
@@ -50,6 +52,20 @@ import {
 // returned as a plain string.
 let samplingBridge: ((prompt: string) => Promise<string>) | null = null;
 let samplingBatchBridge: ((prompts: string[]) => Promise<string[]>) | null = null;
+// Phase 1/2 — recursive Nucleus session bridges. Spawn a child
+// runRLMFromContent inside the solver; the child's LLM calls flow
+// through samplingBridge so each child turn fires through the same
+// MCP suspension/sampling protocol the parent uses. The MCP user
+// experiences M suspensions per (rlm_query …) call, where M is
+// the child's turn count to FINAL.
+let samplingRlmBridge:
+  | ((prompt: string, contextDoc: string | null) => Promise<string>)
+  | null = null;
+let samplingRlmBatchBridge:
+  | ((
+      items: Array<{ prompt: string; contextDoc: string | null }>
+    ) => Promise<string[]>)
+  | null = null;
 
 // Default cap for sub-LLM responses. The MCP sampling protocol requires a
 // maxTokens value; we keep it modest so sub-LLM calls stay cheap and the
@@ -416,6 +432,26 @@ serial llm_query suspensions. 92% round-trip reduction on N=12, 99% on
 N=100 — protocol overhead dominates map+llm_query cost, not per-item work.
 Use map+llm_query only when per-item judgment references prior items or
 the lambda body isn't a direct (llm_query …).
+
+RLM_QUERY (recursive child Nucleus session — for sub-tasks needing multi-step reasoning):
+  (rlm_query "prompt")                                     No context — child sees prompt as its document
+  (rlm_query "extract" (context RESULTS))                  Pass a binding as the child's working document
+  (rlm_query "scan" (context (chunk_by_lines 100)))        Pass a fresh result handle
+Spawns a child Nucleus session that runs its OWN multi-turn loop —
+greps, chunks, sub-LLM calls, etc. — until it produces a FINAL.
+Differs from (llm_query …) which is a single LLM call: rlm_query
+gives the child a structured working document and lets it iterate.
+The child's LLM calls flow through the same MCP sampling bridge,
+so you'll see M suspensions per (rlm_query …) call where M is the
+child's turn count to FINAL.
+
+RLM_BATCH (concurrent variant — N child sessions in parallel):
+  (rlm_batch chunks (lambda c (rlm_query "extract" (context c))))
+  (rlm_batch RESULTS (lambda x (rlm_query "deep dive" (context x))))
+Drop-in replacement for (map COLL (lambda x (rlm_query …))) when
+per-item recursion is independent. All N child sessions run
+concurrently; per-item failures surface as
+"Error: rlm_batch item N failed — …" without aborting the rest.
 
 ONE_OF (enum validation — makes downstream filter/count reliable):
   (llm_query "Rate: {x}" (x y) (one_of "low" "medium" "high"))
@@ -869,6 +905,8 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
           const newSession = new HandleSession({
             llmQuery: samplingBridge ?? undefined,
             llmBatch: samplingBatchBridge ?? undefined,
+            rlmQuery: samplingRlmBridge ?? undefined,
+            rlmBatch: samplingRlmBatchBridge ?? undefined,
           });
           try {
             stats = await newSession.loadFile(filePath);
@@ -1355,9 +1393,73 @@ async function main() {
     return promise;
   };
 
+  // Phase 1 — recursive child Nucleus session for `(rlm_query …)`.
+  // Spawns runRLMFromContent inside the solver. The child's
+  // llmClient is `samplingBridge` (the same one the parent uses),
+  // so each child turn fires through the same MCP suspension /
+  // sampling protocol. The MCP user experiences M suspensions per
+  // (rlm_query …) call where M is the child's turn count to FINAL.
+  //
+  // This is the bridge that closes the runRLM-vs-MCP feature gap
+  // for recursive primitives.
+  samplingRlmBridge = async (
+    prompt: string,
+    contextDoc: string | null
+  ): Promise<string> => {
+    if (!samplingBridge) {
+      return "Error: rlm_query unavailable — samplingBridge not initialized";
+    }
+    // Child's working document: explicit context if supplied,
+    // else fall back to the prompt itself (mirrors runRLM's
+    // rlmQuerySpawner contract).
+    const childDoc =
+      contextDoc !== null && contextDoc.length > 0 ? contextDoc : prompt;
+    try {
+      const result = await runRLMFromContent(prompt, childDoc, {
+        llmClient: samplingBridge,
+        adapter: createNucleusAdapter(),
+        // Conservative cap — every child turn is an MCP round-trip
+        // for the user. 4 turns lets the child grep + analyze +
+        // FINAL with one slack turn. Configurable later if needed.
+        maxTurns: 4,
+        ragEnabled: false,
+        verbose: false,
+      });
+      return typeof result === "string" ? result : JSON.stringify(result);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return `Error: rlm_query child failed — ${msg}`;
+    }
+  };
+
+  // Phase 2 — concurrent variant for `(rlm_batch …)`. Fans out to
+  // N samplingRlmBridge calls via Promise.all. Each child runs
+  // independently, sharing the parent's MCP llmClient. Errors in
+  // one item don't abort the rest — the slot gets a marker string.
+  samplingRlmBatchBridge = async (
+    items: Array<{ prompt: string; contextDoc: string | null }>
+  ): Promise<string[]> => {
+    if (!samplingRlmBridge) {
+      return items.map(
+        (_, i) => `Error: rlm_batch item ${i} — samplingRlmBridge not initialized`
+      );
+    }
+    return Promise.all(
+      items.map(async (it, idx) => {
+        try {
+          return await samplingRlmBridge!(it.prompt, it.contextDoc);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return `Error: rlm_batch item ${idx} failed — ${msg}`;
+        }
+      })
+    );
+  };
+
   await server.connect(transport);
 
   console.error("[Lattice] LLM query bridge installed — (llm_query ...) uses MCP sampling when available, multi-turn protocol otherwise");
+  console.error("[Lattice] RLM bridge installed — (rlm_query …) and (rlm_batch …) spawn child Nucleus sessions");
 
   console.error("[Lattice] MCP server started (handle-based mode)");
   console.error(`[Lattice] Session timeout: ${SESSION_TIMEOUT_MS / 1000}s`);

--- a/src/lattice-mcp-server.ts
+++ b/src/lattice-mcp-server.ts
@@ -1409,11 +1409,16 @@ async function main() {
     if (!samplingBridge) {
       return "Error: rlm_query unavailable — samplingBridge not initialized";
     }
-    // Child's working document: explicit context if supplied,
-    // else fall back to the prompt itself (mirrors runRLM's
-    // rlmQuerySpawner contract).
-    const childDoc =
-      contextDoc !== null && contextDoc.length > 0 ? contextDoc : prompt;
+    // Child's working document. contextDoc === null means the user
+    // OMITTED the (context …) form — fall back to the prompt so a
+    // no-context rlm_query still has something to operate on. An
+    // EMPTY string ("") means the user passed an explicit but
+    // empty context (e.g., `(context [])` — empty handle); preserve
+    // their intent and let the child see an empty document.
+    // Conflating the two would silently mask "I expected results
+    // but got none" bugs — same correctness fix applied in
+    // rlm.ts's rlmQuerySpawner during the Phase 1 review.
+    const childDoc = contextDoc !== null ? contextDoc : prompt;
     try {
       const result = await runRLMFromContent(prompt, childDoc, {
         llmClient: samplingBridge,
@@ -1432,10 +1437,27 @@ async function main() {
     }
   };
 
-  // Phase 2 — concurrent variant for `(rlm_batch …)`. Fans out to
-  // N samplingRlmBridge calls via Promise.all. Each child runs
-  // independently, sharing the parent's MCP llmClient. Errors in
-  // one item don't abort the rest — the slot gets a marker string.
+  // Phase 2 — sequential variant for `(rlm_batch …)` in the MCP
+  // path. We run children ONE AT A TIME instead of via Promise.all
+  // because the multi-turn suspension protocol can only carry ONE
+  // pending llm_query suspension at a time: if 5 children all
+  // suspend in parallel, only the first suspension reaches the
+  // user via the lattice_query reply, and the other 4 hang
+  // forever in pendingQueries with no way for the user to respond
+  // to them. Sequential dispatch trades parallelism for protocol
+  // correctness.
+  //
+  // For sampling-capable clients (samplingBridge uses
+  // server.createMessage directly, no suspension), concurrent
+  // dispatch would work — but rlm_batch already only matters when
+  // each child runs multiple turns, and serializing N children
+  // each running M turns = N*M round-trips either way. The
+  // round-trip count is identical; only wall-clock differs.
+  // Per project rule (correctness > performance): take the
+  // correct sequential path uniformly.
+  //
+  // Per-item errors still surface as marker strings without
+  // aborting the rest of the batch.
   samplingRlmBatchBridge = async (
     items: Array<{ prompt: string; contextDoc: string | null }>
   ): Promise<string[]> => {
@@ -1444,16 +1466,16 @@ async function main() {
         (_, i) => `Error: rlm_batch item ${i} — samplingRlmBridge not initialized`
       );
     }
-    return Promise.all(
-      items.map(async (it, idx) => {
-        try {
-          return await samplingRlmBridge!(it.prompt, it.contextDoc);
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          return `Error: rlm_batch item ${idx} failed — ${msg}`;
-        }
-      })
-    );
+    const results: string[] = [];
+    for (let idx = 0; idx < items.length; idx++) {
+      try {
+        results.push(await samplingRlmBridge(items[idx].prompt, items[idx].contextDoc));
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        results.push(`Error: rlm_batch item ${idx} failed — ${msg}`);
+      }
+    }
+    return results;
   };
 
   await server.connect(transport);

--- a/src/logic/lc-solver.ts
+++ b/src/logic/lc-solver.ts
@@ -543,11 +543,21 @@ async function evaluate(
       // FINAL_VAR substitution, or just passed back to the user as
       // the answer. Format mirrors `lattice_bindings` in spirit but
       // is reachable from inside a query.
-      if (bindings.size === 0) {
+      //
+      // Internal bindings start with `_` followed by a non-digit
+      // character (e.g., `_sessionDB`, `_compaction_trace`). These
+      // are private plumbing the user shouldn't see — surfacing
+      // them would expose internal state and confuse the LLM about
+      // what it can FINAL_VAR-reference. User-visible bindings:
+      // RESULTS, plain names, and `_<digits>` (per-turn results).
+      const isInternal = (name: string): boolean =>
+        name.startsWith("_") && name.length > 1 && !/^_\d/.test(name);
+      const visibleEntries = [...bindings].filter(([n]) => !isInternal(n));
+      if (visibleEntries.length === 0) {
         return "No bindings yet — run a query to populate RESULTS or a binding name.";
       }
       const lines: string[] = [];
-      for (const [name, value] of bindings) {
+      for (const [name, value] of visibleEntries) {
         let shape: string;
         if (Array.isArray(value)) {
           shape = `Array(${value.length})`;
@@ -568,7 +578,7 @@ async function evaluate(
         }
         lines.push(`  ${name}: ${shape}`);
       }
-      return `Bindings (${bindings.size}):\n${lines.join("\n")}`;
+      return `Bindings (${visibleEntries.length}):\n${lines.join("\n")}`;
     }
 
     case "context": {

--- a/src/rlm.ts
+++ b/src/rlm.ts
@@ -428,6 +428,18 @@ export interface RLMOptions {
    */
   maxErrors?: number;
   /**
+   * Phase 6 — compaction threshold in chars. When the FSM's prompt
+   * (system + user/assistant history concatenated) exceeds this
+   * threshold, the loop emits a one-shot summarization llm_query
+   * to condense turns 2..N into a single assistant message,
+   * then resumes with [system, first user, summary, latest turn].
+   * The full pre-compaction history is stashed as a binding
+   * (`_compaction_trace`) for retrieval. Default unset = no
+   * compaction. Use this to keep long-running sessions from
+   * blowing past the model's context window.
+   */
+  compactionThresholdChars?: number;
+  /**
    * Internal — current sub-RLM depth. Automatically incremented by
    * the sub-RLM spawner each time a `(llm_query …)` call recurses.
    * Never set this manually from user code; it's a private parameter
@@ -501,6 +513,7 @@ export async function runRLMFromContent(
     maxTimeoutMs,
     maxTokens,
     maxErrors,
+    compactionThresholdChars,
     _subRLMDepth = 0,
   } = options;
 
@@ -824,6 +837,7 @@ export async function runRLMFromContent(
       maxTimeoutMs,
       maxTokens,
       maxErrors,
+      compactionThresholdChars,
     });
 
     const engine = new FSMEngine<RLMContext>();

--- a/tests/logic/compaction.test.ts
+++ b/tests/logic/compaction.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Phase 6 — history compaction.
+ *
+ * When the FSM's message history grows past `compactionThresholdChars`,
+ * the loop emits a one-shot summarization llm_query that condenses
+ * turns 2..N into a single assistant message. The history is then
+ * replaced with [system, first user, summary, latest turn] so the
+ * next LLM call sees a much smaller prompt without losing the gist
+ * of prior progress. The full pre-compaction history is stashed as
+ * a binding (`_compaction_trace`) for later retrieval if needed.
+ *
+ * Coverage:
+ *   1. Threshold-trigger: with a low threshold, compaction fires on
+ *      a multi-turn run; subsequent prompts are smaller.
+ *   2. Preservation: solver bindings (RESULTS, _N) survive
+ *      compaction — they're separate from the message history.
+ *   3. Stash: the pre-compaction trace is retrievable via the
+ *      `_compaction_trace` binding.
+ *   4. Backwards-compat: with no threshold, behavior is unchanged.
+ *   5. Single-shot: a turn that crosses the threshold once doesn't
+ *      keep firing summarization indefinitely.
+ */
+
+import { describe, it, expect } from "vitest";
+import { runRLMFromContent } from "../../src/rlm.js";
+import { createNucleusAdapter } from "../../src/adapters/nucleus.js";
+
+describe("Phase 6 — compaction trigger", () => {
+  it("compacts when history exceeds threshold and shrinks subsequent prompts", async () => {
+    // Track every prompt size. With compaction at 1500 chars, the
+    // sequence should show: turn 1 (small), turn 2 (bigger), turn 3
+    // (likely triggers compaction → smaller again), ...
+    const promptSizes: number[] = [];
+    let summaryCalls = 0;
+    const llm = async (prompt: string): Promise<string> => {
+      promptSizes.push(prompt.length);
+      // Compaction fires its summarization with a "Summarize your
+      // progress so far" prefix so we can detect and tag the call.
+      if (/summarize.*progress|summarize.*conversation/i.test(prompt)) {
+        summaryCalls++;
+        return "Summary: turn 1 grepped X (3 matches), turn 2 grepped Y (2 matches).";
+      }
+      // Each non-summary turn returns a grep so the FSM accumulates
+      // history chunks.
+      return `(grep "X")`;
+    };
+    // Doc with enough lines that grep accumulates per-turn output.
+    const doc = Array.from({ length: 60 }, (_, i) => `X-line-${i}: some content`).join("\n");
+
+    const result = (await runRLMFromContent("scan X", doc, {
+      llmClient: llm,
+      adapter: createNucleusAdapter(),
+      maxTurns: 6,
+      ragEnabled: false,
+      compactionThresholdChars: 2500,
+    })) as string;
+
+    expect(typeof result).toBe("string");
+    // Must have triggered AT LEAST one summarization.
+    expect(summaryCalls).toBeGreaterThanOrEqual(1);
+    // After compaction, a subsequent prompt MUST be smaller than
+    // the prompt that triggered it. Find the largest prompt and
+    // check that a SMALLER prompt comes after it (proving the
+    // history surgery actually shrank things).
+    const largestIdx = promptSizes.indexOf(Math.max(...promptSizes));
+    const after = promptSizes.slice(largestIdx + 1);
+    expect(after.length).toBeGreaterThan(0);
+    expect(Math.min(...after)).toBeLessThan(promptSizes[largestIdx]);
+  });
+});
+
+describe("Phase 6 — bindings survive compaction", () => {
+  it("RESULTS / _N bindings remain available after a compaction event", async () => {
+    // Turn 1: grep (large result → triggers compaction afterward).
+    // Turn 2: AFTER compaction, FINAL inlining FINAL_VAR(_1). _1
+    //   must still resolve to the grep array even though the
+    //   message history was rewritten.
+    let turn = 0;
+    const llm = async (prompt: string): Promise<string> => {
+      if (/Summarize your progress so far/.test(prompt)) return "Summary: turn 1 grepped Xs.";
+      turn++;
+      if (turn === 1) return `(grep "X")`;
+      // Turn 2: FINAL referencing _1 (the grep result from turn 1).
+      // If bindings were lost during compaction, FINAL_VAR(_1)
+      // would surface an "[FINAL_VAR error: ...]" string.
+      return `<<<FINAL>>>FINAL_VAR(_1)<<<END>>>`;
+    };
+    const doc = Array.from(
+      { length: 80 },
+      (_, i) => `X-${i} ${"filler".repeat(20)}`
+    ).join("\n");
+    const result = (await runRLMFromContent("scan Xs", doc, {
+      llmClient: llm,
+      adapter: createNucleusAdapter(),
+      maxTurns: 6,
+      ragEnabled: false,
+      compactionThresholdChars: 1500,
+    })) as string;
+
+    expect(typeof result).toBe("string");
+    // _1 resolved → result contains the grep matches (X-0, X-1, ...).
+    // If the binding was lost, we'd see FINAL_VAR error markers.
+    expect(result).not.toMatch(/FINAL_VAR error/i);
+    expect(result).toMatch(/X-0|X-1|X-/);
+  });
+});
+
+describe("Phase 6 — pre-compaction trace stashed", () => {
+  it("the full pre-compaction history is retrievable as the _compaction_trace binding", async () => {
+    let turn = 0;
+    const llm = async (prompt: string): Promise<string> => {
+      if (/Summarize your progress so far/.test(prompt)) return "Summary: stuff happened.";
+      turn++;
+      if (turn === 1) return `(grep "TAG-")`;
+      if (turn === 2) return `(grep "X")`;
+      // After compaction (assumed to fire by turn 3), inspect the
+      // stashed trace.
+      return `<<<FINAL>>>FINAL_VAR(_compaction_trace)<<<END>>>`;
+    };
+    const doc = Array.from({ length: 80 }, (_, i) => `TAG-${i}: ${"x".repeat(30)}`).join(
+      "\n"
+    );
+    const result = (await runRLMFromContent("scan", doc, {
+      llmClient: llm,
+      adapter: createNucleusAdapter(),
+      maxTurns: 6,
+      ragEnabled: false,
+      compactionThresholdChars: 1500,
+    })) as string;
+
+    expect(typeof result).toBe("string");
+    // The stashed trace must contain content from PRE-compaction
+    // turns. We expect to see at least one of the original
+    // assistant responses or feedback strings.
+    expect(result).toMatch(/grep|TAG-|Result:/i);
+    // It must NOT be the unresolved FINAL_VAR marker — the binding
+    // has to actually exist.
+    expect(result).not.toMatch(/FINAL_VAR error/i);
+  });
+});
+
+describe("Phase 6 — failing compaction does not loop forever", () => {
+  it("after N consecutive compaction failures, compaction is disabled and the run continues", async () => {
+    // Simulated failing summarize: every compaction call throws.
+    // Without the failure cap, the FSM would keep retrying every
+    // turn since the failed compaction doesn't shrink history.
+    let summarizeCalls = 0;
+    let turn = 0;
+    const llm = async (prompt: string): Promise<string> => {
+      if (/Summarize your progress so far/.test(prompt)) {
+        summarizeCalls++;
+        throw new Error("simulated summarize failure");
+      }
+      turn++;
+      if (turn === 1) return `(grep "X")`;
+      // After turn 1, history is huge; subsequent turns try to
+      // compact, fail, then continue. We emit FINAL on turn 2.
+      return `<<<FINAL>>>FINAL_VAR(_1)<<<END>>>`;
+    };
+    const doc = Array.from(
+      { length: 80 },
+      (_, i) => `X-${i} ${"filler".repeat(20)}`
+    ).join("\n");
+    const result = (await runRLMFromContent("scan", doc, {
+      llmClient: llm,
+      adapter: createNucleusAdapter(),
+      maxTurns: 6,
+      ragEnabled: false,
+      compactionThresholdChars: 1500,
+    })) as string;
+
+    expect(typeof result).toBe("string");
+    // The cap is N=2 in production. Anything above ~3 means the
+    // loop kept retrying — bug. The cap stops it.
+    expect(summarizeCalls).toBeLessThanOrEqual(3);
+    // The run should complete despite compaction being disabled.
+    expect(result).not.toMatch(/Max turns/);
+  });
+});
+
+describe("Phase 6 — backwards compat", () => {
+  it("with no threshold configured, no summarization fires", async () => {
+    let summaryCalls = 0;
+    let turn = 0;
+    const llm = async (prompt: string): Promise<string> => {
+      if (/summarize.*progress|summarize.*conversation/i.test(prompt)) {
+        summaryCalls++;
+      }
+      turn++;
+      if (turn === 1) return `(grep "X")`;
+      return `<<<FINAL>>>done<<<END>>>`;
+    };
+    const doc = Array.from({ length: 50 }, () => "x".repeat(100)).join("\n");
+    const result = (await runRLMFromContent("X", doc, {
+      llmClient: llm,
+      adapter: createNucleusAdapter(),
+      maxTurns: 3,
+      ragEnabled: false,
+    })) as string;
+    expect(typeof result).toBe("string");
+    expect(summaryCalls).toBe(0);
+    expect(result).toContain("done");
+  });
+});

--- a/tests/logic/handle-session-rlm.test.ts
+++ b/tests/logic/handle-session-rlm.test.ts
@@ -1,0 +1,105 @@
+/**
+ * MCP-side plumbing for rlm_query / rlm_batch.
+ *
+ * HandleSession is what lattice-mcp-server uses to execute Nucleus
+ * queries. Pre-Phase-1, the engine only had llmQuery/llmBatch wired
+ * — calling (rlm_query …) or (rlm_batch …) via the MCP path threw
+ * "not available in this execution context."
+ *
+ * This file locks down: when HandleSessionOptions includes rlmQuery
+ * / rlmBatch callbacks (the lattice-mcp-server's samplingRlmBridge),
+ * the recursive primitives work end-to-end — same surface as the
+ * runRLM path.
+ */
+
+import { describe, it, expect } from "vitest";
+import { HandleSession } from "../../src/engine/handle-session.js";
+
+describe("HandleSession — rlm_query plumbing", () => {
+  it("throws 'not available' when rlmQuery option is omitted (back-compat)", async () => {
+    const session = new HandleSession();
+    await session.loadContentWithSymbols("doc content", "/tmp/x.txt");
+    const result = await session.execute('(rlm_query "test")');
+    expect(result.success).toBe(false);
+    expect(result.error ?? "").toMatch(/rlm_query.*not available/i);
+    session.close();
+  });
+
+  it("dispatches (rlm_query …) through the rlmQuery callback when configured", async () => {
+    let receivedPrompt: string | null = null;
+    let receivedContext: string | null = "<unset>";
+    const session = new HandleSession({
+      rlmQuery: async (prompt, contextDoc) => {
+        receivedPrompt = prompt;
+        receivedContext = contextDoc;
+        return "child returned this";
+      },
+    });
+    await session.loadContentWithSymbols("doc content", "/tmp/x.txt");
+    const result = await session.execute('(rlm_query "summarize")');
+    expect(result.success).toBe(true);
+    expect(receivedPrompt).toBe("summarize");
+    expect(receivedContext).toBeNull();
+    expect(result.value).toBe("child returned this");
+    session.close();
+  });
+
+  it("dispatches (rlm_query \"p\" (context $h)) materializing the binding to the child", async () => {
+    // Same handle-as-document semantics Phase 1 introduced — the
+    // MCP path must preserve this so a child sees clean line-
+    // oriented content, not a JSON blob.
+    let receivedContext: string | null = null;
+    const session = new HandleSession({
+      rlmQuery: async (_p, c) => {
+        receivedContext = c;
+        return "ok";
+      },
+    });
+    await session.loadContentWithSymbols("X-1\nX-2\nY", "/tmp/x.txt");
+    // Bind RESULTS via grep, then pass it as context.
+    await session.execute('(grep "X")');
+    const result = await session.execute(
+      '(rlm_query "scan" (context RESULTS))'
+    );
+    expect(result.success).toBe(true);
+    // Materialized as one item per line.
+    expect(typeof receivedContext).toBe("string");
+    const lines = (receivedContext as unknown as string).split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines.every((l) => /^X-/.test(l))).toBe(true);
+    session.close();
+  });
+});
+
+describe("HandleSession — rlm_batch plumbing", () => {
+  it("throws 'not available' when rlmBatch option is omitted", async () => {
+    const session = new HandleSession();
+    await session.loadContentWithSymbols("X\nY", "/tmp/x.txt");
+    await session.execute('(grep "X")');
+    const result = await session.execute(
+      '(rlm_batch RESULTS (lambda c (rlm_query "p" (context c))))'
+    );
+    expect(result.success).toBe(false);
+    expect(result.error ?? "").toMatch(/rlm_batch.*not available/i);
+    session.close();
+  });
+
+  it("dispatches (rlm_batch …) through the rlmBatch callback when configured", async () => {
+    let receivedItems: Array<{ prompt: string; contextDoc: string | null }> | null = null;
+    const session = new HandleSession({
+      rlmBatch: async (items) => {
+        receivedItems = items;
+        return items.map((_, i) => `r${i}`);
+      },
+    });
+    await session.loadContentWithSymbols("X-1\nX-2\nX-3", "/tmp/x.txt");
+    await session.execute('(grep "X")');
+    const result = await session.execute(
+      '(rlm_batch RESULTS (lambda c (rlm_query "tag" (context c))))'
+    );
+    expect(result.success).toBe(true);
+    expect(receivedItems).toHaveLength(3);
+    expect(receivedItems!.every((it) => it.prompt === "tag")).toBe(true);
+    session.close();
+  });
+});

--- a/tests/logic/handle-session-rlm.test.ts
+++ b/tests/logic/handle-session-rlm.test.ts
@@ -44,6 +44,36 @@ describe("HandleSession — rlm_query plumbing", () => {
     session.close();
   });
 
+  it("preserves an explicit empty context binding (does not silently fall back to prompt)", async () => {
+    // Same correctness contract that rlm.ts's rlmQuerySpawner
+    // honors: contextDoc === null means "user omitted the
+    // (context …) form" (fall back to prompt-as-doc); empty
+    // string means "user passed explicit empty handle"
+    // (preserve the user's intent so they see "no results"
+    // rather than the prompt being used as document).
+    let receivedContext: string | null | undefined = "<unset>";
+    const session = new HandleSession({
+      rlmQuery: async (_p, c) => {
+        receivedContext = c;
+        return "ok";
+      },
+    });
+    await session.loadContentWithSymbols("doc", "/tmp/x.txt");
+    // Bind RESULTS to an empty array so the materializer produces "".
+    // (Use grep with a non-matching pattern to get an empty array.)
+    const probe = await session.execute('(grep "NEVER_MATCHES")');
+    expect(probe.success).toBe(true);
+    const result = await session.execute(
+      '(rlm_query "task" (context RESULTS))'
+    );
+    expect(result.success).toBe(true);
+    // Must reach the child as "" (empty), NOT null (no-context).
+    // Without this contract, a binding that legitimately has no
+    // matches would silently swap in the prompt — masking bugs.
+    expect(receivedContext).toBe("");
+    session.close();
+  });
+
   it("dispatches (rlm_query \"p\" (context $h)) materializing the binding to the child", async () => {
     // Same handle-as-document semantics Phase 1 introduced — the
     // MCP path must preserve this so a child sees clean line-

--- a/tests/logic/integration-audit.test.ts
+++ b/tests/logic/integration-audit.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Integration audit — cross-phase regression sweep.
+ *
+ * Six phases (rlm_query, rlm_batch, multi-context, FINAL_VAR/show_vars,
+ * resource limits, compaction) shipped independently with their own
+ * unit tests + benefit demos. Each review found one bug. This file
+ * tests the *combinations* — phase-interaction bugs that wouldn't
+ * show up in any single-phase test.
+ *
+ * Each scenario probes a specific composition that real users will
+ * hit. If something here breaks, it's a real bug, not a contrived
+ * edge case.
+ */
+
+import { describe, it, expect } from "vitest";
+import { runRLMFromContent } from "../../src/rlm.js";
+import { createNucleusAdapter } from "../../src/adapters/nucleus.js";
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// ============================================================
+// 1. rlm_batch + maxTimeoutMs — does the timeout propagate to
+//    every child in the batch, not just the first?
+// ============================================================
+
+describe("integration: rlm_batch + maxTimeoutMs propagation", () => {
+  it("a slow child hits the parent's remaining timeout cap, not the child's own clock", async () => {
+    // Parent: chunk_by_lines → rlm_batch → each child sleeps 200ms.
+    // With concurrency 4 and 8 chunks, sequential batches = 400ms.
+    // maxTimeoutMs = 250ms means the SECOND batch should be
+    // interrupted; the run aborts cleanly.
+    const llm = async (prompt: string): Promise<string> => {
+      const isChild =
+        prompt.startsWith("You are a sub-LLM invoked") ||
+        /Query:\s*scan/.test(prompt);
+      if (isChild) {
+        await sleep(200);
+        return `<<<FINAL>>>done<<<END>>>`;
+      }
+      // Parent flow.
+      if (!prompt.includes("Bindings:")) {
+        return `(chunk_by_lines 1)`;
+      }
+      if ((prompt.match(/\nBindings:\n/g)?.length ?? 0) === 1) {
+        return `(rlm_batch RESULTS (lambda c (rlm_query "scan" (context c))))`;
+      }
+      return `<<<FINAL>>>FINAL_VAR(_2)<<<END>>>`;
+    };
+    const doc = ["a", "b", "c", "d", "e", "f", "g", "h"].join("\n");
+    const start = Date.now();
+    const result = (await runRLMFromContent("scan all", doc, {
+      llmClient: llm,
+      adapter: createNucleusAdapter(),
+      maxTurns: 6,
+      ragEnabled: false,
+      subRLMMaxDepth: 1,
+      maxConcurrentSubcalls: 4,
+      maxTimeoutMs: 250,
+    })) as string;
+    const elapsed = Date.now() - start;
+
+    // Must abort cleanly (the timeout race fires) within ~1.5x the
+    // cap. Without proper propagation, the run would burn 400ms+
+    // letting the second batch complete.
+    expect(elapsed).toBeLessThan(450);
+    expect(result).toMatch(/aborted.*timeout/i);
+  });
+});
+
+// ============================================================
+// 2. rlm_query + (context N) — can a child see the parent's
+//    multi-context loaded docs, or does it only see the chunk
+//    the parent passed?
+// ============================================================
+
+describe("integration: rlm_query + multi-context", () => {
+  it("a child rlm_query receives only its assigned context, not all parent contexts", async () => {
+    // Parent loads 3 docs. Spawns rlm_query with (context 1) — the
+    // child's working document MUST be doc 1's content. The child
+    // running its own (grep "X") should match in doc 1, NOT in doc 0
+    // or doc 2.
+    const llm = async (prompt: string): Promise<string> => {
+      const isChild =
+        prompt.startsWith("You are a sub-LLM invoked") ||
+        /Query:\s*find marker/.test(prompt);
+      if (isChild) {
+        // Child: emit grep for the unique marker.
+        if (!prompt.includes("Bindings:")) {
+          return `(grep "MARKER")`;
+        }
+        return `<<<FINAL>>>FINAL_VAR(_1)<<<END>>>`;
+      }
+      if (!prompt.includes("Bindings:")) {
+        return `(rlm_query "find marker" (context (context 1)))`;
+      }
+      return `<<<FINAL>>>FINAL_VAR(_1)<<<END>>>`;
+    };
+    const docs = [
+      "doc0: no marker here\nfiller",
+      "doc1: MARKER-FOUND-IN-DOC1\nMARKER-AGAIN-IN-DOC1",
+      "doc2: also no marker",
+    ];
+    const result = (await runRLMFromContent("locate", docs, {
+      llmClient: llm,
+      adapter: createNucleusAdapter(),
+      maxTurns: 6,
+      ragEnabled: false,
+      subRLMMaxDepth: 1,
+    })) as string;
+
+    expect(typeof result).toBe("string");
+    // The child's grep must have found exactly the doc-1 markers,
+    // not the absence-of-marker text from doc 0 or doc 2.
+    expect(result).toMatch(/MARKER-FOUND-IN-DOC1/);
+    expect(result).toMatch(/MARKER-AGAIN-IN-DOC1/);
+    // And NOT doc 0 / doc 2 content.
+    expect(result).not.toMatch(/doc0|doc2|no marker/);
+  });
+});
+
+// ============================================================
+// 3. compaction + FINAL_VAR — after a compaction event, can
+//    the LLM still inline a binding via FINAL_VAR(_N)?
+// ============================================================
+
+describe("integration: compaction + FINAL_VAR", () => {
+  it("FINAL_VAR(_N) resolves correctly even after compaction has rewritten history", async () => {
+    let turn = 0;
+    const llm = async (prompt: string): Promise<string> => {
+      if (/Summarize your progress so far/.test(prompt)) {
+        return "Summary: ran a grep for X.";
+      }
+      turn++;
+      if (turn === 1) return `(grep "X")`;
+      // Turn 2 fires after compaction (history was big from
+      // turn 1's grep result feedback). FINAL_VAR(_1) must
+      // resolve to the grep array — the binding was set in
+      // turn 1 and survives compaction.
+      return `<<<FINAL>>>FINAL_VAR(_1)<<<END>>>`;
+    };
+    const doc = Array.from({ length: 60 }, (_, i) => `X-${i} ${"f".repeat(30)}`).join(
+      "\n"
+    );
+    const result = (await runRLMFromContent("scan", doc, {
+      llmClient: llm,
+      adapter: createNucleusAdapter(),
+      maxTurns: 4,
+      ragEnabled: false,
+      compactionThresholdChars: 1500,
+    })) as string;
+
+    expect(typeof result).toBe("string");
+    // Must contain real grep results — proves the binding survived.
+    expect(result).toMatch(/X-0|X-1/);
+    // And no FINAL_VAR error markers.
+    expect(result).not.toMatch(/FINAL_VAR error/i);
+  });
+});
+
+// ============================================================
+// 4. rlm_query + maxErrors — does a stuck child trip the
+//    parent's error budget, or does the child's own error count
+//    stay isolated?
+// ============================================================
+
+describe("integration: rlm_query + maxErrors isolation", () => {
+  it("a child's parse-error loop does NOT count against the parent's maxErrors", async () => {
+    // Parent's first turn fires rlm_query. The CHILD always emits
+    // parse errors. If maxErrors propagates correctly (and the
+    // child has its OWN counter), the child trips its own error
+    // cap and returns an "[aborted: errors ...]" string — which
+    // the parent receives as a normal rlm_query result. The
+    // parent itself has not had any errors and proceeds to FINAL.
+    const llm = async (prompt: string): Promise<string> => {
+      const isChild =
+        prompt.startsWith("You are a sub-LLM invoked") ||
+        /Query:\s*deep/.test(prompt);
+      if (isChild) {
+        return `(grep`; // unbalanced — parser error
+      }
+      if (!prompt.includes("Bindings:")) {
+        return `(rlm_query "deep" (context (context 0)))`;
+      }
+      // Parent's _1 = the child's "[aborted: errors ...]" string.
+      // Parent's FINAL inlines that as the answer.
+      return `<<<FINAL>>>child returned: FINAL_VAR(_1)<<<END>>>`;
+    };
+    const result = (await runRLMFromContent("ask", "X\nY\nZ", {
+      llmClient: llm,
+      adapter: createNucleusAdapter(),
+      // Parent maxTurns=6 → child inherits floor(6/2)=3 turns, enough
+      // to accumulate 2 consecutive errors before maxTurns kicks in.
+      maxTurns: 6,
+      ragEnabled: false,
+      subRLMMaxDepth: 1,
+      maxErrors: 2, // child should hit this; parent shouldn't
+    })) as string;
+
+    expect(typeof result).toBe("string");
+    // The parent's run completed — it surfaced the child's failure
+    // string but did not itself trip the error cap.
+    expect(result).toMatch(/aborted.*errors/i);
+    // And the parent did NOT itself abort — the answer flows from
+    // the parent's FINAL, not from a parent-level abort.
+    expect(result).toMatch(/child returned:/);
+  });
+});
+
+// ============================================================
+// 5. (show_vars) inside rlm_query — does a child see ITS OWN
+//    bindings, not the parent's?
+// ============================================================
+
+describe("integration: show_vars inside rlm_query child", () => {
+  it("a child's (show_vars) reflects only the child's bindings", async () => {
+    // Parent: turn 1 grep, turn 2 rlm_query, turn 3 FINAL.
+    // Child: turn 1 grep (binds child-_1), turn 2 (show_vars)
+    // (binds child-_2 = string of child bindings only),
+    // turn 3 FINAL referencing child-_2.
+    //
+    // The child's show_vars output MUST mention child's _1 (the
+    // child's grep) and NOT the parent's RESULTS or _N. If they
+    // leaked, scope is broken.
+    const llm = async (prompt: string): Promise<string> => {
+      const isChild =
+        prompt.startsWith("You are a sub-LLM invoked") ||
+        /Query:\s*introspect/.test(prompt);
+      if (isChild) {
+        // Use the prior-turn marker count to pick the child's turn
+        // because the child's history isn't compacted here.
+        const childTurns = (prompt.match(/\nBindings:\n/g)?.length ?? 0) + 1;
+        if (childTurns === 1) return `(grep "CHILD-")`;
+        if (childTurns === 2) return `(show_vars)`;
+        return `<<<FINAL>>>FINAL_VAR(_2)<<<END>>>`;
+      }
+      const parentTurns = (prompt.match(/\nBindings:\n/g)?.length ?? 0) + 1;
+      if (parentTurns === 1) return `(grep "PARENT-")`;
+      if (parentTurns === 2) {
+        return `(rlm_query "introspect" (context (context 0)))`;
+      }
+      return `<<<FINAL>>>FINAL_VAR(_2)<<<END>>>`;
+    };
+    const doc = "PARENT-line-A\nCHILD-line-B\nPARENT-line-C\nCHILD-line-D";
+    const result = (await runRLMFromContent("scope test", doc, {
+      llmClient: llm,
+      adapter: createNucleusAdapter(),
+      maxTurns: 6,
+      ragEnabled: false,
+      subRLMMaxDepth: 1,
+    })) as string;
+
+    expect(typeof result).toBe("string");
+    // The result is the parent's FINAL, which expands to the
+    // rlm_query result, which is the CHILD's FINAL_VAR(_2)
+    // expansion = the child's show_vars output. That string
+    // describes the child's bindings.
+    //
+    // Child bound _1 (its grep) and _2 (show_vars itself). Both
+    // those names should appear in the show_vars output. If the
+    // PARENT's _1 (PARENT-) data leaked into the child's bindings,
+    // it would corrupt scope.
+    expect(result).toMatch(/_1.*Array|RESULTS.*Array/i);
+    // Sanity: the child's grep bound _1 to CHILD- entries; if scope
+    // is correct, the child's RESULTS array contains CHILD-line-*
+    // matches via grep over the child's document.
+  });
+});
+
+// ============================================================
+// 6. resource limits + child abort — does a child's
+//    [aborted: ...] string leak into the parent's
+//    bestPartialAnswer? (Phase 5 review caught this once.)
+// ============================================================
+
+describe("integration: child abort isolation in bestPartialAnswer", () => {
+  it("a child's '[aborted: ...]' string never replaces the parent's good partial", async () => {
+    // Parent: turn 1 useful grep (good RESULTS), turn 2 slow
+    // rlm_query. Child times out via its own (propagated) cap.
+    // Parent ALSO hits its cap on turn 3. Parent's partial
+    // answer must surface its turn-1 grep, NOT the child's
+    // "[aborted: ...]" string.
+    const llm = async (prompt: string): Promise<string> => {
+      const isChild =
+        prompt.startsWith("You are a sub-LLM invoked") ||
+        /Query:\s*deep/.test(prompt);
+      if (isChild) {
+        await sleep(150);
+        return `(grep "Z")`;
+      }
+      const parentTurns = (prompt.match(/\nBindings:\n/g)?.length ?? 0) + 1;
+      if (parentTurns === 1) return `(grep "TOKEN-")`;
+      await sleep(150);
+      return `(rlm_query "deep" (context (context 0)))`;
+    };
+    const doc = "TOKEN-A\nTOKEN-B\nTOKEN-C\nfiller";
+    const result = (await runRLMFromContent("find", doc, {
+      llmClient: llm,
+      adapter: createNucleusAdapter(),
+      maxTurns: 6,
+      ragEnabled: false,
+      subRLMMaxDepth: 1,
+      maxTimeoutMs: 250,
+    })) as string;
+
+    expect(typeof result).toBe("string");
+    expect(result).toMatch(/aborted/i);
+    // Partial must include the parent's grep (TOKEN-*).
+    expect(result).toMatch(/TOKEN-/);
+    // EXACTLY ONE "[aborted:" — the parent's. The child's
+    // failure string MUST NOT have leaked into the partial.
+    const aborts = result.match(/\[aborted:/g);
+    expect(aborts ? aborts.length : 0).toBe(1);
+  });
+});

--- a/tests/logic/show-vars.test.ts
+++ b/tests/logic/show-vars.test.ts
@@ -95,4 +95,44 @@ describe("(show_vars) solver", () => {
     const out = result.value as string;
     expect(out).toMatch(/no bindings|no variables|empty/i);
   });
+
+  it("filters out internal bindings (_sessionDB, _compaction_trace, etc.)", async () => {
+    // Internal plumbing names start with `_` and a non-digit char.
+    // They MUST NOT surface via show_vars — leaking session DB
+    // refs or pre-compaction traces to the LLM exposes private
+    // state and clutters the user-visible binding list.
+    const parsed = parse("(show_vars)");
+    const tools = makeTools();
+    const bindings = new Map<string, unknown>([
+      ["_sessionDB", { internal: true }],
+      ["_compaction_trace", "long history dump"],
+      ["RESULTS", [1, 2, 3]],
+      ["_1", "turn-1 result"],
+      ["_2", 42],
+    ]);
+    const result = await solve(parsed.term!, tools, bindings);
+    expect(result.success).toBe(true);
+    const out = result.value as string;
+    // User-visible bindings are present.
+    expect(out).toContain("RESULTS");
+    expect(out).toContain("_1");
+    expect(out).toContain("_2");
+    // Internal bindings are NOT.
+    expect(out).not.toContain("_sessionDB");
+    expect(out).not.toContain("_compaction_trace");
+    // Count reflects user-visible only.
+    expect(out).toMatch(/Bindings \(3\):/);
+  });
+
+  it("returns the friendly empty-state message when only internal bindings exist", async () => {
+    const parsed = parse("(show_vars)");
+    const tools = makeTools();
+    const bindings = new Map<string, unknown>([
+      ["_sessionDB", { internal: true }],
+    ]);
+    const result = await solve(parsed.term!, tools, bindings);
+    expect(result.success).toBe(true);
+    const out = result.value as string;
+    expect(out).toMatch(/no bindings/i);
+  });
 });


### PR DESCRIPTION
Adds compactionThresholdChars to RLMOptions. When the FSM's prompt exceeds the threshold, the loop emits a one-shot summarization llm_query that condenses turns 2..N into a single assistant message, then resumes with [system, first user, summary, "next action"]. Bindings (RESULTS, _N) survive — only the message history is rewritten. The full pre-compaction trace is stashed as the `_compaction_trace` solver binding so a follow-up FINAL_VAR(_compaction_trace) can retrieve it.

Implementation:
- RLMOptions: new optional `compactionThresholdChars`. Unset → no compaction (back-compat). RLMContext gains compactionThresholdChars, compactionCount, compactionFailures.
- handleQueryLLM: after limit checks, if prompt size exceeds threshold, calls compactHistory before building the actual prompt. Skipped after N failures (see review fix below).
- compactHistory: stashes full trace as a binding, sends a "Summarize your progress so far" prompt to llmClient, replaces history[2..N] with the resulting summary. Multiple compactions in one run get suffixed binding names (`_compaction_trace_2`, etc.) so the prior trace is preserved.
- formatAbort and bestPartialAnswer surface unchanged — partial answers from pre-compaction turns still flow through.

Demo gate (matryoshka-zpn):
- Simulated context limit of 6000 chars; baseline (no compaction) hits "Max turns reached" because the model rejects oversized prompts mid-run. Phase 6 (threshold=4500) trims history before crossing the limit and produces a real FINAL with grep results from turn 5.

Review pass found and fixed:
- Bug: a failing summarize call (e.g., model rejects oversized prompt) would leave history unchanged, so the threshold check would fire compaction again on every subsequent turn — infinite loop. Fixed by tracking compactionFailures and disabling further compaction attempts after the cap (default 2). Run continues to its other limits cleanly. Per project rule: correctness > performance, surface failure rather than spinning silently.
- Test added: simulated always-throwing summarize verifies the cap holds and the run completes.

Total: 3189/3192 tests pass. 5 unit tests + before/after demo.