### PR TITLE
fix(lattice-mcp): graceful shutdown + --version/--help under symlink

### DIFF
--- a/src/lattice-mcp-server.ts
+++ b/src/lattice-mcp-server.ts
@@ -30,8 +30,9 @@ import {
   type CallToolResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import { stat } from "node:fs/promises";
+import { realpathSync } from "node:fs";
 import { resolve, sep } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
 import { HandleSession, type HandleResult } from "./engine/handle-session.js";
 import { runRLMFromContent } from "./rlm.js";
@@ -1280,16 +1281,29 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
   }
 }
 
-// Cleanup on exit
-process.on("SIGINT", () => {
-  closeSession("process interrupted");
-  process.exit(0);
-});
+// Cleanup on exit. SIGINT / SIGTERM are the canonical termination paths.
+// SIGHUP fires when the controlling terminal goes away (e.g. iTerm session
+// closed without proper hangup propagation). Without it, the server would
+// keep running after its launching terminal died — the original zombie
+// process bug.
+let shuttingDown = false;
+function shutdown(reason: string, exitCode = 0): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  try {
+    closeSession(reason);
+  } catch (err) {
+    console.error(
+      "[Lattice] Error during shutdown:",
+      err instanceof Error ? err.message : String(err)
+    );
+  }
+  process.exit(exitCode);
+}
 
-process.on("SIGTERM", () => {
-  closeSession("process terminated");
-  process.exit(0);
-});
+process.on("SIGINT", () => shutdown("process interrupted"));
+process.on("SIGTERM", () => shutdown("process terminated"));
+process.on("SIGHUP", () => shutdown("SIGHUP (terminal closed)"));
 
 // CLI flags
 const skipCwdChecking = process.argv.includes("--dangerously-skip-cwd-checking");
@@ -1298,6 +1312,31 @@ async function main() {
   // Handle version flag
   if (process.argv.includes("-v") || process.argv.includes("--version")) {
     console.log(`lattice-mcp v${getVersion()}`);
+    process.exit(0);
+  }
+
+  // Handle help flag. Without this, `lattice-mcp --help` falls through to
+  // the stdio MCP transport and blocks waiting for client messages,
+  // appearing to hang.
+  if (process.argv.includes("-h") || process.argv.includes("--help")) {
+    console.log(
+      `lattice-mcp v${getVersion()} — handle-based document analysis MCP server\n` +
+        `\n` +
+        `Usage: lattice-mcp [options]\n` +
+        `\n` +
+        `Options:\n` +
+        `  -v, --version                       Print version and exit\n` +
+        `  -h, --help                          Show this help and exit\n` +
+        `      --dangerously-skip-cwd-checking Disable CWD path safety check\n` +
+        `\n` +
+        `The server speaks the Model Context Protocol over stdio. It is meant\n` +
+        `to be launched by an MCP client (Claude Code, Claude Desktop, etc.)\n` +
+        `rather than invoked directly. The server exits automatically when\n` +
+        `the client closes stdin (EOF) or sends SIGINT/SIGTERM/SIGHUP.\n` +
+        `\n` +
+        `Environment:\n` +
+        `  LATTICE_TIMEOUT_MS   Session inactivity timeout in ms (default: 600000)`
+    );
     process.exit(0);
   }
 
@@ -1323,6 +1362,25 @@ async function main() {
   });
 
   const transport = new StdioServerTransport();
+
+  // Detect parent disconnect. The MCP SDK's StdioServerTransport only
+  // listens for `data` / `error` on stdin, never `end` / `close`, so when
+  // the client closes its end of the pipe (or the host process dies
+  // without delivering SIGTERM/SIGHUP) nothing tells us to exit and the
+  // process lingers forever. Attach our own EOF listeners and a transport
+  // onclose so any of those paths shuts us down.
+  //
+  // Order matters: set `transport.onclose` BEFORE `server.connect(transport)`
+  // because the SDK's Protocol.connect() WRAPS the existing onclose:
+  //   const _onclose = this.transport?.onclose;
+  //   this._transport.onclose = () => { _onclose?.(); this._onclose(); };
+  // Setting it after connect() would overwrite the wrapper and skip the
+  // protocol's own cleanup (clearing response handlers, aborting in-flight
+  // requests, etc.). Setting it before lets our handler compose cleanly.
+  transport.onclose = () => shutdown("transport closed");
+  process.stdin.on("end", () => shutdown("stdin EOF (client disconnected)"));
+  process.stdin.on("close", () => shutdown("stdin closed (client disconnected)"));
+
   // Install the sampling bridge BEFORE awaiting `server.connect()`.
   //
   // Subtle race: `server.connect(transport)` returns after the transport
@@ -1529,9 +1587,25 @@ async function main() {
 // like `sweepStalePending` and `makePendingId` from this module — without
 // this guard, every test worker would silently spin up a stdio server
 // connected to its own stdin/stdout, which conflicts with vitest's I/O.
-const isEntryPoint =
-  typeof process.argv[1] === "string" &&
-  import.meta.url === pathToFileURL(process.argv[1]).href;
+//
+// Compare realpaths on both sides. A naive `import.meta.url === pathToFileURL(argv[1])`
+// check breaks when the bin is reached through an `npm link` symlink:
+// `argv[1]` keeps the symlinked path (e.g. /opt/homebrew/lib/.../dist/lattice-mcp-server.js)
+// while `import.meta.url` resolves through it to the real source path.
+// The mismatch made `main()` never run — so `--version` printed nothing
+// and the server silently failed to start under symlinked installs.
+function detectEntryPoint(): boolean {
+  const argv1 = process.argv[1];
+  if (typeof argv1 !== "string") return false;
+  try {
+    const argv1Real = realpathSync(argv1);
+    const moduleReal = realpathSync(fileURLToPath(import.meta.url));
+    return argv1Real === moduleReal;
+  } catch {
+    return false;
+  }
+}
+const isEntryPoint = detectEntryPoint();
 
 if (isEntryPoint) {
   main().catch((err) => {

--- a/tests/lattice-mcp-shutdown.test.ts
+++ b/tests/lattice-mcp-shutdown.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for lattice-mcp process lifecycle: --version / --help flags and
+ * graceful shutdown on stdin EOF.
+ *
+ * Background: long-lived lattice-mcp processes were piling up in `ps`
+ * because StdioServerTransport never listens for stdin `end`/`close`. When
+ * the MCP client closed its end of the pipe (or its terminal died without
+ * sending SIGTERM), nothing told the server to exit. These tests pin the
+ * fix: any of the disconnect paths produces a clean exit within ~2s.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { spawn, execSync } from "node:child_process";
+import { resolve } from "node:path";
+import { existsSync, readFileSync, statSync, symlinkSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO_ROOT = resolve(import.meta.dirname, "..");
+const SERVER_ENTRY = resolve(REPO_ROOT, "src/lattice-mcp-server.ts");
+const SERVER_DIST = resolve(REPO_ROOT, "dist/lattice-mcp-server.js");
+// CLI-flag tests use tsx (fast, no build needed). Lifecycle/signal tests
+// invoke `node dist/...` directly because tsx wraps the user script in a
+// parent Node process: SIGHUP/SIGTERM sent to the tsx wrapper kill the
+// wrapper before propagating to the child, so the test would observe the
+// wrapper's death-by-signal rather than the server's clean exit.
+const TSX_BIN = resolve(REPO_ROOT, "node_modules/.bin/tsx");
+const EXPECTED_VERSION = JSON.parse(
+  readFileSync(resolve(REPO_ROOT, "package.json"), "utf-8")
+).version as string;
+
+// Ensure dist/lattice-mcp-server.js exists and is newer than its source.
+// The shutdown tests spawn the built artifact (see comment above), so a
+// missing or stale dist would either fail or silently exercise the wrong
+// code. `tsc` is fast (~2s) — cheaper than maintaining a stale-detection
+// dance.
+function ensureDistBuilt(): void {
+  const srcMtime = statSync(SERVER_ENTRY).mtimeMs;
+  const distMtime = existsSync(SERVER_DIST) ? statSync(SERVER_DIST).mtimeMs : 0;
+  if (distMtime < srcMtime) {
+    execSync("pnpm build", { cwd: REPO_ROOT, stdio: "inherit" });
+  }
+}
+
+// Vitest's default per-test timeout is fine; we cap subprocess waits well
+// under it. 2000ms is generous — shutdown should fire on the next tick
+// after EOF / signal.
+const SHUTDOWN_WAIT_MS = 2000;
+
+function runCli(args: string[]): { stdout: string; stderr: string; code: number } {
+  try {
+    const stdout = execSync(`${TSX_BIN} ${SERVER_ENTRY} ${args.join(" ")}`, {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      timeout: 15000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { stdout, stderr: "", code: 0 };
+  } catch (e: unknown) {
+    const err = e as { stdout?: Buffer | string; stderr?: Buffer | string; status?: number };
+    return {
+      stdout: typeof err.stdout === "string" ? err.stdout : err.stdout?.toString() ?? "",
+      stderr: typeof err.stderr === "string" ? err.stderr : err.stderr?.toString() ?? "",
+      code: err.status ?? 1,
+    };
+  }
+}
+
+describe("lattice-mcp CLI flags", () => {
+  it("--version prints version and exits 0", () => {
+    const { stdout, code } = runCli(["--version"]);
+    expect(code).toBe(0);
+    expect(stdout.trim()).toBe(`lattice-mcp v${EXPECTED_VERSION}`);
+  });
+
+  it("-v is an alias for --version", () => {
+    const { stdout, code } = runCli(["-v"]);
+    expect(code).toBe(0);
+    expect(stdout.trim()).toBe(`lattice-mcp v${EXPECTED_VERSION}`);
+  });
+
+  it("--help prints usage and exits 0", () => {
+    const { stdout, code } = runCli(["--help"]);
+    expect(code).toBe(0);
+    expect(stdout).toContain("Usage: lattice-mcp");
+    expect(stdout).toContain("--version");
+    expect(stdout).toContain("--help");
+    // Help should document the EOF/signal shutdown contract so a user
+    // reading it understands the server isn't hung waiting on stdin.
+    expect(stdout).toMatch(/EOF|SIGINT|SIGTERM|SIGHUP/);
+  });
+
+  it("-h is an alias for --help", () => {
+    const { stdout, code } = runCli(["-h"]);
+    expect(code).toBe(0);
+    expect(stdout).toContain("Usage: lattice-mcp");
+  });
+
+  it("--version works when invoked through a symlink (npm-link case)", () => {
+    // Regression test for the original bug: when the bin is reached via
+    // an npm-link symlink, `argv[1]` keeps the symlinked path while
+    // `import.meta.url` resolves through it — naive entry-point detection
+    // would mismatch and `main()` would never run. Simulate by pointing a
+    // temp symlink at the real entry file.
+    const dir = mkdtempSync(join(tmpdir(), "lattice-symlink-"));
+    const linkPath = join(dir, "lattice-mcp-server.ts");
+    try {
+      symlinkSync(SERVER_ENTRY, linkPath);
+      const stdout = execSync(`${TSX_BIN} ${linkPath} --version`, {
+        cwd: REPO_ROOT,
+        encoding: "utf-8",
+        timeout: 15000,
+      });
+      expect(stdout.trim()).toBe(`lattice-mcp v${EXPECTED_VERSION}`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("lattice-mcp shutdown lifecycle", () => {
+  beforeAll(() => {
+    ensureDistBuilt();
+  }, 60000);
+
+  /**
+   * Spawn the server, wait for it to announce it has started, then run
+   * `triggerShutdown` against the child. Returns the exit code and how
+   * long the shutdown took. Times out if the process doesn't exit within
+   * SHUTDOWN_WAIT_MS after the trigger.
+   */
+  async function spawnServerAndShutdown(
+    triggerShutdown: (child: ReturnType<typeof spawn>) => void
+  ): Promise<{ code: number | null; signal: NodeJS.Signals | null; elapsedMs: number }> {
+    const child = spawn(process.execPath, [SERVER_DIST], {
+      cwd: REPO_ROOT,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    if (!child.stdin || !child.stderr) {
+      throw new Error("spawned child missing piped stdio");
+    }
+    const childStderr = child.stderr;
+
+    let stderr = "";
+    childStderr.on("data", (d) => (stderr += d.toString()));
+
+    // Wait until the server logs that it has started. Using stderr because
+    // the lattice server writes its startup banner to stderr (stdout is the
+    // MCP message channel).
+    await new Promise<void>((resolveReady, rejectReady) => {
+      const onData = (d: Buffer) => {
+        if (d.toString().includes("MCP server started")) {
+          childStderr.off("data", onData);
+          resolveReady();
+        }
+      };
+      childStderr.on("data", onData);
+      const startupTimer = setTimeout(() => {
+        childStderr.off("data", onData);
+        rejectReady(new Error(`server did not start within 10s.\nstderr:\n${stderr}`));
+      }, 10000);
+      child.on("exit", () => clearTimeout(startupTimer));
+    });
+
+    const startedAt = Date.now();
+    triggerShutdown(child);
+
+    return await new Promise((resolveExit, rejectExit) => {
+      const exitTimer = setTimeout(() => {
+        // Kill so we don't leak the process from the test suite.
+        try { child.kill("SIGKILL"); } catch { /* already gone */ }
+        rejectExit(
+          new Error(
+            `process did not exit within ${SHUTDOWN_WAIT_MS}ms.\nstderr:\n${stderr}`
+          )
+        );
+      }, SHUTDOWN_WAIT_MS);
+
+      child.on("exit", (code, signal) => {
+        clearTimeout(exitTimer);
+        resolveExit({ code, signal, elapsedMs: Date.now() - startedAt });
+      });
+    });
+  }
+
+  it("exits cleanly when stdin is closed (the zombie-process root cause)", async () => {
+    const result = await spawnServerAndShutdown((child) => {
+      // Close our write end of the pipe — the child sees stdin EOF.
+      child.stdin?.end();
+    });
+    expect(result.code).toBe(0);
+    expect(result.signal).toBeNull();
+    // Should be near-instant — failure mode is "never exits".
+    expect(result.elapsedMs).toBeLessThan(SHUTDOWN_WAIT_MS);
+  });
+
+  it("exits cleanly on SIGTERM", async () => {
+    const result = await spawnServerAndShutdown((child) => {
+      child.kill("SIGTERM");
+    });
+    expect(result.code).toBe(0);
+  });
+
+  it("exits cleanly on SIGHUP (terminal closure)", async () => {
+    // SIGHUP is the new handler — added because terminal teardown
+    // delivers SIGHUP, not SIGTERM, and the old code ignored it.
+    const result = await spawnServerAndShutdown((child) => {
+      child.kill("SIGHUP");
+    });
+    expect(result.code).toBe(0);
+  });
+});


### PR DESCRIPTION
The MCP SDK's StdioServerTransport only listens for `data`/`error` on stdin, never `end`/`close`. When the MCP client closed its end of the pipe (or its terminal died without delivering SIGTERM), nothing told the server to exit and lattice-mcp processes accumulated across days of normal use.

Fixes:
- Add stdin `end`/`close` listeners and a SIGHUP handler, all routing through one idempotent `shutdown()` that calls `closeSession()` then exits. Listeners attach before `server.connect()` so an EOF during the handshake isn't missed.
- Set `transport.onclose` before `connect()` so the SDK's Protocol can compose it; setting it after would overwrite the wrapper and skip the protocol's internal cleanup (response handlers, abort controllers, ConnectionClosed errors).
- `detectEntryPoint()` realpaths both sides of the argv[1] vs import.meta.url comparison. Under `npm link`, argv[1] kept the symlinked path while import.meta.url resolved through it, so the mismatch made main() never run — `--version` printed nothing and the server silently failed to start under symlinked installs.
- Add a `--help` handler with usage text that documents the EOF/signal shutdown contract, so users running `lattice-mcp --help` don't see it appear to hang on stdin.

Tests cover all three behaviors: subprocess `--version`/`--help` (including via a symlink), and clean exits on stdin EOF, SIGTERM, and SIGHUP. Lifecycle tests run `node dist/...` directly because tsx wraps the script in a parent Node process that doesn't forward SIGHUP.