### PR TITLE
feat(rlm): configurable FSM outer timeout, raise default to 15min

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -93,6 +93,13 @@ const ANALYZE_DOCUMENT_TOOL: MCPTool = {
         type: "number",
         description: "Maximum number of exploration turns (default: 10)",
       },
+      timeoutMs: {
+        type: "number",
+        description:
+          "Hard outer timeout for the entire FSM run, in milliseconds. " +
+          "Default 900000 (15 min). Raise this for slow models or large " +
+          "documents where 10+ turns take longer than the default cap.",
+      },
     },
     required: ["query", "filePath"],
   },
@@ -322,10 +329,11 @@ export function createMCPServer(options: MCPServerOptions = {}): MCPServerInstan
 
       // Handle analyze_document
       if (name === "analyze_document") {
-        const { query, filePath, maxTurns } = args as {
+        const { query, filePath, maxTurns, timeoutMs } = args as {
           query: string;
           filePath: string;
           maxTurns?: number;
+          timeoutMs?: number;
         };
 
         const analyzePathError = validateFilePath(filePath);
@@ -343,6 +351,7 @@ export function createMCPServer(options: MCPServerOptions = {}): MCPServerInstan
           const result = await runRLM(query, filePath, {
             llmClient: client,
             maxTurns: maxTurns || 10,
+            fsmTimeoutMs: typeof timeoutMs === "number" && timeoutMs > 0 ? timeoutMs : undefined,
           });
 
           const text = typeof result === "string" ? result : JSON.stringify(result, null, 2);

--- a/src/rlm.ts
+++ b/src/rlm.ts
@@ -440,6 +440,17 @@ export interface RLMOptions {
    */
   compactionThresholdChars?: number;
   /**
+   * Hard outer ceiling on the entire FSM run, in milliseconds. Acts as
+   * a Promise.race against the FSM loop — when it fires, the run
+   * rejects regardless of where the FSM is. Distinct from
+   * `maxTimeoutMs`, which is the FSM's own between-turn check. Default
+   * 15 minutes — paper-aligned for slow models on large docs (10
+   * turns × 30s/turn = 5 min was the prior default and tripped on
+   * legitimate work; 15 min holds the safety net without strangling
+   * real runs).
+   */
+  fsmTimeoutMs?: number;
+  /**
    * Internal — current sub-RLM depth. Automatically incremented by
    * the sub-RLM spawner each time a `(llm_query …)` call recurses.
    * Never set this manually from user code; it's a private parameter
@@ -856,7 +867,13 @@ export async function runRLMFromContent(
     });
 
     const engine = new FSMEngine<RLMContext>();
-    const FSM_TIMEOUT_MS = 5 * 60 * 1000;
+    // Hard outer ceiling on the FSM run (Promise.race guard). Distinct
+    // from `maxTimeoutMs` (the FSM's own between-turn check). Default
+    // 15 min — paper-aligned for slow models on large docs (10 turns ×
+    // 30s/turn = 5 min was the prior hardcoded value, tripped on
+    // legitimate work). Per-call override via `fsmTimeoutMs` keeps it
+    // tunable.
+    const FSM_TIMEOUT_MS = options.fsmTimeoutMs ?? 15 * 60 * 1000;
     // The timer must be stored so we can clear it when the FSM wins the
     // race — otherwise the setTimeout holds the Node event loop alive for
     // FSM_TIMEOUT_MS after a successful run (CLI hangs, long-lived

--- a/tests/rlm.test.ts
+++ b/tests/rlm.test.ts
@@ -212,6 +212,39 @@ describe("RLM Executor", () => {
       expect(firstPrompt).toMatch(/3 chunks/i);
       expect(firstPrompt).toMatch(/total chars/i);
     });
+
+    // Paper-conformance fix (T1.3): the outer FSM timeout was hardcoded
+    // at 5 min, which tripped on legitimate runs (10 turns × 30s/turn
+    // for a slow model). Raised default to 15 min and made it
+    // configurable per-call via fsmTimeoutMs so callers can tune it.
+    it("should respect a custom fsmTimeoutMs", async () => {
+      // Slow LLM: each call takes 1 second
+      const slowMockLLM = vi.fn(
+        () => new Promise<string>((resolve) =>
+          setTimeout(() => resolve('(grep "x")'), 1000)
+        )
+      );
+
+      const t0 = Date.now();
+      let caught: unknown;
+      try {
+        await runRLM("query", "./test-fixtures/small.txt", {
+          llmClient: slowMockLLM,
+          maxTurns: 100,
+          // Force a tight cap so the test finishes deterministically
+          fsmTimeoutMs: 200,
+        });
+      } catch (err) {
+        caught = err;
+      }
+      const elapsed = Date.now() - t0;
+
+      // Should abort well under the 100-turn ceiling — within ~3× the
+      // configured timeout to account for the in-flight LLM call.
+      expect(elapsed).toBeLessThan(3500);
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toMatch(/FSM run exceeded 200ms timeout/);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Previously `FSM_TIMEOUT_MS` was hardcoded at 5 minutes (`src/rlm.ts:844`) — a `Promise.race` guard around the entire FSM run. With slow models (e.g. GLM at ~30s per turn) and default `maxTurns=10`, legitimate runs hit `10 × 30s = 5min` and aborted with no partial answer surfaced. This is the proximate cause of the "RLM times out on >2000-line files" issue I observed earlier.
- Adds `fsmTimeoutMs` to `RLMOptions` (default 15 min, paper-aligned for slow models on large docs). Distinct from `maxTimeoutMs` (the FSM's own between-turn check that produces a clean partial-answer abort).
- Exposes the same option via the MCP `analyze_document` tool as `timeoutMs`, so MCP callers can tune it without touching the library API.

## Test plan
- [x] Unit test: `tests/rlm.test.ts > should respect a custom fsmTimeoutMs` — slow mock LLM (1s/call), `fsmTimeoutMs=200`, asserts the run aborts in <3.5s with the expected error message
- [x] Live test against real GLM on `src/logic/lc-solver.ts` (2622 lines, the original timeout repro), `fsmTimeoutMs=20_000`: aborted in 20.0s with `FSM run exceeded 20000ms timeout`. Without the option (default 15min), this would have run far longer.
- [x] Full suite: 3223 passed / 3 skipped (no regressions)

This is PR 2 of a 5-PR sequence improving paper conformance and timeout robustness. PR 1 (#54) added context metadata to the initial user message.