### PR TITLE
fix(fsm): abort RLM loop on repeated LLM client failures

### DIFF
--- a/src/fsm/rlm-states.ts
+++ b/src/fsm/rlm-states.ts
@@ -78,6 +78,17 @@ export interface RLMContext {
   startTime: number;
   totalTokens: number;
   consecutiveErrors: number;
+  /**
+   * Counts consecutive LLM-client throws (auth failure, network error,
+   * bad URL). Reset to 0 after a successful LLM call. When it reaches
+   * `MAX_CONSECUTIVE_LLM_ERRORS`, the FSM aborts with the original
+   * error message in the abort string. Without this, an unrecoverable
+   * config error (e.g., invalid API key) would silently retry until
+   * maxTurns and surface as "max turns reached" — masking the real
+   * cause.
+   */
+  consecutiveLlmErrors: number;
+  lastLlmError: string;
   compactionThresholdChars?: number;
   compactionCount: number;
   /**
@@ -107,6 +118,15 @@ export interface RLMContext {
 // ===== HELPERS =====
 
 const MAX_HISTORY_ENTRIES = 40;
+
+/**
+ * Hard cap on consecutive LLM-client throws. Independent of the
+ * user-configurable `maxErrors` (which counts solver/parse errors).
+ * 3 is tight on purpose: auth failures and bad URLs are deterministic,
+ * not transient, so retrying past a small handful is just delaying the
+ * inevitable. A real network blip recovers within 1-2 retries.
+ */
+const MAX_CONSECUTIVE_LLM_ERRORS = 3;
 
 function pruneHistory(history: RLMContext["history"]): void {
   while (history.length > MAX_HISTORY_ENTRIES) {
@@ -239,7 +259,7 @@ function verifyAndReturnResult(
  * work — the partial answer is always surfaced when present.
  */
 function formatAbort(
-  reason: "timeout" | "tokens" | "errors",
+  reason: "timeout" | "tokens" | "errors" | "llm",
   detail: string,
   ctx: RLMContext
 ): string {
@@ -452,7 +472,20 @@ async function handleQueryLLM(ctx: RLMContext): Promise<RLMContext> {
       ctx.log(`[Turn ${ctx.turn}] Aborting — timeout hit during LLM call`);
       return ctx;
     }
+    ctx.consecutiveLlmErrors++;
+    ctx.lastLlmError = errMsg;
     ctx.log(`[Turn ${ctx.turn}] LLM error: ${errMsg}`);
+    if (ctx.consecutiveLlmErrors >= MAX_CONSECUTIVE_LLM_ERRORS) {
+      ctx.result = formatAbort(
+        "llm",
+        `${ctx.consecutiveLlmErrors} consecutive LLM call failures: ${errMsg}`,
+        ctx
+      );
+      ctx.log(
+        `[Turn ${ctx.turn}] Aborting — ${ctx.consecutiveLlmErrors} consecutive LLM call failures`
+      );
+      return ctx;
+    }
     ctx.history.push({
       role: "user",
       content: `LLM call failed: ${errMsg}. Please try again.`,
@@ -462,6 +495,7 @@ async function handleQueryLLM(ctx: RLMContext): Promise<RLMContext> {
   } finally {
     if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
   }
+  ctx.consecutiveLlmErrors = 0;
   ctx.totalTokens += response.length;
 
   if (!response) {
@@ -1090,6 +1124,8 @@ export function createInitialContext(opts: {
     startTime: Date.now(),
     totalTokens: 0,
     consecutiveErrors: 0,
+    consecutiveLlmErrors: 0,
+    lastLlmError: "",
     bestPartialAnswer: "",
     compactionThresholdChars: opts.compactionThresholdChars,
     compactionCount: 0,

--- a/tests/fsm/rlm-states.test.ts
+++ b/tests/fsm/rlm-states.test.ts
@@ -167,6 +167,66 @@ describe("RLM FSM States", () => {
     });
   });
 
+  describe("LLM call failures", () => {
+    it("should abort and surface the original error after repeated LLM throws", async () => {
+      let calls = 0;
+      const ctx = createInitialContext({
+        query: "What?",
+        adapter: makeMockAdapter(),
+        llmClient: async () => {
+          calls++;
+          throw new Error("401 Unauthorized: invalid API key");
+        },
+        solverTools: makeMockTools("doc"),
+        systemPrompt: "system",
+        userMessage: "Query: What?",
+        maxTurns: 50,
+        sessionId: "test",
+        log: () => {},
+      });
+
+      const engine = new FSMEngine<RLMContext>();
+      const result = await engine.run(buildRLMSpec(), ctx);
+
+      // Must abort, not run to maxTurns
+      expect(calls).toBeLessThan(50);
+      expect(result.result).not.toBeNull();
+      // The aborted result must surface the actual LLM error message
+      expect(result.result).toMatch(/401 Unauthorized/);
+      // And label the abort reason as an LLM failure
+      expect(result.result).toMatch(/\[aborted: llm/);
+    });
+
+    it("should not abort on a single transient LLM error followed by success", async () => {
+      const responses = [
+        new Error("transient 503"),
+        '(grep "data")',
+        '<<<FINAL>>>data found<<<END>>>',
+      ];
+      let i = 0;
+      const ctx = createInitialContext({
+        query: "What?",
+        adapter: makeMockAdapter(),
+        llmClient: async () => {
+          const r = responses[i++];
+          if (r instanceof Error) throw r;
+          return r;
+        },
+        solverTools: makeMockTools("data: hello"),
+        systemPrompt: "system",
+        userMessage: "Query: What?",
+        maxTurns: 5,
+        sessionId: "test",
+        log: () => {},
+      });
+
+      const engine = new FSMEngine<RLMContext>();
+      const result = await engine.run(buildRLMSpec(), ctx);
+      expect(result.result).toMatch(/data found/);
+      expect(result.result).not.toMatch(/\[aborted/);
+    });
+  });
+
   describe("state trace", () => {
     it("should follow expected state sequence for simple query", async () => {
       const document = "answer: 42";


### PR DESCRIPTION
## Summary
- Previously, when the LLM client threw (auth failure, bad URL, network error), the catch block in `handleQueryLLM` swallowed the error, pushed a "please try again" message into history, and let the FSM loop back. With the default `maxErrors` unset and `consecutiveErrors` not incremented for LLM throws, an unrecoverable config error (e.g., invalid API key) ran silently to `maxTurns` and surfaced as "max turns reached" — masking the real cause.
- Add a separate `consecutiveLlmErrors` counter with a hard cap of 3 (LLM throws are typically deterministic, not transient). On hit, abort with `[aborted: llm ...]` and surface the original error message. Reset to 0 on every successful LLM response.
- Independent of `maxErrors` so users still get the same configurable budget for solver/parse errors.

## Test plan
- [x] New test: 3 consecutive LLM throws → FSM aborts before maxTurns, abort string contains the original error (`401 Unauthorized`) and the `[aborted: llm` prefix
- [x] New test: single transient LLM throw followed by success → run completes normally without abort
- [x] Full suite: `npx vitest run` → 3222 passed / 3 skipped (was 3220 + 2 new tests; no regressions)