### PR TITLE
feat(adapter): teach (seq …) composition + batching guidance

### DIFF
--- a/src/adapters/nucleus.ts
+++ b/src/adapters/nucleus.ts
@@ -25,7 +25,7 @@ function buildSystemPrompt(
   if (!Number.isFinite(contextLength) || contextLength < 0) contextLength = 0;
   const sizeCategory = contextLength < 2000 ? "SMALL" : "LARGE";
 
-  return `ONE command per turn.
+  return `One S-expression per turn. Compose multi-step strategies with (seq …) so a single turn can chain commands instead of taking a turn per step.
 
 SEARCH:
 (grep "pat")              → matched lines + lineNums
@@ -42,6 +42,12 @@ TRANSFORM:
 (map RESULTS (lambda x (match x "pat" 1)))
 (count RESULTS)   (sum RESULTS)
 
+COMPOSE (multi-step in ONE turn):
+(seq expr1 expr2 ... exprN)   → run in order, RESULTS threads through, value = last expr
+  Use this aggressively. Prefer
+    (seq (grep "X") (filter RESULTS (lambda x …)) (count RESULTS))
+  over three separate turns. Each turn costs an LLM round-trip.
+
 SUB-LLM (work grep can't do):
 (llm_query "...{items}" (items RESULTS))   → one call over binding
 (map RESULTS (lambda x (llm_query "..." (item x))))   → per-item
@@ -50,6 +56,8 @@ Rules:
   prompt literal w/ {name} placeholders
   each (name TERM) fills one placeholder
   use for classify/summarize/paraphrase, not regex
+  BATCH heavily — one llm_query over a whole chunk beats one-per-item.
+  For per-item work use (rlm_batch …) so calls fire concurrently.
 
 CODE:
 (list_symbols)  (list_symbols "function")

--- a/src/logic/constraint-resolver.ts
+++ b/src/logic/constraint-resolver.ts
@@ -136,6 +136,9 @@ export function resolveConstraints(term: LCTerm): ResolvedTerm {
       case "list_symbols":
         return t;
 
+      case "seq":
+        return { ...t, exprs: t.exprs.map((e) => resolve(e, depth + 1)) };
+
       default:
         return t;
     }

--- a/src/logic/lc-parser.ts
+++ b/src/logic/lc-parser.ts
@@ -588,6 +588,24 @@ function parseList(state: ParserState, depth: number = 0): LCTerm | null {
       return { tag: "chunk_by_regex", pattern: patTerm.value };
     }
 
+    case "seq": {
+      // Parse a variadic list of subexprs. Empty seq is meaningless,
+      // single-expr seq is silly but accepted (degrades to that expr's
+      // value). Cap at 64 to bound damage from a runaway emit.
+      const MAX_SEQ_EXPRS = 64;
+      const exprs: LCTerm[] = [];
+      while (true) {
+        const next = peek(state);
+        if (!next || next.type === "rparen") break;
+        const sub = parseTerm(state, d);
+        if (!sub) return null;
+        exprs.push(sub);
+        if (exprs.length > MAX_SEQ_EXPRS) return null;
+      }
+      if (exprs.length === 0) return null; // empty seq is meaningless
+      return { tag: "seq", exprs };
+    }
+
     case "filter": {
       const collection = parseTerm(state, d);
       if (!collection) return null;
@@ -1389,6 +1407,8 @@ export function prettyPrint(term: LCTerm): string {
       return `(chunk_by_lines ${term.lineCount})`;
     case "chunk_by_regex":
       return `(chunk_by_regex "${escapeForPrint(term.pattern)}")`;
+    case "seq":
+      return `(seq ${term.exprs.map(e => prettyPrint(e)).join(" ")})`;
     case "filter":
       return `(filter ${prettyPrint(term.collection)} ${prettyPrint(term.predicate)})`;
     case "map":

--- a/src/logic/lc-solver.ts
+++ b/src/logic/lc-solver.ts
@@ -779,6 +779,41 @@ async function evaluate(
       return chunks;
     }
 
+    case "seq": {
+      // Evaluate each subexpr in order, threading bindings through.
+      // Each subexpr's result is bound to RESULTS (when it's an array)
+      // and to a fresh `_seqN` slot, making it visible to later
+      // subexprs. The whole seq evaluates to the value of the LAST
+      // subexpr.
+      //
+      // Per project rule (correctness > performance): subexprs run
+      // sequentially even though some pairs are independent —
+      // dependent expressions are the common case (later steps
+      // reference RESULTS of earlier steps), and parallel scheduling
+      // would require dataflow analysis we don't have.
+      const MAX_SEQ_EXPRS_RUNTIME = 64;
+      if (term.exprs.length === 0) {
+        throw new Error("seq: empty seq is meaningless");
+      }
+      if (term.exprs.length > MAX_SEQ_EXPRS_RUNTIME) {
+        throw new Error(`seq: too many subexprs (${term.exprs.length} > ${MAX_SEQ_EXPRS_RUNTIME})`);
+      }
+      let last: unknown = null;
+      for (let i = 0; i < term.exprs.length; i++) {
+        const sub = term.exprs[i];
+        last = await evaluate(sub, tools, bindings, log, depth + 1);
+        // Make every step's result available to subsequent steps so the
+        // model can write `(seq (grep ...) (count RESULTS))`. Mirror
+        // what handleAnalyze does at the FSM boundary, but in-loop so
+        // RESULTS is fresh inside the same turn.
+        if (Array.isArray(last)) {
+          bindings.set("RESULTS", last);
+        }
+        bindings.set(`_seq${i + 1}`, last);
+      }
+      return last;
+    }
+
     case "chunk_by_regex": {
       // Split the document wherever `pattern` matches. Empty chunks
       // produced by adjacent delimiters are dropped — the paper's OOLONG

--- a/src/logic/type-inference.ts
+++ b/src/logic/type-inference.ts
@@ -203,6 +203,11 @@ function infer(term: LCTerm, env: TypeEnv): LCType {
       // All three chunking primitives return array<string>.
       return { tag: "array", element: { tag: "string" } };
 
+    case "seq":
+      // (seq …) evaluates to the type of the LAST subexpr. Empty seq is
+      // rejected by the parser so we can safely take the tail.
+      return infer(term.exprs[term.exprs.length - 1], env);
+
     case "sum":
       return { tag: "number" };
 

--- a/src/logic/types.ts
+++ b/src/logic/types.ts
@@ -78,7 +78,8 @@ export type LCTerm =
   | LCShowVars
   | LCChunkBySize
   | LCChunkByLines
-  | LCChunkByRegex;
+  | LCChunkByRegex
+  | LCSeq;
 
 /**
  * (input) - reference to the current input string
@@ -221,6 +222,31 @@ export interface LCChunkByLines {
 export interface LCChunkByRegex {
   tag: "chunk_by_regex";
   pattern: string;
+}
+
+/**
+ * (seq <expr1> <expr2> ... <exprN>) - evaluate exprs in order, threading
+ * solver bindings through. The result of each subexpr is bound to a
+ * fresh `_seqN` slot (and to `RESULTS` if it's an array), making it
+ * available to later subexprs. The whole `seq` evaluates to the value
+ * of the LAST subexpr.
+ *
+ * Paper-conformance: lets the model emit a multi-step program in a
+ * single turn — the paper's Algorithm 1 has each REPL turn run a full
+ * code block, not one statement. Without this primitive, our
+ * "ONE command per turn" forced 3-step strategies into 3 turns, which
+ * is a major contributor to the timeout problem on large docs.
+ *
+ * Example:
+ *   (seq (grep "ERROR")
+ *        (filter RESULTS (lambda x (match x "timeout" 0)))
+ *        (count RESULTS))
+ *
+ * Empty seq is rejected by the parser (a no-op seq is meaningless).
+ */
+export interface LCSeq {
+  tag: "seq";
+  exprs: LCTerm[];
 }
 
 /**

--- a/tests/adapters/nucleus.test.ts
+++ b/tests/adapters/nucleus.test.ts
@@ -46,6 +46,31 @@ describe("Nucleus Adapter", () => {
       expect(prompt).toContain("<<<FINAL>>>");
       expect(prompt).toContain("<<<END>>>");
     });
+
+    // Paper-conformance fixes (T2.x): the prompt must teach (seq …)
+    // composition (so the model can run multi-step strategies in one
+    // turn) and encourage batching for sub-LLM calls. The "ONE command
+    // per turn" framing — which forced 3-step strategies into 3 turns
+    // and was the dominant timeout contributor — is gone.
+    it("should teach (seq …) for multi-step composition", () => {
+      expect(prompt).toContain("(seq");
+      expect(prompt).toContain("RESULTS threads through");
+    });
+
+    it("should not enforce ONE-command-per-turn", () => {
+      // Old framing was literally "ONE command per turn." which
+      // discouraged composition. Replaced with guidance that
+      // composes via (seq …).
+      expect(prompt).not.toMatch(/^ONE command per turn\./m);
+    });
+
+    it("should encourage batching of sub-LLM calls", () => {
+      // The Qwen variant of the paper prompt explicitly tells the model
+      // to batch llm_query rather than fire one per item — we should do
+      // the same.
+      expect(prompt).toMatch(/BATCH/i);
+      expect(prompt).toMatch(/rlm_batch/);
+    });
   });
 
   describe("extractCode", () => {

--- a/tests/logic/lc-parser.test.ts
+++ b/tests/logic/lc-parser.test.ts
@@ -420,6 +420,102 @@ describe("Source-pattern checks (from audits)", () => {
       });
     });
 
+  // Paper-conformance fix (T1.2): the `(seq …)` primitive lets the
+  // model emit a multi-step program in one turn instead of consuming
+  // a turn per S-expression. The parser must accept variadic seq,
+  // reject empty seq, and round-trip via prettyPrint.
+  describe("seq", () => {
+    it("should parse a seq with multiple subexprs", () => {
+      const result = parse('(seq (grep "ERROR") (count RESULTS))');
+      expect(result.success).toBe(true);
+      expect(result.term?.tag).toBe("seq");
+      if (result.term?.tag === "seq") {
+        expect(result.term.exprs).toHaveLength(2);
+        expect(result.term.exprs[0]?.tag).toBe("grep");
+        expect(result.term.exprs[1]?.tag).toBe("count");
+      }
+    });
+
+    it("should reject empty (seq) — empty seq is meaningless", () => {
+      const result = parse("(seq)");
+      expect(result.success).toBe(false);
+    });
+
+    it("should accept single-expr (seq)", () => {
+      const result = parse('(seq (grep "X"))');
+      expect(result.success).toBe(true);
+      expect(result.term?.tag).toBe("seq");
+      if (result.term?.tag === "seq") {
+        expect(result.term.exprs).toHaveLength(1);
+      }
+    });
+
+    it("should support nested seq", () => {
+      const result = parse(
+        '(seq (grep "a") (seq (count RESULTS) (sum RESULTS)))'
+      );
+      expect(result.success).toBe(true);
+      if (result.term?.tag === "seq") {
+        expect(result.term.exprs).toHaveLength(2);
+        expect(result.term.exprs[1]?.tag).toBe("seq");
+      }
+    });
+
+    it("should round-trip via prettyPrint with printable subexprs", () => {
+      // Use grep + grep — both have prettyPrint cases. (Many other LC
+      // primitives don't print yet, e.g. count → "<unknown:count>";
+      // that's a pre-existing limitation, not specific to seq.)
+      const src = '(seq (grep "X") (grep "Y"))';
+      const result = parse(src);
+      expect(result.success).toBe(true);
+      if (result.term) {
+        const printed = prettyPrint(result.term);
+        expect(printed).toMatch(/^\(seq /);
+        const reparsed = parse(printed);
+        expect(reparsed.success).toBe(true);
+        expect(reparsed.term?.tag).toBe("seq");
+      }
+    });
+
+    it("should evaluate seq sequentially, threading RESULTS into later exprs", async () => {
+      // Build a tiny doc with two distinct rows; seq runs grep then count.
+      const doc = "ERROR: a\nWARN: b\nERROR: c\nINFO: d\n";
+      const tools: SolverTools = {
+        context: doc,
+        lines: doc.split("\n"),
+        grep: (pattern: string) => {
+          const re = new RegExp(pattern, "gmi");
+          const out: Array<{
+            match: string; line: string; lineNum: number; index: number; groups: string[];
+          }> = [];
+          let m: RegExpExecArray | null;
+          while ((m = re.exec(doc)) !== null) {
+            const lineNum = (doc.slice(0, m.index).match(/\n/g) || []).length + 1;
+            out.push({ match: m[0], line: doc.split("\n")[lineNum - 1] || "", lineNum, index: m.index, groups: [] });
+          }
+          return out;
+        },
+        fuzzy_search: () => [],
+        bm25: () => [],
+        semantic: () => [],
+        text_stats: () => ({ length: doc.length, lineCount: 4, sample: { start: "", middle: "", end: "" } }),
+      };
+
+      // (seq (grep "ERROR") (count RESULTS)) should give 2 — both ERROR
+      // rows. Without the seq primitive this would take 2 turns.
+      const r = await solve(
+        { tag: "seq", exprs: [
+          { tag: "grep", pattern: "ERROR" },
+          { tag: "count", collection: { tag: "var", name: "RESULTS" } },
+        ]},
+        tools,
+        new Map()
+      );
+      expect(r.success).toBe(true);
+      expect(r.value).toBe(2);
+    });
+  });
+
   // from tests/audit96.test.ts #12 — parse() errors out on oversize input, doesn't silently truncate
   describe("#12 — parse() errors out on oversize input, doesn't silently truncate", () => {
       it("an input with > MAX_TOKENS tokens produces a parse failure, not a partial success", async () => {


### PR DESCRIPTION
## Summary
- The old prompt opened with literally `ONE command per turn.` which discouraged composition. Combined with `extractCode` taking only the first S-expression, this forced 3-step strategies into 3 turns × 30s/turn = 90s minimum, the dominant timeout contributor.
- Replace with composition-friendly framing: `One S-expression per turn. Compose multi-step strategies with (seq …) so a single turn can chain commands.`
- New `COMPOSE` block teaches `(seq …)` semantics (RESULTS threading, last-expr value).
- Strengthened SUB-LLM section: explicit batching guidance ("BATCH heavily — one llm_query over a whole chunk beats one-per-item. For per-item work use (rlm_batch …) so calls fire concurrently."), aligned with the paper's Qwen-variant prompt.

## Live test — original timeout repro
The query that timed out at 5+ min in PR 2's analysis (\`runRLM\` on \`src/logic/lc-solver.ts\`, 2622 lines) now:
- **completes in 66.5s** with a complete, accurate answer
- 4 LLM calls (efficient — model didn't even need \`(seq …)\` here)
- 0 compactions needed
- Returns specific patterns with line numbers

```
1. Null/Empty and Length Checks: ... lines 206-216 (e.g., `if (!pattern)` at line 206, ...)
2. Type and Bounds Validation: ... line 2582, line 2583 ...
3. Numeric Validity Guards: NaN and Infinity checks ...
```

## Test plan
- [x] Unit test: prompt teaches `(seq …)` and threading semantics
- [x] Unit test: prompt no longer enforces ONE-command-per-turn
- [x] Unit test: prompt encourages batching
- [x] Live test: original 5-min timeout repro completes in 66.5s with correct answer
- [x] Full suite: 3231 passed / 3 skipped (was 3228 + 3 new tests)

This PR is **stacked on top of #57** (the `(seq …)` primitive). When #57 merges, this PR's base will update automatically.

Sequence summary:
- #54 — initial-prompt context metadata (PR 1)
- #55 — configurable FSM timeout, default 15min (PR 2)
- #56 — compaction default-on at 20K chars (PR 3)
- #57 — `(seq …)` primitive (PR 4)
- this — prompt updates teaching seq + batching (PR 5)

The cumulative effect: the timeout problem on >2000-line files is resolved.