### PR TITLE
feat(rlm): enable history compaction by default at 20K chars

### DIFF
--- a/src/rlm.ts
+++ b/src/rlm.ts
@@ -524,9 +524,26 @@ export async function runRLMFromContent(
     maxTimeoutMs,
     maxTokens,
     maxErrors,
-    compactionThresholdChars,
+    compactionThresholdChars: rawCompactionThresholdChars,
     _subRLMDepth = 0,
   } = options;
+
+  // Paper-conformance fix (T1.4): the reference impl enables compaction
+  // by default at ~75% of model context. We default-on at 20_000 chars
+  // — fires around turn 12-15 of substantial result feedback (each turn
+  // contributes ~1500 chars after pruneHistory caps and the 4KB-Result
+  // truncate apply). Comfortably under the 8K-token window of even the
+  // smallest practical models (~24K chars at 3 chars/token); leaves
+  // headroom for the system prompt + last few turns after compaction.
+  // Without this, long runs silently bloat history past the model's
+  // window. Caller can disable with 0/negative; otherwise undefined
+  // picks the default.
+  const compactionThresholdChars =
+    rawCompactionThresholdChars === undefined
+      ? 20_000
+      : rawCompactionThresholdChars > 0
+        ? rawCompactionThresholdChars
+        : undefined;
 
   // Validate sessionId
   const safeSessionId = typeof rawSessionId === "string" && rawSessionId.length > 0 && rawSessionId.length <= 256 && /^[a-zA-Z0-9_-]+$/.test(rawSessionId)

--- a/tests/rlm.test.ts
+++ b/tests/rlm.test.ts
@@ -245,6 +245,82 @@ describe("RLM Executor", () => {
       expect(caught).toBeInstanceOf(Error);
       expect((caught as Error).message).toMatch(/FSM run exceeded 200ms timeout/);
     });
+
+    // Paper-conformance fix (T1.4): the reference impl enables
+    // compaction by default at ~75% of model context. Ours required
+    // an explicit compactionThresholdChars, so long runs would
+    // silently bloat history past the model's window. Default now
+    // fires when history concatenation exceeds 20K chars.
+    it("should compact history by default when prompt grows past the default threshold", async () => {
+      // Build a doc whose `grep "X"` produces many large matches.
+      const bigDoc = Array.from(
+        { length: 200 },
+        (_, i) => `LINE-${i}: ${"X".repeat(200)} payload entry`
+      ).join("\n");
+      const { runRLMFromContent } = await import("../src/rlm.js");
+
+      let summarizeCalls = 0;
+      let turn = 0;
+      const promptSizes: number[] = [];
+      let lastPrompt = "";
+      const llm = vi.fn(async (prompt: string) => {
+        promptSizes.push(prompt.length);
+        lastPrompt = prompt;
+        if (/Summarize your progress so far/.test(prompt)) {
+          summarizeCalls++;
+          return "Summary: ran greps.";
+        }
+        turn++;
+        if (turn >= 30) return "<<<FINAL>>>done<<<END>>>";
+        // Vary the pattern each turn to avoid the FSM's repeated-code
+        // guard short-circuiting execution and starving the feedback
+        // channel — we need real per-turn result previews to bloat
+        // history and hit the threshold.
+        return `(grep "LINE-${turn}:")`;
+      });
+
+      const result = await runRLMFromContent("scan", bigDoc, {
+        llmClient: llm,
+        maxTurns: 40,
+      });
+
+      // If compaction never fires, surface the prompt-size trajectory
+      // so the failure tells us *why* (threshold mis-tuned vs. wiring
+      // broken).
+      expect(
+        summarizeCalls,
+        `prompt sizes per turn: ${promptSizes.join(", ")}\n--last prompt tail--\n${lastPrompt.slice(-1000)}`
+      ).toBeGreaterThanOrEqual(1);
+      expect(result).toMatch(/done|Summary/);
+    });
+
+    it("should allow callers to disable compaction by passing compactionThresholdChars: 0", async () => {
+      const bigDoc = Array.from(
+        { length: 200 },
+        (_, i) => `LINE-${i}: ${"X".repeat(200)} payload entry`
+      ).join("\n");
+      const { runRLMFromContent } = await import("../src/rlm.js");
+
+      let summarizeCalls = 0;
+      let turn = 0;
+      const llm = vi.fn(async (prompt: string) => {
+        if (/Summarize your progress so far/.test(prompt)) {
+          summarizeCalls++;
+          return "Summary";
+        }
+        turn++;
+        if (turn >= 12) return "<<<FINAL>>>done<<<END>>>";
+        return `(grep "LINE-${turn}:")`;
+      });
+
+      await runRLMFromContent("scan", bigDoc, {
+        llmClient: llm,
+        maxTurns: 16,
+        compactionThresholdChars: 0, // explicit opt-out
+      });
+
+      expect(summarizeCalls).toBe(0);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Reference impl in `alexzhang13/rlm` enables compaction when `compaction=True` (their default) at ~75% of model context. Ours required an explicit `compactionThresholdChars`, so long runs silently bloated history past the model's window with no recovery path.
- Default now fires at 20K chars — fires around turn 12-15 of substantial result feedback. Comfortable headroom under any practical model context (~6.7K tokens at 3 chars/token, well under even the smallest 8K-token windows).
- Caller still has full control:
  - omitted → use default 20K
  - positive → use that value
  - 0 / negative → disable compaction (explicit opt-out)

## Test plan
- [x] Unit test: `should compact history by default when prompt grows past the default threshold` — varied-grep mock against a 200-line synthetic doc, runs 30 turns, asserts at least one compaction call fires
- [x] Unit test: `should allow callers to disable compaction by passing compactionThresholdChars: 0` — same harness, opt-out, asserts zero compaction calls
- [x] Live test against real GLM on `src/logic/lc-solver.ts`: query completed in 2 turns (efficient model didn't need compaction); confirms the new default doesn't break short runs.
- [x] Full suite: 3224 passed / 3 skipped (no regressions)

This is PR 3 of the 5-PR sequence. PR 1 (#54 metadata) and PR 2 (#55 timeout) cover the other low-risk paper-conformance fixes.